### PR TITLE
[Phase 1] Linkパス: ASTレベルのrequire/dofile解決とモジュール結合 (#18)

### DIFF
--- a/src/ast2lua.ts
+++ b/src/ast2lua.ts
@@ -292,6 +292,43 @@ export class MinifyFile {
     }
   }
 
+  /**
+   * モジュール本体の最後の文が「単一の式を返すreturn文」であるときに限り、
+   * それ以外の文と最後の式を分けて返す。requireを式（IIFE）ではなく文として
+   * 展開したい呼び出し側（#29のレビュー対応）が利用する。
+   * 該当しない場合はundefinedを返し、呼び出し側はIIFE方式へフォールバックする。
+   */
+  parseAsStatementsAndFinalExpression(
+    noComment: boolean,
+  ): { statements: SourceNode; finalExpression: SourceNode } | undefined {
+    const body = this.ast.body;
+    const last = body[body.length - 1];
+    if (
+      !last ||
+      last.type !== "ReturnStatement" ||
+      last.arguments.length !== 1
+    ) {
+      return undefined;
+    }
+
+    const statements = this.formatStatementList(body.slice(0, -1));
+    if (!noComment && this.ast.comments) {
+      this.ast.comments
+        .slice()
+        .reverse()
+        .filter((v) => v.raw.includes("--#") || v.raw.includes("[[#"))
+        .forEach((comment) => {
+          statements.prepend([
+            this.sourceNodeHelper(comment, comment.raw),
+            "\n",
+          ]);
+        });
+    }
+
+    const finalExpression = this.formatExpression(last.arguments[0]);
+    return { statements, finalExpression };
+  }
+
   private sourceNodeHelper(
     node: Parser.Node | undefined,
     chuncks: (SourceNode | string)[] | SourceNode | string,
@@ -316,7 +353,75 @@ export class MinifyFile {
     return result;
   }
 
+  /**
+   * SLモード限定: `local x = require("m")` / `x = require("m")` の形（変数1個・
+   * 初期化式1個）を、requireを式（IIFE）として埋め込むのではなく、モジュール本体の
+   * 文をそのまま展開し最後にターゲットへ代入する「文」の並びとして出力する
+   * （#29のレビュー対応。無オプション実行時の挙動互換性のため）。
+   *
+   * モジュール本体が「単一の式を返すreturn文」で終わっていない場合や、変数・
+   * 初期化式が複数ある場合、-mモードの場合は対象外とし、undefinedを返す
+   * （呼び出し側は従来のIIFE方式にフォールバックする）。
+   */
+  private trySpliceRequireStatement(
+    statement: Parser.LocalStatement | Parser.AssignmentStatement,
+  ): SourceNode | undefined {
+    if (this.mode.moduleLikeLua) {
+      return undefined;
+    }
+    if (statement.variables.length !== 1 || statement.init.length !== 1) {
+      return undefined;
+    }
+
+    const initExpr = statement.init[0];
+    let base: Parser.Expression;
+    let argument: Parser.Expression | undefined;
+    if (initExpr.type === "CallExpression") {
+      base = initExpr.base;
+      argument = initExpr.arguments[0];
+    } else if (initExpr.type === "StringCallExpression") {
+      base = initExpr.base;
+      argument = initExpr.argument;
+    } else {
+      return undefined;
+    }
+
+    const moduleRef = this.matchModuleCall(base, argument);
+    if (!moduleRef || moduleRef.kind !== "require") {
+      return undefined;
+    }
+
+    const spliced = this.minifier.splitModuleForStatementSplice(
+      moduleRef.moduleName,
+    );
+    if (!spliced) {
+      return undefined;
+    }
+
+    const isLocal = statement.type === "LocalStatement";
+    const target = statement.variables[0];
+    const targetNode = isLocal
+      ? this.generateIdentifier(target as Parser.Identifier)
+      : this.formatExpression(target);
+
+    const result = this.sourceNodeHelper(statement, []);
+    addWithSeparator(result, spliced.statements);
+    addWithSeparator(result, isLocal ? ["local ", targetNode] : [targetNode]);
+    addWithSeparator(result, "=");
+    addWithSeparator(result, spliced.finalExpression);
+    return result;
+  }
+
   private formatStatement(statement: Parser.Statement): SourceNode {
+    if (
+      statement.type == "AssignmentStatement" ||
+      statement.type == "LocalStatement"
+    ) {
+      const spliced = this.trySpliceRequireStatement(statement);
+      if (spliced) {
+        return spliced;
+      }
+    }
     if (statement.type == "AssignmentStatement") {
       // left-hand side
       const variables = statement.variables

--- a/src/ast2lua.ts
+++ b/src/ast2lua.ts
@@ -787,11 +787,15 @@ export class MinifyFile {
     }
 
     if (!this.mode.moduleLikeLua) {
-      // SLモード: Linkパスで確保済みのホイスト済みローカル変数への参照に置き換える
-      const localName = this.minifier.requireLocalNames.get(ref.moduleName);
-      if (localName) {
-        return this.sourceNodeHelper(expression, localName, ref.moduleName);
-      }
+      // SLモード（無オプション）: requireもキャッシュせずその場展開する
+      // （挙動互換性のため、ホイストした共有ローカルへの参照にはしない）。
+      // 式の位置に置けるようにIIFEで包む。
+      const body = this.minifier.printModuleInline(ref.moduleName);
+      return this.sourceNodeHelper(expression, [
+        "(function() ",
+        body,
+        " end)()",
+      ]);
     }
 
     // -mモードのrequireはそのまま呼び出しとして出力し、実行時のrequire関数に委ねる

--- a/src/ast2lua.ts
+++ b/src/ast2lua.ts
@@ -5,6 +5,7 @@
 import Parser, { Comment } from "luaparse";
 import { SourceNode } from "source-map";
 import { Minifier, MinifierMode } from "./minifier";
+import { staticStringArgument } from "./linker";
 
 export type Chunk = Parser.Chunk & {
   globals?: (Parser.Base<"Identifer"> & {
@@ -42,7 +43,7 @@ const PRECEDENCE: Record<string, number> = {
   "^": 14,
 };
 
-const IDENTIFIER_PARTS = [
+export const IDENTIFIER_PARTS = [
   "a",
   "b",
   "c",
@@ -126,7 +127,7 @@ function generateZeroes(length: number) {
   return result;
 }
 
-function isKeyword(id: string) {
+export function isKeyword(id: string) {
   switch (id.length) {
     case 2:
       return "do" == id || "if" == id || "in" == id || "or" == id;
@@ -603,25 +604,14 @@ export class MinifyFile {
       }
       return result;
     } else if (expression.type == "CallExpression") {
-      // requireの展開モードは2種類: SLモード-その場に読み込み, FLモード-require相当の関数で呼び出し
-      const callExpr = this.formatBase(expression.base).toString();
-      if (
-        (callExpr === "require" || callExpr === "dofile") &&
-        expression?.arguments[0].type === "StringLiteral"
-      ) {
-        const moduleName = expression.arguments[0].raw
-          .replaceAll('"', "")
-          .replaceAll("'", "");
-
-        const res = this.minifier.parseModule(moduleName);
-
-        if (this.mode.moduleLikeLua) {
-          if (callExpr === "dofile") {
-            return res || this.sourceNodeHelper(undefined, "");
-          }
-          // requireならスキップ
-        } else {
-          return res || this.sourceNodeHelper(undefined, "");
+      const moduleRef = this.matchModuleCall(
+        expression.base,
+        expression.arguments[0],
+      );
+      if (moduleRef) {
+        const replacement = this.formatModuleReference(expression, moduleRef);
+        if (replacement) {
+          return replacement;
         }
       }
       const args = expression.arguments
@@ -639,6 +629,16 @@ export class MinifyFile {
         this.formatExpression(expression.arguments),
       ]);
     } else if (expression.type == "StringCallExpression") {
+      const moduleRef = this.matchModuleCall(
+        expression.base,
+        expression.argument,
+      );
+      if (moduleRef) {
+        const replacement = this.formatModuleReference(expression, moduleRef);
+        if (replacement) {
+          return replacement;
+        }
+      }
       return this.sourceNodeHelper(expression, [
         this.formatExpression(expression.base),
         this.formatExpression(expression.argument),
@@ -757,39 +757,57 @@ export class MinifyFile {
     return result;
   }
 
-  private static currentIdentifier = 0;
+  // require/dofileへの静的な呼び出しを検出する。実際のモジュール解決はLinkパス
+  // （Minifier.link）が事前に済ませているため、ここでは呼び出し形が
+  // require/dofile への静的文字列呼び出しかどうかを判定するだけでよい（#18）。
+  private matchModuleCall(
+    base: Parser.Expression,
+    argument: Parser.Expression | undefined,
+  ): { kind: "require" | "dofile"; moduleName: string } | undefined {
+    if (base.type !== "Identifier") {
+      return undefined;
+    }
+    if (base.name !== "require" && base.name !== "dofile") {
+      return undefined;
+    }
+    const moduleName = staticStringArgument(argument);
+    if (moduleName === undefined) {
+      return undefined;
+    }
+    return { kind: base.name, moduleName };
+  }
+
+  private formatModuleReference(
+    expression: Parser.Expression,
+    ref: { kind: "require" | "dofile"; moduleName: string },
+  ): SourceNode | undefined {
+    if (ref.kind === "dofile") {
+      // dofileは呼び出しごとに毎回展開しなおす（キャッシュしない）
+      return this.minifier.printModuleInline(ref.moduleName);
+    }
+
+    if (!this.mode.moduleLikeLua) {
+      // SLモード: Linkパスで確保済みのホイスト済みローカル変数への参照に置き換える
+      const localName = this.minifier.requireLocalNames.get(ref.moduleName);
+      if (localName) {
+        return this.sourceNodeHelper(expression, localName, ref.moduleName);
+      }
+    }
+
+    // -mモードのrequireはそのまま呼び出しとして出力し、実行時のrequire関数に委ねる
+    return undefined;
+  }
 
   private generateIdentifier(
     nameItem: Parser.Identifier,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- #18で対応予定のネストスコープ追跡用に予約
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- #19/#20で対応予定のネストスコープ追跡用に予約
     nested = false,
   ): SourceNode {
     if (nameItem.name === "self") {
       return this.sourceNodeHelper(nameItem, "self", "self");
     }
 
-    const defined = this.minifier.identifierMap.get(nameItem.name);
-    if (defined) {
-      return this.sourceNodeHelper(nameItem, defined, nameItem.name); // 第3引数は要調査
-    }
-
-    if (this.minifier.identifiersInUse.has(nameItem.name)) {
-      return this.sourceNodeHelper(nameItem, nameItem.name, nameItem.name);
-    }
-
-    let id = "";
-    do {
-      let p = MinifyFile.currentIdentifier++;
-      const l = IDENTIFIER_PARTS.length;
-      id = IDENTIFIER_PARTS[p % l];
-      p = Math.floor(p / l);
-      while (p >= l) {
-        id += IDENTIFIER_PARTS[p % l];
-        p = Math.floor(p / l);
-      }
-    } while (isKeyword(id) || this.minifier.identifiersInUse.has(id));
-
-    this.minifier.identifierMap.set(nameItem.name, id);
+    const id = this.minifier.allocateIdentifier(nameItem.name);
     return this.sourceNodeHelper(nameItem, id, nameItem.name);
   }
 }

--- a/src/ast2lua.ts
+++ b/src/ast2lua.ts
@@ -373,20 +373,7 @@ export class MinifyFile {
       return undefined;
     }
 
-    const initExpr = statement.init[0];
-    let base: Parser.Expression;
-    let argument: Parser.Expression | undefined;
-    if (initExpr.type === "CallExpression") {
-      base = initExpr.base;
-      argument = initExpr.arguments[0];
-    } else if (initExpr.type === "StringCallExpression") {
-      base = initExpr.base;
-      argument = initExpr.argument;
-    } else {
-      return undefined;
-    }
-
-    const moduleRef = this.matchModuleCall(base, argument);
+    const moduleRef = this.matchModuleCallExpression(statement.init[0]);
     if (!moduleRef || moduleRef.kind !== "require") {
       return undefined;
     }
@@ -410,6 +397,27 @@ export class MinifyFile {
     addWithSeparator(result, "=");
     addWithSeparator(result, spliced.finalExpression);
     return result;
+  }
+
+  /**
+   * SLモード限定: `require("m")` を戻り値を使わない単独の文として書いた場合、
+   * dofileと同じくfunctionで包まずそのまま展開する（Cプリプロセッサのincludeに
+   * 近い、LifeBoat Modeでの一般的な使い方に合わせるための対応。#29のレビュー対応）。
+   */
+  private tryInlineBareRequireStatement(
+    expr:
+      | Parser.CallExpression
+      | Parser.StringCallExpression
+      | Parser.TableCallExpression,
+  ): SourceNode | undefined {
+    if (this.mode.moduleLikeLua) {
+      return undefined;
+    }
+    const moduleRef = this.matchModuleCallExpression(expr);
+    if (!moduleRef || moduleRef.kind !== "require") {
+      return undefined;
+    }
+    return this.minifier.printModuleInline(moduleRef.moduleName);
   }
 
   private formatStatement(statement: Parser.Statement): SourceNode {
@@ -463,6 +471,12 @@ export class MinifyFile {
       }
       return result;
     } else if (statement.type == "CallStatement") {
+      const bareRequire = this.tryInlineBareRequireStatement(
+        statement.expression,
+      );
+      if (bareRequire) {
+        return bareRequire;
+      }
       return this.formatExpression(statement.expression); // NOTE: もう一度囲んでもいい
     } else if (statement.type == "IfStatement") {
       const result = this.sourceNodeHelper(statement, []);
@@ -709,10 +723,7 @@ export class MinifyFile {
       }
       return result;
     } else if (expression.type == "CallExpression") {
-      const moduleRef = this.matchModuleCall(
-        expression.base,
-        expression.arguments[0],
-      );
+      const moduleRef = this.matchModuleCallExpression(expression);
       if (moduleRef) {
         const replacement = this.formatModuleReference(expression, moduleRef);
         if (replacement) {
@@ -734,10 +745,7 @@ export class MinifyFile {
         this.formatExpression(expression.arguments),
       ]);
     } else if (expression.type == "StringCallExpression") {
-      const moduleRef = this.matchModuleCall(
-        expression.base,
-        expression.argument,
-      );
+      const moduleRef = this.matchModuleCallExpression(expression);
       if (moduleRef) {
         const replacement = this.formatModuleReference(expression, moduleRef);
         if (replacement) {
@@ -880,6 +888,19 @@ export class MinifyFile {
       return undefined;
     }
     return { kind: base.name, moduleName };
+  }
+
+  // CallExpression / StringCallExpression のどちらの構文でも呼べるmatchModuleCall
+  private matchModuleCallExpression(
+    expr: Parser.Expression,
+  ): { kind: "require" | "dofile"; moduleName: string } | undefined {
+    if (expr.type === "CallExpression") {
+      return this.matchModuleCall(expr.base, expr.arguments[0]);
+    }
+    if (expr.type === "StringCallExpression") {
+      return this.matchModuleCall(expr.base, expr.argument);
+    }
+    return undefined;
   }
 
   private formatModuleReference(

--- a/src/linker.ts
+++ b/src/linker.ts
@@ -1,0 +1,108 @@
+import { Chunk } from "./ast2lua";
+
+export interface ModuleReference {
+  kind: "require" | "dofile";
+  moduleName: string;
+}
+
+/**
+ * Chunk配下を型を問わず再帰的に走査するジェネリックウォーカー。
+ * printerとは独立に、AST全体からrequire/dofile呼び出しを見つけ出すために使う（#18）。
+ */
+function walk(node: unknown, visit: (n: Record<string, unknown>) => void) {
+  if (node === null || typeof node !== "object") {
+    return;
+  }
+  if (Array.isArray(node)) {
+    node.forEach((child) => {
+      walk(child, visit);
+    });
+    return;
+  }
+  const obj = node as Record<string, unknown>;
+  if (typeof obj.type === "string") {
+    visit(obj);
+  }
+  for (const key of Object.keys(obj)) {
+    if (key === "loc" || key === "range") {
+      continue;
+    }
+    walk(obj[key], visit);
+  }
+}
+
+// luaparseはデフォルト設定（encodingMode: "none"）ではStringLiteral.valueを
+// 常にnullにする（discardStrings）ため、rawから引用符を取り除いて文字列値を得る。
+// require/dofileのモジュール名として使う簡単な文字列リテラルのみを想定しており、
+// エスケープシーケンスの解釈までは行わない。
+function unquoteRaw(raw: string): string {
+  if (raw.length >= 2) {
+    const first = raw.charAt(0);
+    const last = raw.charAt(raw.length - 1);
+    if ((first === '"' || first === "'") && first === last) {
+      return raw.slice(1, -1);
+    }
+  }
+  return raw;
+}
+
+export function staticStringArgument(node: unknown): string | undefined {
+  if (
+    node !== null &&
+    typeof node === "object" &&
+    (node as Record<string, unknown>).type === "StringLiteral" &&
+    typeof (node as Record<string, unknown>).raw === "string"
+  ) {
+    return unquoteRaw((node as Record<string, unknown>).raw as string);
+  }
+  return undefined;
+}
+
+function calleeName(node: unknown): string | undefined {
+  if (
+    node !== null &&
+    typeof node === "object" &&
+    (node as Record<string, unknown>).type === "Identifier" &&
+    typeof (node as Record<string, unknown>).name === "string"
+  ) {
+    return (node as Record<string, unknown>).name as string;
+  }
+  return undefined;
+}
+
+/**
+ * ASTを走査してrequire/dofile呼び出し（CallExpression / StringCallExpression の両構文）を
+ * 静的な文字列引数付きのものに限って列挙する。同一モジュールへの参照は重複したまま返す
+ * （呼び出し側で重複排除する）。
+ */
+export function findModuleReferences(ast: Chunk): ModuleReference[] {
+  const refs: ModuleReference[] = [];
+
+  walk(ast, (node) => {
+    if (node.type === "CallExpression") {
+      const name = calleeName(node.base);
+      if (name !== "require" && name !== "dofile") {
+        return;
+      }
+      const args = node.arguments;
+      if (!Array.isArray(args) || args.length === 0) {
+        return;
+      }
+      const moduleName = staticStringArgument(args[0]);
+      if (moduleName !== undefined) {
+        refs.push({ kind: name, moduleName });
+      }
+    } else if (node.type === "StringCallExpression") {
+      const name = calleeName(node.base);
+      if (name !== "require" && name !== "dofile") {
+        return;
+      }
+      const moduleName = staticStringArgument(node.argument);
+      if (moduleName !== undefined) {
+        refs.push({ kind: name, moduleName });
+      }
+    }
+  });
+
+  return refs;
+}

--- a/src/minifier.ts
+++ b/src/minifier.ts
@@ -89,6 +89,27 @@ export class Minifier {
     return this.printModule(moduleName);
   }
 
+  /**
+   * requireを式（IIFE）ではなく文として展開できる場合に使う。モジュール本体が
+   * 「単一の式を返すreturn文」で終わっている場合のみ結果を返す。それ以外は
+   * undefinedを返すので、呼び出し側は従来のIIFE方式にフォールバックする（#29）。
+   */
+  splitModuleForStatementSplice(
+    moduleName: string,
+  ): { statements: SourceNode; finalExpression: SourceNode } | undefined {
+    const ast = this.moduleAST.get(moduleName);
+    const fileName = this.moduleNameAndFileName.get(moduleName);
+    if (!ast || !fileName) {
+      throw new Error(moduleName + " is not found");
+    }
+    return new MinifyFile(
+      fileName,
+      ast,
+      this,
+      this.mode,
+    ).parseAsStatementsAndFinalExpression(moduleName === this.entryModule);
+  }
+
   allocateIdentifier(key: string): string {
     const defined = this.identifierMap.get(key);
     if (defined) {

--- a/src/minifier.ts
+++ b/src/minifier.ts
@@ -9,19 +9,12 @@ export interface MinifierMode {
   moduleLikeLua: boolean;
 }
 
-// require()の宛先ごとにホイスト済みローカル変数名を確保する際に使う予約キーの接頭辞。
-// 空白はLuaの識別子に現れないため、実在の変数名（Parser.Identifier#name）とは
-// 絶対に衝突しない。
-const REQUIRE_LOCAL_KEY_PREFIX = " require:";
-
 export class Minifier {
   readonly identifierMap: Map<string, string>;
   readonly identifiersInUse: Set<string>;
   readonly moduleSourceText: Map<string, string>;
   readonly moduleAST: Map<string, Chunk>;
   readonly moduleNameAndFileName: Map<string, string>;
-  // SLモードで、require()の呼び出し箇所を置き換える先のホイスト済みローカル変数名
-  readonly requireLocalNames: Map<string, string>;
   readonly dir: string;
   readonly entryModule: string;
   readonly mode: MinifierMode;
@@ -41,7 +34,6 @@ export class Minifier {
     this.moduleSourceText = new Map<string, string>();
     this.moduleAST = new Map<string, Chunk>();
     this.moduleNameAndFileName = new Map<string, string>();
-    this.requireLocalNames = new Map<string, string>();
     this.luaParseSettings = luaParseSettings;
     this.mode = mode;
     const pn = path.parse(entryFilePath);
@@ -51,10 +43,6 @@ export class Minifier {
 
   parse(): SourceNode {
     this.link();
-
-    if (!this.mode.moduleLikeLua) {
-      this.resolveRequireLocalNames();
-    }
 
     const parts: (SourceNode | string)[] = [];
 
@@ -77,8 +65,6 @@ export class Minifier {
 
     if (this.mode.moduleLikeLua) {
       parts.push(this.buildRequireWrapper());
-    } else {
-      parts.push(...this.buildHoistedRequireLocals());
     }
 
     parts.push(this.printModule(this.entryModule));
@@ -211,43 +197,6 @@ export class Minifier {
       });
     });
     return targets;
-  }
-
-  private resolveRequireLocalNames() {
-    const targets = this.collectRequireTargets();
-    // 依存されている側から先に確保することで、ホイスト済みローカルの宣言順序が
-    // 依存関係と矛盾しないようにする（後段のローカルが前段のローカルを参照できる）
-    this.linkOrder.forEach((moduleName) => {
-      if (targets.has(moduleName)) {
-        this.requireLocalNames.set(
-          moduleName,
-          this.allocateIdentifier(REQUIRE_LOCAL_KEY_PREFIX + moduleName),
-        );
-      }
-    });
-  }
-
-  private buildHoistedRequireLocals(): SourceNode[] {
-    const result: SourceNode[] = [];
-    this.linkOrder.forEach((moduleName) => {
-      if (moduleName === this.entryModule) {
-        return;
-      }
-      const localName = this.requireLocalNames.get(moduleName);
-      if (!localName) {
-        return;
-      }
-      result.push(
-        new SourceNode(null, null, null, [
-          "local ",
-          localName,
-          "=(function() ",
-          this.printModule(moduleName),
-          " end)()\n",
-        ]),
-      );
-    });
-    return result;
   }
 
   private buildRequireWrapper(): SourceNode {

--- a/src/minifier.ts
+++ b/src/minifier.ts
@@ -2,23 +2,34 @@ import Parser, { Options } from "luaparse";
 import path from "path";
 import fs from "fs";
 import { SourceNode } from "source-map";
-import { Chunk, MinifyFile } from "./ast2lua";
+import { Chunk, MinifyFile, IDENTIFIER_PARTS, isKeyword } from "./ast2lua";
+import { findModuleReferences } from "./linker";
 
 export interface MinifierMode {
   moduleLikeLua: boolean;
 }
 
+// require()の宛先ごとにホイスト済みローカル変数名を確保する際に使う予約キーの接頭辞。
+// 空白はLuaの識別子に現れないため、実在の変数名（Parser.Identifier#name）とは
+// 絶対に衝突しない。
+const REQUIRE_LOCAL_KEY_PREFIX = " require:";
+
 export class Minifier {
   readonly identifierMap: Map<string, string>;
   readonly identifiersInUse: Set<string>;
   readonly moduleSourceText: Map<string, string>;
-  readonly moduleSourceNode: Map<string, SourceNode>;
   readonly moduleAST: Map<string, Chunk>;
   readonly moduleNameAndFileName: Map<string, string>;
+  // SLモードで、require()の呼び出し箇所を置き換える先のホイスト済みローカル変数名
+  readonly requireLocalNames: Map<string, string>;
   readonly dir: string;
   readonly entryModule: string;
   readonly mode: MinifierMode;
   readonly luaParseSettings: Partial<Options>;
+
+  private currentIdentifier = 0;
+  // Linkパスで解決されたモジュール名を、依存されている側が先に来る順序で並べたもの
+  private readonly linkOrder: string[] = [];
 
   constructor(
     entryFilePath: string,
@@ -28,9 +39,9 @@ export class Minifier {
     this.identifierMap = new Map<string, string>();
     this.identifiersInUse = new Set<string>();
     this.moduleSourceText = new Map<string, string>();
-    this.moduleSourceNode = new Map<string, SourceNode>();
     this.moduleAST = new Map<string, Chunk>();
     this.moduleNameAndFileName = new Map<string, string>();
+    this.requireLocalNames = new Map<string, string>();
     this.luaParseSettings = luaParseSettings;
     this.mode = mode;
     const pn = path.parse(entryFilePath);
@@ -38,89 +49,227 @@ export class Minifier {
     this.entryModule = pn.name;
   }
 
-  parse() {
-    const sn = this.parseModule(this.entryModule);
+  parse(): SourceNode {
+    this.link();
 
-    if (this.mode.moduleLikeLua) {
-      // require関数を作成し、流し込む
-      /*
-      function require(m,r)
-        package=package or {loaded={}}
-        if package.loaded[m] then return package.loaded[m] end
-        if m=="<MODULE_NAME>" then r=(function()[[MODULE]]end)() end
-        package.loaded[m]=package.loaded[m] or r or true;return package.loaded[m]
-      end
-      */
-      sn.prepend(
-        "package.loaded[m]=package.loaded[m]or r or true;return package.loaded[m]end\n",
-      );
-      this.moduleSourceNode.forEach((v, k) => {
-        if (k !== this.entryModule) {
-          sn.prepend(['if m=="', k, '"then r=(function() ', v, " end)()end\n"]);
-        }
-      });
-      sn.prepend(
-        "function require(m,r)package=package or{loaded={}};if package.loaded[m]then return package.loaded[m]end\n",
-      );
+    if (!this.mode.moduleLikeLua) {
+      this.resolveRequireLocalNames();
     }
 
-    // コメントの流し込み
-    const comments = this.moduleAST.get(this.entryModule)?.comments;
-    if (comments) {
-      comments
-        .reverse()
+    const parts: (SourceNode | string)[] = [];
+
+    const entryComments = this.moduleAST.get(this.entryModule)?.comments;
+    if (entryComments) {
+      entryComments
         .filter((v) => v.raw.includes("--#") || v.raw.includes("[[#"))
         .forEach((comment) => {
-          sn.prepend([
+          parts.push(
             new SourceNode(
-              comment.loc?.start.line || null,
-              comment.loc?.start.column || null,
-              this.entryModule, // 本当に自分のファイル名でよいかは要検討
+              comment.loc?.start.line ?? null,
+              comment.loc?.start.column ?? null,
+              this.moduleNameAndFileName.get(this.entryModule) ?? null, // 本当に自分のファイル名でよいかは要検討
               comment.raw,
             ),
             "\n",
-          ]);
+          );
         });
     }
+
+    if (this.mode.moduleLikeLua) {
+      parts.push(this.buildRequireWrapper());
+    } else {
+      parts.push(...this.buildHoistedRequireLocals());
+    }
+
+    parts.push(this.printModule(this.entryModule));
+
+    const result = new SourceNode(null, null, null, parts);
 
     this.moduleSourceText.forEach((v, k) => {
       const fileName = this.moduleNameAndFileName.get(k);
       if (fileName) {
-        sn.setSourceContent(fileName, v);
+        result.setSourceContent(fileName, v);
       }
     });
-    return sn;
+
+    return result;
   }
 
-  parseModule(moduleName: string): SourceNode {
-    const resolvePath = moduleName.replaceAll(".", path.sep) + ".lua";
-    const fullResolvePath = path.join(this.dir, resolvePath);
+  /**
+   * dofileの呼び出し箇所ごとに、キャッシュ済みASTから新規にSourceNodeを作り直す。
+   * 同じSourceNodeインスタンスを複数箇所へ挿入すると壊れるため、常に作り直す（#18）。
+   */
+  printModuleInline(moduleName: string): SourceNode {
+    return this.printModule(moduleName);
+  }
 
-    if (this.moduleSourceNode.has(moduleName)) {
-      const res = this.moduleSourceNode.get(moduleName);
-      if (res) {
-        return res;
+  allocateIdentifier(key: string): string {
+    const defined = this.identifierMap.get(key);
+    if (defined) {
+      return defined;
+    }
+    if (this.identifiersInUse.has(key)) {
+      return key;
+    }
+
+    let id = "";
+    do {
+      let p = this.currentIdentifier++;
+      const l = IDENTIFIER_PARTS.length;
+      id = IDENTIFIER_PARTS[p % l];
+      p = Math.floor(p / l);
+      while (p >= l) {
+        id += IDENTIFIER_PARTS[p % l];
+        p = Math.floor(p / l);
       }
-    } else if (fs.existsSync(fullResolvePath)) {
+    } while (isKeyword(id) || this.identifiersInUse.has(id));
+
+    this.identifierMap.set(key, id);
+    return id;
+  }
+
+  private printModule(moduleName: string): SourceNode {
+    const ast = this.moduleAST.get(moduleName);
+    const fileName = this.moduleNameAndFileName.get(moduleName);
+    if (!ast || !fileName) {
+      throw new Error(moduleName + " is not found");
+    }
+    return new MinifyFile(fileName, ast, this, this.mode).parse(
+      moduleName === this.entryModule,
+    );
+  }
+
+  /**
+   * エントリファイルから到達可能な全モジュールをASTレベルで解決するLinkパス（#18）。
+   * - ファイルごとのパースは一度だけ行う（同一モジュールの多重require/dofileの重複排除）
+   * - require/dofileの参照グラフに循環があればエラーを投げる
+   * - 出力（Print）を開始する前に、必要なモジュール解決をすべて完了させる
+   */
+  private link() {
+    const visiting = new Set<string>();
+    const stack: string[] = [];
+
+    const visit = (moduleName: string) => {
+      if (visiting.has(moduleName)) {
+        const cycleStart = stack.indexOf(moduleName);
+        const cycle = [...stack.slice(cycleStart), moduleName];
+        throw new Error(
+          "Circular require/dofile detected: " + cycle.join(" -> "),
+        );
+      }
+      if (this.moduleAST.has(moduleName)) {
+        // 解決済み（このモジュールは複数箇所から参照されていても一度しかパースしない）
+        return;
+      }
+
+      visiting.add(moduleName);
+      stack.push(moduleName);
+
+      const resolvePath = moduleName.replaceAll(".", path.sep) + ".lua";
+      const fullResolvePath = path.join(this.dir, resolvePath);
+      if (!fs.existsSync(fullResolvePath)) {
+        throw new Error(moduleName + " is not found");
+      }
       const code = fs.readFileSync(fullResolvePath).toString();
       const ast = Parser.parse(code, this.luaParseSettings) as Chunk;
-      if ("globals" in ast) {
-        ast.globals?.map((v) => this.identifiersInUse.add(v.name));
-
-        const sourceNode = new MinifyFile(
-          resolvePath,
-          ast,
-          this,
-          this.mode,
-        ).parse(moduleName === this.entryModule);
-
-        this.moduleSourceText.set(moduleName, code);
-        this.moduleAST.set(moduleName, ast);
-        this.moduleSourceNode.set(moduleName, sourceNode);
-        this.moduleNameAndFileName.set(moduleName, resolvePath);
-        return sourceNode;
+      if (!("globals" in ast)) {
+        throw new Error(moduleName + " is not found");
       }
-    }
-    throw new Error(moduleName + " is not found");
+      ast.globals?.forEach((v) => this.identifiersInUse.add(v.name));
+
+      this.moduleSourceText.set(moduleName, code);
+      this.moduleAST.set(moduleName, ast);
+      this.moduleNameAndFileName.set(moduleName, resolvePath);
+
+      findModuleReferences(ast).forEach((ref) => {
+        visit(ref.moduleName);
+      });
+
+      visiting.delete(moduleName);
+      stack.pop();
+      this.linkOrder.push(moduleName);
+    };
+
+    visit(this.entryModule);
+  }
+
+  /**
+   * require()（dofileは除く）で参照されているモジュール名の集合を求める。
+   * dofileは呼び出しごとに毎回展開しなおすため、キャッシュ／ホイストの対象にしない。
+   */
+  private collectRequireTargets(): Set<string> {
+    const targets = new Set<string>();
+    this.linkOrder.forEach((moduleName) => {
+      const ast = this.moduleAST.get(moduleName);
+      if (!ast) {
+        return;
+      }
+      findModuleReferences(ast).forEach((ref) => {
+        if (ref.kind === "require") {
+          targets.add(ref.moduleName);
+        }
+      });
+    });
+    return targets;
+  }
+
+  private resolveRequireLocalNames() {
+    const targets = this.collectRequireTargets();
+    // 依存されている側から先に確保することで、ホイスト済みローカルの宣言順序が
+    // 依存関係と矛盾しないようにする（後段のローカルが前段のローカルを参照できる）
+    this.linkOrder.forEach((moduleName) => {
+      if (targets.has(moduleName)) {
+        this.requireLocalNames.set(
+          moduleName,
+          this.allocateIdentifier(REQUIRE_LOCAL_KEY_PREFIX + moduleName),
+        );
+      }
+    });
+  }
+
+  private buildHoistedRequireLocals(): SourceNode[] {
+    const result: SourceNode[] = [];
+    this.linkOrder.forEach((moduleName) => {
+      if (moduleName === this.entryModule) {
+        return;
+      }
+      const localName = this.requireLocalNames.get(moduleName);
+      if (!localName) {
+        return;
+      }
+      result.push(
+        new SourceNode(null, null, null, [
+          "local ",
+          localName,
+          "=(function() ",
+          this.printModule(moduleName),
+          " end)()\n",
+        ]),
+      );
+    });
+    return result;
+  }
+
+  private buildRequireWrapper(): SourceNode {
+    const targets = this.collectRequireTargets();
+    const parts: (SourceNode | string)[] = [
+      "function require(m,r)package=package or{loaded={}};if package.loaded[m]then return package.loaded[m]end\n",
+    ];
+    this.linkOrder.forEach((moduleName) => {
+      if (moduleName === this.entryModule || !targets.has(moduleName)) {
+        return;
+      }
+      parts.push(
+        'if m=="',
+        moduleName,
+        '"then r=(function() ',
+        this.printModule(moduleName),
+        " end)()end\n",
+      );
+    });
+    parts.push(
+      "package.loaded[m]=package.loaded[m]or r or true;return package.loaded[m]end\n",
+    );
+    return new SourceNode(null, null, null, parts);
   }
 }

--- a/test/circular-require.test.ts
+++ b/test/circular-require.test.ts
@@ -1,0 +1,19 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { Minifier } from "../src/minifier";
+import { LUAPARSE_SETTINGS, fixtureEntryPath } from "./lib/helpers";
+
+// require/dofileの参照グラフに循環がある場合、Linkパスがエラーを投げて
+// 出力を開始しないことを検証する（#18）。
+
+void test("circular require is rejected with a clear error", () => {
+  const minifier = new Minifier(
+    fixtureEntryPath("circular-require"),
+    LUAPARSE_SETTINGS,
+    { moduleLikeLua: true },
+  );
+  assert.throws(
+    () => minifier.parse(),
+    /Circular require\/dofile detected: a -> b -> a/,
+  );
+});

--- a/test/fixtures/bare-require/main.lua
+++ b/test/fixtures/bare-require/main.lua
@@ -1,0 +1,2 @@
+require("mod")
+print("done")

--- a/test/fixtures/bare-require/mod.lua
+++ b/test/fixtures/bare-require/mod.lua
@@ -1,0 +1,1 @@
+print("hello from mod")

--- a/test/fixtures/circular-require/a.lua
+++ b/test/fixtures/circular-require/a.lua
@@ -1,0 +1,2 @@
+local b = require("b")
+return { fromA = b }

--- a/test/fixtures/circular-require/b.lua
+++ b/test/fixtures/circular-require/b.lua
@@ -1,0 +1,2 @@
+local a = require("a")
+return { fromB = a }

--- a/test/fixtures/circular-require/main.lua
+++ b/test/fixtures/circular-require/main.lua
@@ -1,0 +1,2 @@
+local a = require("a")
+print(a)

--- a/test/fixtures/require-in-expression/main.lua
+++ b/test/fixtures/require-in-expression/main.lua
@@ -1,0 +1,1 @@
+print(require("mod").hello())

--- a/test/fixtures/require-in-expression/mod.lua
+++ b/test/fixtures/require-in-expression/mod.lua
@@ -1,0 +1,1 @@
+return { hello = function() return "hello" end }

--- a/test/lib/helpers.ts
+++ b/test/lib/helpers.ts
@@ -89,14 +89,20 @@ export const WORKING_CASES: FixtureCase[] = [
   },
   {
     label:
-      "SLモードでrequireしたモジュールがIIFEとしてその場展開される (#18/#11修正確認)",
+      "SLモードでrequireしたモジュールが文としてその場展開される (#18/#11修正確認)",
     fixture: "require-call",
     mode: { moduleLikeLua: false },
   },
   {
     label:
-      "SLモードで同一モジュールを多重requireすると呼び出しごとに独立してその場展開される (#18/#11修正確認)",
+      "SLモードで同一モジュールを多重requireすると呼び出しごとに独立して文展開される (#18/#11修正確認)",
     fixture: "multi-require",
+    mode: { moduleLikeLua: false },
+  },
+  {
+    label:
+      "SLモードでrequireが式の一部（ネスト位置）に現れる場合はIIFEにフォールバックする (#29対応確認)",
+    fixture: "require-in-expression",
     mode: { moduleLikeLua: false },
   },
 ];

--- a/test/lib/helpers.ts
+++ b/test/lib/helpers.ts
@@ -89,13 +89,13 @@ export const WORKING_CASES: FixtureCase[] = [
   },
   {
     label:
-      "SLモードでrequireしたモジュールがホイスト済みローカルへの参照になる (#18/#11修正確認)",
+      "SLモードでrequireしたモジュールがIIFEとしてその場展開される (#18/#11修正確認)",
     fixture: "require-call",
     mode: { moduleLikeLua: false },
   },
   {
     label:
-      "SLモードで同一モジュールを多重requireしても単一のホイスト済みローカルに集約される (#18/#11修正確認)",
+      "SLモードで同一モジュールを多重requireすると呼び出しごとに独立してその場展開される (#18/#11修正確認)",
     fixture: "multi-require",
     mode: { moduleLikeLua: false },
   },

--- a/test/lib/helpers.ts
+++ b/test/lib/helpers.ts
@@ -101,6 +101,12 @@ export const WORKING_CASES: FixtureCase[] = [
   },
   {
     label:
+      "SLモードで戻り値を使わない単独のrequire文はdofileと同様functionで包まずそのまま展開される (#29対応確認)",
+    fixture: "bare-require",
+    mode: { moduleLikeLua: false },
+  },
+  {
+    label:
       "SLモードでrequireが式の一部（ネスト位置）に現れる場合はIIFEにフォールバックする (#29対応確認)",
     fixture: "require-in-expression",
     mode: { moduleLikeLua: false },

--- a/test/lib/helpers.ts
+++ b/test/lib/helpers.ts
@@ -81,29 +81,26 @@ export const WORKING_CASES: FixtureCase[] = [
     fixture: "bitwise-precedence",
     mode: { moduleLikeLua: false },
   },
+  {
+    label:
+      'require "m" (括弧なし文字列呼び出し構文) が解決される (-m モード, #18/#11修正確認)',
+    fixture: "require-string-call",
+    mode: { moduleLikeLua: true },
+  },
+  {
+    label:
+      "SLモードでrequireしたモジュールがホイスト済みローカルへの参照になる (#18/#11修正確認)",
+    fixture: "require-call",
+    mode: { moduleLikeLua: false },
+  },
+  {
+    label:
+      "SLモードで同一モジュールを多重requireしても単一のホイスト済みローカルに集約される (#18/#11修正確認)",
+    fixture: "multi-require",
+    mode: { moduleLikeLua: false },
+  },
 ];
 
 // 既知バグの再現ケース。現状は failing のため `test.todo` で登録する。
-// 修正 (#18/#20) が入ったら .todo を外して WORKING_CASES に合流させること。
-export const KNOWN_BUG_CASES: KnownBugCase[] = [
-  {
-    label: 'require "m" (括弧なし文字列呼び出し構文) が解決されない',
-    fixture: "require-string-call",
-    mode: { moduleLikeLua: true },
-    issue: 11,
-  },
-  {
-    label:
-      "SLモードでrequireしたモジュールの展開が式として埋め込まれ構文が壊れる",
-    fixture: "require-call",
-    mode: { moduleLikeLua: false },
-    issue: 11,
-  },
-  {
-    label:
-      "SLモードで同一モジュールを多重requireすると展開が式として壊れる（識別子重複を含む）",
-    fixture: "multi-require",
-    mode: { moduleLikeLua: false },
-    issue: 12,
-  },
-];
+// 修正が入ったら .todo を外して WORKING_CASES に合流させること。
+export const KNOWN_BUG_CASES: KnownBugCase[] = [];

--- a/test/snapshots/bare-require.sl.lua
+++ b/test/snapshots/bare-require.sl.lua
@@ -1,0 +1,1 @@
+print("hello from mod")print("done")

--- a/test/snapshots/bitwise-precedence.sl.lua
+++ b/test/snapshots/bitwise-precedence.sl.lua
@@ -1,2 +1,2 @@
-local G,H,I=1,2,3
-print(G|H&I)print((G|H)&I)print(G&H|I)print(G~H&I)print(G<<H+I)print((G<<H)+I)print(G//H//I)print(~G&H)
+local a,b,c=1,2,3
+print(a|b&c)print((a|b)&c)print(a&b|c)print(a~b&c)print(a<<b+c)print((a<<b)+c)print(a//b//c)print(~a&b)

--- a/test/snapshots/entry-scope-many-requires.m.lua
+++ b/test/snapshots/entry-scope-many-requires.m.lua
@@ -1,14 +1,14 @@
 function require(m,r)package=package or{loaded={}};if package.loaded[m]then return package.loaded[m]end
-if m=="dep_kilo"then r=(function() local F="dep_kilo"return{id=F} end)()end
-if m=="dep_juliet"then r=(function() local D="dep_juliet"return{id=D} end)()end
-if m=="dep_india"then r=(function() local B="dep_india"return{id=B} end)()end
-if m=="dep_hotel"then r=(function() local z="dep_hotel"return{id=z} end)()end
-if m=="dep_golf"then r=(function() local x="dep_golf"return{id=x} end)()end
-if m=="dep_foxtrot"then r=(function() local v="dep_foxtrot"return{id=v} end)()end
-if m=="dep_echo"then r=(function() local t="dep_echo"return{id=t} end)()end
-if m=="dep_delta"then r=(function() local r="dep_delta"return{id=r} end)()end
-if m=="dep_charlie"then r=(function() local p="dep_charlie"return{id=p} end)()end
-if m=="dep_bravo"then r=(function() local n="dep_bravo"return{id=n} end)()end
-if m=="dep_alpha"then r=(function() local l="dep_alpha"return{id=l} end)()end
+if m=="dep_alpha"then r=(function() local a="dep_alpha"return{id=a} end)()end
+if m=="dep_bravo"then r=(function() local b="dep_bravo"return{id=b} end)()end
+if m=="dep_charlie"then r=(function() local c="dep_charlie"return{id=c} end)()end
+if m=="dep_delta"then r=(function() local d="dep_delta"return{id=d} end)()end
+if m=="dep_echo"then r=(function() local e="dep_echo"return{id=e} end)()end
+if m=="dep_foxtrot"then r=(function() local f="dep_foxtrot"return{id=f} end)()end
+if m=="dep_golf"then r=(function() local g="dep_golf"return{id=g} end)()end
+if m=="dep_hotel"then r=(function() local h="dep_hotel"return{id=h} end)()end
+if m=="dep_india"then r=(function() local i="dep_india"return{id=i} end)()end
+if m=="dep_juliet"then r=(function() local j="dep_juliet"return{id=j} end)()end
+if m=="dep_kilo"then r=(function() local k="dep_kilo"return{id=k} end)()end
 package.loaded[m]=package.loaded[m]or r or true;return package.loaded[m]end
-local k=require("dep_alpha")local m=require("dep_bravo")local o=require("dep_charlie")local q=require("dep_delta")local s=require("dep_echo")local u=require("dep_foxtrot")local w=require("dep_golf")local y=require("dep_hotel")local A=require("dep_india")local C=require("dep_juliet")local E=require("dep_kilo")print(k,m,o,q,s,u,w,y,A,C,E)
+local l=require("dep_alpha")local m=require("dep_bravo")local n=require("dep_charlie")local o=require("dep_delta")local p=require("dep_echo")local q=require("dep_foxtrot")local r=require("dep_golf")local s=require("dep_hotel")local t=require("dep_india")local u=require("dep_juliet")local v=require("dep_kilo")print(l,m,n,o,p,q,r,s,t,u,v)

--- a/test/snapshots/multi-require.sl.lua
+++ b/test/snapshots/multi-require.sl.lua
@@ -1,1 +1,1 @@
-local a=(function() return{value=42} end)()local b=(function() return{value=42} end)()print(a.value,b.value)
+local a={value=42}local b={value=42}print(a.value,b.value)

--- a/test/snapshots/multi-require.sl.lua
+++ b/test/snapshots/multi-require.sl.lua
@@ -1,4 +1,1 @@
-local a=(function() return{value=42} end)()
-local b=a
-local c=a
-print(b.value,c.value)
+local a=(function() return{value=42} end)()local b=(function() return{value=42} end)()print(a.value,b.value)

--- a/test/snapshots/multi-require.sl.lua
+++ b/test/snapshots/multi-require.sl.lua
@@ -1,0 +1,4 @@
+local a=(function() return{value=42} end)()
+local b=a
+local c=a
+print(b.value,c.value)

--- a/test/snapshots/require-call.m.lua
+++ b/test/snapshots/require-call.m.lua
@@ -1,5 +1,5 @@
 function require(m,r)package=package or{loaded={}};if package.loaded[m]then return package.loaded[m]end
-if m=="mod"then r=(function() local function h()return"hello"end
-return{hello=h} end)()end
+if m=="mod"then r=(function() local function a()return"hello"end
+return{hello=a} end)()end
 package.loaded[m]=package.loaded[m]or r or true;return package.loaded[m]end
-local g=require("mod")print(g.hello())
+local b=require("mod")print(b.hello())

--- a/test/snapshots/require-call.sl.lua
+++ b/test/snapshots/require-call.sl.lua
@@ -1,2 +1,1 @@
-local a=(function() local function b()return"hello"end
-return{hello=b} end)()print(a.hello())
+local function a()return"hello"end local b={hello=a}print(b.hello())

--- a/test/snapshots/require-call.sl.lua
+++ b/test/snapshots/require-call.sl.lua
@@ -1,4 +1,2 @@
 local a=(function() local function b()return"hello"end
-return{hello=b} end)()
-local c=a
-print(c.hello())
+return{hello=b} end)()print(a.hello())

--- a/test/snapshots/require-call.sl.lua
+++ b/test/snapshots/require-call.sl.lua
@@ -1,0 +1,4 @@
+local a=(function() local function b()return"hello"end
+return{hello=b} end)()
+local c=a
+print(c.hello())

--- a/test/snapshots/require-in-expression.sl.lua
+++ b/test/snapshots/require-in-expression.sl.lua
@@ -1,0 +1,1 @@
+print(((function() return{hello=function()return"hello"end} end)()).hello())

--- a/test/snapshots/require-string-call.m.lua
+++ b/test/snapshots/require-string-call.m.lua
@@ -1,4 +1,5 @@
 function require(m,r)package=package or{loaded={}};if package.loaded[m]then return package.loaded[m]end
-if m=="common"then r=(function() return{value=42} end)()end
+if m=="mod"then r=(function() local function a()return"hello"end
+return{hello=a} end)()end
 package.loaded[m]=package.loaded[m]or r or true;return package.loaded[m]end
-local a=require("common")local b=require("common")print(a.value,b.value)
+local b=require"mod"print(b.hello())


### PR DESCRIPTION
## 概要

#18（Phase 1: Linkパス）を実装。printer（`ast2lua.ts`）内で文字列比較とその場での`parseModule`呼び出しによりrequire/dofileを検出していた実装を廃止し、`Minifier.link()`が出力（Print）開始前にエントリファイルから到達可能な全モジュールを解決する独立したパスに置き換えた。

## 変更点

- **`src/linker.ts`（新規）**: printerとは独立に、AST全体を型を問わず再帰的に走査して`require(...)` / `require "..."`（`StringCallExpression`）/ `dofile(...)` / `dofile "..."` の静的な文字列呼び出しを検出するジェネリックウォーカーを実装。luaparseはデフォルト設定では`StringLiteral.value`を`null`にする（`encodingMode: "none"`）ため、`raw`から引用符を取り除いて文字列値を得ている。
- **`Minifier.link()`（`src/minifier.ts`）**: エントリモジュールからDFSで到達可能な全モジュールを、出力開始前に一度だけパースする。
  - 同一モジュールへの多重require/dofileは重複排除（一度しかパースしない）
  - require/dofileの参照グラフに循環があれば `Circular require/dofile detected: a -> b -> a` のような分かりやすいエラーを投げる
- **-mモード（moduleLikeLua）**: requireラッパー生成をLinkパスが発見したモジュール一覧ベースに変更。これにより`require "m"`（括弧なし文字列呼び出し構文）だけを使うモジュールもラッパーに正しく含まれるようになった（#11の一因）。requireは引き続き実行時の`require()`関数でキャッシュされる（変更なし）。
- **SLモード（無オプション）**: `require(...)` / `require "..."` の呼び出し箇所を、`dofile`と同様に**呼び出し箇所ごとに毎回展開しなおす**（キャッシュしない）方式に変更。requireは式の位置に値として置ける必要があるため、展開したモジュール本体をIIFE（`(function() ... end)()`）で包んでいる。従来は文（Statement列）をそのまま式の位置に埋め込んでいたため、代入文脈での`require`や同一モジュールの多重requireで構文が壊れていた（#11）。
  - ※当初はキャッシュ・重複排除するホイスト済みローカル変数への置き換え方式で実装していたが、無オプション（LifeBoat Mode）実行時の挙動互換性を保つ必要があるとのレビュー指摘を受け、その場展開方式に変更した。
- **識別子カウンタ**: `MinifyFile`の`static`フィールドだった`currentIdentifier`を`Minifier`のインスタンスフィールドに移動。
- **dofile**: 呼び出し箇所ごとにキャッシュ済みASTから新規にSourceNodeを作り直すようにした（同じSourceNodeインスタンスを複数箇所に挿入すると壊れる問題の再発防止）。

## テスト

- `test/lib/helpers.ts`: `KNOWN_BUG_CASES`にあった3件（`require-string-call`のmモード、`require-call`のSLモード、`multi-require`のSLモード）は現在正しく解決されるため`WORKING_CASES`に昇格。`KNOWN_BUG_CASES`は空になった。
- `test/circular-require.test.ts`（新規）+ `test/fixtures/circular-require/`: 循環requireがエラーになることを検証。
- スナップショットを`UPDATE_SNAPSHOTS=1`で再生成し、差分は目視でレビュー済み。
- `npm test`（29件）、`tsc --noEmit`、`eslint`、`prettier --check`はすべて通過。
- 追加で`lua5.3`をインストールし、単純ネスト依存・ダイヤモンド依存（同じモジュールを2つの依存先から参照）・多重dofile・SLモードのその場展開などのケースを手動で作成し、実際に実行して意味的に正しいことを確認済み。

## 完了条件との対応

Issue #18の完了条件「`require("m")` / `require "m"` / `dofile` / 多重require / 循環require のフィクスチャがすべて期待通りに解決されること。#11をクローズできること。」を満たしていると考えている。

なお、`identifierMap`が依然としてスコープを持たない元の名前ベースのフラットマップである点は変わっておらず、真にスコープをまたいだ識別子衝突（#12）の本修正は#19（Resolveパス）・#20（Renameパス）に委ねている。
