### PR TITLE
ci: GitHub ActionsによるCIワークフローを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+    branches:
+      - main
+      - develop
+
+jobs:
+  build-lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22.x"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Check formatting
+        run: npm run format:check
+
+      - name: Test
+        run: npm test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,39 @@
+name: Publish to npm
+
+# NOTE: npm publish is disabled for now (see issue #10).
+# Once the repository is ready to publish (NPM_TOKEN secret configured,
+# owner sign-off), uncomment the "Publish" step below.
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22.x"
+          cache: "npm"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: npm test
+
+      # - name: Publish
+      #   run: npm publish
+      #   env:
+      #     NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

- `.github/workflows/ci.yml` を追加。`develop` / `main` への push・pull_request をトリガーに、Node.js 22.x で `npm ci` → `npm run build` → `npm run lint` → `npm run format:check` → `npm test` を実行
- `.github/workflows/publish.yml` を追加。GitHub Release公開 (`release: published`) をトリガーに build/lint/test まで実行するが、`npm publish` ステップは現時点ではコメントアウトして無効化（NPM_TOKENシークレット設定・オーナー承認後に有効化する想定）

## 背景

#10 の残タスクである「GitHub Actions による build / lint / test のCIワークフロー整備」に対応。テストハーネス(#16)・lint/formatツール導入(#17)は完了済みのため、本PRはCI上でそれらを実行する仕組みの追加のみを行う。

## ブランチ保護について(コード外の対応が必要)

以下はリポジトリ設定(Settings > Branches)側の作業のため、今回のPRには含まれていません。オーナー側で設定をお願いします。

- `develop`: 本PRの `CI / build-lint-test` ステータスチェックを必須化
- `main`: プルリクエストレビュー(オーナー承認)を必須化

## Test plan

- [x] ローカルで `npm ci` → `npm run build` → `npm run lint` → `npm run format:check` → `npm test` が全て成功することを確認済み(exit code 0)
- [x] 本PRのCIワークフロー自体がGitHub Actions上で正常に動作することを確認


---
_Generated by [Claude Code](https://claude.ai/code/session_013zu2JogbJbyJCCuSmE47my)_