### PR TITLE
Resolveパス: スコープ解析とシンボルテーブルの構築 (#19)

### DIFF
--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -1,0 +1,378 @@
+// Resolveパス（#19）: 宣言ごとに一意なシンボルを持つスコープツリーを構築し、
+// 識別子の参照を対応する宣言シンボルに解決する。グローバル参照も識別する。
+// このパスは解析のみを行い、ASTやその出力を一切変更しない。
+import Parser from "luaparse";
+
+export type SymbolKind = "local" | "param" | "for" | "label";
+
+export interface Scope {
+  readonly kind: "chunk" | "function" | "block";
+  readonly parent: Scope | null;
+  readonly children: Scope[];
+  // このスコープで直接宣言されたシンボル（宣言順。同名の再宣言もすべて含む）
+  readonly symbols: Symbol[];
+}
+
+export interface Symbol {
+  readonly id: number;
+  readonly name: string;
+  readonly kind: SymbolKind;
+  readonly scope: Scope;
+  readonly declaration: Parser.Identifier;
+  // このシンボルを指す参照（宣言箇所自体は含まない）
+  readonly references: Parser.Identifier[];
+}
+
+export interface GlobalBinding {
+  readonly name: string;
+  readonly references: Parser.Identifier[];
+}
+
+export interface ResolveResult {
+  readonly chunkScope: Scope;
+  // チャンク全体で宣言された全シンボル（宣言順）
+  readonly symbols: Symbol[];
+  readonly globals: Map<string, GlobalBinding>;
+  // 宣言・参照どちらの識別子ノードからも対応するシンボルを引ける。
+  // グローバル参照やフィールド名など、シンボルを持たない識別子はundefinedを返す。
+  symbolOf(identifier: Parser.Identifier): Symbol | undefined;
+}
+
+interface MutableScope extends Scope {
+  readonly parent: MutableScope | null;
+  readonly children: MutableScope[];
+  readonly bindings: Map<string, Symbol>;
+  readonly labels: Map<string, Symbol>;
+}
+
+export function resolveScopes(chunk: Parser.Chunk): ResolveResult {
+  let nextSymbolId = 0;
+  const allSymbols: Symbol[] = [];
+  const globals = new Map<string, GlobalBinding>();
+  const identifierSymbols = new WeakMap<Parser.Identifier, Symbol>();
+
+  function createScope(
+    kind: Scope["kind"],
+    parent: MutableScope | null,
+  ): MutableScope {
+    const scope: MutableScope = {
+      kind,
+      parent,
+      children: [],
+      symbols: [],
+      bindings: new Map(),
+      labels: new Map(),
+    };
+    parent?.children.push(scope);
+    return scope;
+  }
+
+  function declare(
+    scope: MutableScope,
+    node: Parser.Identifier,
+    kind: SymbolKind,
+  ): Symbol {
+    const symbol: Symbol = {
+      id: nextSymbolId++,
+      name: node.name,
+      kind,
+      scope,
+      declaration: node,
+      references: [],
+    };
+    // 同名の再宣言はスコープ内の以後の参照から見た束縛を上書きする（Luaの通常のシャドーイング）
+    scope.symbols.push(symbol);
+    scope.bindings.set(node.name, symbol);
+    allSymbols.push(symbol);
+    identifierSymbols.set(node, symbol);
+    return symbol;
+  }
+
+  function declareLabel(scope: MutableScope, node: Parser.Identifier): Symbol {
+    const symbol: Symbol = {
+      id: nextSymbolId++,
+      name: node.name,
+      kind: "label",
+      scope,
+      declaration: node,
+      references: [],
+    };
+    scope.symbols.push(symbol);
+    scope.labels.set(node.name, symbol);
+    allSymbols.push(symbol);
+    identifierSymbols.set(node, symbol);
+    return symbol;
+  }
+
+  function lookupBinding(
+    scope: MutableScope,
+    name: string,
+  ): Symbol | undefined {
+    for (let s: MutableScope | null = scope; s; s = s.parent) {
+      const found = s.bindings.get(name);
+      if (found) {
+        return found;
+      }
+    }
+    return undefined;
+  }
+
+  function lookupLabel(scope: MutableScope, name: string): Symbol | undefined {
+    for (let s: MutableScope | null = scope; s; s = s.parent) {
+      const found = s.labels.get(name);
+      if (found) {
+        return found;
+      }
+    }
+    return undefined;
+  }
+
+  function reference(scope: MutableScope, node: Parser.Identifier) {
+    const symbol = lookupBinding(scope, node.name);
+    if (symbol) {
+      symbol.references.push(node);
+      identifierSymbols.set(node, symbol);
+      return;
+    }
+    let binding = globals.get(node.name);
+    if (!binding) {
+      binding = { name: node.name, references: [] };
+      globals.set(node.name, binding);
+    }
+    binding.references.push(node);
+  }
+
+  // ラベルはブロック内での宣言位置に関わらずブロック全体から参照できる
+  // （前方goto）ため、通常の宣言文と違い先読みで登録する。
+  function hoistLabels(body: Parser.Statement[], scope: MutableScope) {
+    body.forEach((statement) => {
+      if (statement.type === "LabelStatement") {
+        declareLabel(scope, statement.label);
+      }
+    });
+  }
+
+  function resolveBlock(body: Parser.Statement[], scope: MutableScope) {
+    hoistLabels(body, scope);
+    body.forEach((statement) => {
+      resolveStatement(statement, scope);
+    });
+  }
+
+  function resolveStatement(
+    statement: Parser.Statement,
+    scope: MutableScope,
+  ): void {
+    switch (statement.type) {
+      case "LocalStatement":
+        // 初期化式は新しいローカルが宣言される前の束縛で解決する
+        // （`local x = x` の右辺は外側のxを指す）
+        statement.init.forEach((expr) => {
+          resolveExpression(expr, scope);
+        });
+        statement.variables.forEach((v) => declare(scope, v, "local"));
+        return;
+      case "AssignmentStatement":
+        statement.init.forEach((expr) => {
+          resolveExpression(expr, scope);
+        });
+        statement.variables.forEach((v) => {
+          if (v.type === "Identifier") {
+            reference(scope, v);
+          } else {
+            resolveExpression(v, scope);
+          }
+        });
+        return;
+      case "CallStatement":
+        resolveExpression(statement.expression, scope);
+        return;
+      case "DoStatement": {
+        const inner = createScope("block", scope);
+        resolveBlock(statement.body, inner);
+        return;
+      }
+      case "WhileStatement": {
+        resolveExpression(statement.condition, scope);
+        const inner = createScope("block", scope);
+        resolveBlock(statement.body, inner);
+        return;
+      }
+      case "RepeatStatement": {
+        // `until`の条件式は本体で宣言されたローカルを参照できる
+        const inner = createScope("block", scope);
+        resolveBlock(statement.body, inner);
+        resolveExpression(statement.condition, inner);
+        return;
+      }
+      case "IfStatement":
+        statement.clauses.forEach((clause) => {
+          if (clause.type !== "ElseClause") {
+            resolveExpression(clause.condition, scope);
+          }
+          const inner = createScope("block", scope);
+          resolveBlock(clause.body, inner);
+        });
+        return;
+      case "ForNumericStatement": {
+        resolveExpression(statement.start, scope);
+        resolveExpression(statement.end, scope);
+        if (statement.step) {
+          resolveExpression(statement.step, scope);
+        }
+        const inner = createScope("block", scope);
+        declare(inner, statement.variable, "for");
+        resolveBlock(statement.body, inner);
+        return;
+      }
+      case "ForGenericStatement": {
+        statement.iterators.forEach((iterator) => {
+          resolveExpression(iterator, scope);
+        });
+        const inner = createScope("block", scope);
+        statement.variables.forEach((v) => declare(inner, v, "for"));
+        resolveBlock(statement.body, inner);
+        return;
+      }
+      case "FunctionDeclaration":
+        resolveFunctionDeclaration(statement, scope);
+        return;
+      case "ReturnStatement":
+        statement.arguments.forEach((argument) => {
+          resolveExpression(argument, scope);
+        });
+        return;
+      case "BreakStatement":
+        return;
+      case "LabelStatement":
+        // hoistLabelsで宣言済みのため、ここでは何もしない
+        return;
+      case "GotoStatement": {
+        const symbol = lookupLabel(scope, statement.label.name);
+        if (symbol) {
+          symbol.references.push(statement.label);
+          identifierSymbols.set(statement.label, symbol);
+        }
+        return;
+      }
+      default: {
+        const exhaustive: never = statement;
+        throw new TypeError(
+          "Unknown statement type: `" + JSON.stringify(exhaustive) + "`",
+        );
+      }
+    }
+  }
+
+  function resolveFunctionDeclaration(
+    fn: Parser.FunctionDeclaration,
+    scope: MutableScope,
+  ) {
+    if (fn.identifier) {
+      if (fn.identifier.type === "Identifier") {
+        if (fn.isLocal) {
+          // `local function`は再帰呼び出しのため、本体を解決する前に自身を宣言する
+          declare(scope, fn.identifier, "local");
+        } else {
+          // 非local: 既存のローカル/グローバルへの代入として扱う（新規宣言ではない）
+          reference(scope, fn.identifier);
+        }
+      } else {
+        resolveExpression(fn.identifier, scope);
+      }
+    }
+    const inner = createScope("function", scope);
+    fn.parameters.forEach((parameter) => {
+      if (parameter.type === "Identifier") {
+        declare(inner, parameter, "param");
+      }
+    });
+    resolveBlock(fn.body, inner);
+  }
+
+  function resolveExpression(
+    expr: Parser.Expression,
+    scope: MutableScope,
+  ): void {
+    switch (expr.type) {
+      case "Identifier":
+        reference(scope, expr);
+        return;
+      case "StringLiteral":
+      case "NumericLiteral":
+      case "BooleanLiteral":
+      case "NilLiteral":
+      case "VarargLiteral":
+        return;
+      case "LogicalExpression":
+      case "BinaryExpression":
+        resolveExpression(expr.left, scope);
+        resolveExpression(expr.right, scope);
+        return;
+      case "UnaryExpression":
+        resolveExpression(expr.argument, scope);
+        return;
+      case "CallExpression":
+        resolveExpression(expr.base, scope);
+        expr.arguments.forEach((argument) => {
+          resolveExpression(argument, scope);
+        });
+        return;
+      case "TableCallExpression":
+        resolveExpression(expr.base, scope);
+        resolveExpression(expr.arguments, scope);
+        return;
+      case "StringCallExpression":
+        resolveExpression(expr.base, scope);
+        resolveExpression(expr.argument, scope);
+        return;
+      case "IndexExpression":
+        resolveExpression(expr.base, scope);
+        resolveExpression(expr.index, scope);
+        return;
+      case "MemberExpression":
+        resolveExpression(expr.base, scope);
+        // フィールド名（`.identifier`）は変数参照ではないため解決しない
+        return;
+      case "FunctionDeclaration": {
+        const inner = createScope("function", scope);
+        expr.parameters.forEach((parameter) => {
+          if (parameter.type === "Identifier") {
+            declare(inner, parameter, "param");
+          }
+        });
+        resolveBlock(expr.body, inner);
+        return;
+      }
+      case "TableConstructorExpression":
+        expr.fields.forEach((field) => {
+          if (field.type === "TableKey") {
+            resolveExpression(field.key, scope);
+            resolveExpression(field.value, scope);
+          } else if (field.type === "TableValue") {
+            resolveExpression(field.value, scope);
+          } else {
+            // TableKeyString: キー名（`{ key = value }`のkey）は変数参照ではない
+            resolveExpression(field.value, scope);
+          }
+        });
+        return;
+      default: {
+        const exhaustive: never = expr;
+        throw new TypeError(
+          "Unknown expression type: `" + JSON.stringify(exhaustive) + "`",
+        );
+      }
+    }
+  }
+
+  const chunkScope = createScope("chunk", null);
+  resolveBlock(chunk.body, chunkScope);
+
+  return {
+    chunkScope,
+    symbols: allSymbols,
+    globals,
+    symbolOf: (identifier) => identifierSymbols.get(identifier),
+  };
+}

--- a/test/resolver.test.ts
+++ b/test/resolver.test.ts
@@ -1,0 +1,206 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import Parser from "luaparse";
+import { resolveScopes } from "../src/resolver";
+
+// Resolveパス（#19）の単体テスト。宣言と参照の対応、シャドーイング、グローバル判定を検証する。
+// このパスは出力を変更しないため、ここでは解析結果のみを検証する。
+
+function parse(code: string): Parser.Chunk {
+  return Parser.parse(code, { luaVersion: "5.3" });
+}
+
+void test("resolves references to their declaring local symbol", () => {
+  const chunk = parse(`
+    local x = 1
+    print(x)
+    x = 2
+  `);
+  const result = resolveScopes(chunk);
+
+  const declaration = (chunk.body[0] as Parser.LocalStatement).variables[0];
+  const declSymbol = result.symbolOf(declaration);
+  assert.ok(declSymbol);
+  assert.equal(declSymbol.kind, "local");
+
+  const printArg = (
+    (chunk.body[1] as Parser.CallStatement).expression as Parser.CallExpression
+  ).arguments[0] as Parser.Identifier;
+  assert.equal(result.symbolOf(printArg), declSymbol);
+
+  const assignTarget = (chunk.body[2] as Parser.AssignmentStatement)
+    .variables[0] as Parser.Identifier;
+  assert.equal(result.symbolOf(assignTarget), declSymbol);
+
+  assert.deepEqual(
+    declSymbol.references.map((r) => r.name),
+    ["x", "x"],
+  );
+});
+
+void test("shadowed locals in a nested block resolve to a distinct symbol", () => {
+  const chunk = parse(`
+    local x = 1
+    do
+      local x = 2
+      print(x)
+    end
+    print(x)
+  `);
+  const result = resolveScopes(chunk);
+
+  const outerDecl = (chunk.body[0] as Parser.LocalStatement).variables[0];
+  const outerSymbol = result.symbolOf(outerDecl);
+
+  const doStatement = chunk.body[1] as Parser.DoStatement;
+  const innerDecl = (doStatement.body[0] as Parser.LocalStatement).variables[0];
+  const innerSymbol = result.symbolOf(innerDecl);
+
+  assert.ok(outerSymbol);
+  assert.ok(innerSymbol);
+  assert.notEqual(innerSymbol, outerSymbol);
+
+  const innerPrintArg = (
+    (doStatement.body[1] as Parser.CallStatement)
+      .expression as Parser.CallExpression
+  ).arguments[0] as Parser.Identifier;
+  assert.equal(result.symbolOf(innerPrintArg), innerSymbol);
+
+  const outerPrintArg = (
+    (chunk.body[2] as Parser.CallStatement).expression as Parser.CallExpression
+  ).arguments[0] as Parser.Identifier;
+  assert.equal(result.symbolOf(outerPrintArg), outerSymbol);
+});
+
+void test("re-declaring a local in the same block shadows only subsequent references", () => {
+  const chunk = parse(`
+    local x = 1
+    print(x)
+    local x = 2
+    print(x)
+  `);
+  const result = resolveScopes(chunk);
+
+  const firstSymbol = result.symbolOf(
+    (chunk.body[0] as Parser.LocalStatement).variables[0],
+  );
+  const secondSymbol = result.symbolOf(
+    (chunk.body[2] as Parser.LocalStatement).variables[0],
+  );
+  assert.ok(firstSymbol);
+  assert.ok(secondSymbol);
+  assert.notEqual(firstSymbol, secondSymbol);
+
+  const firstPrintArg = (
+    (chunk.body[1] as Parser.CallStatement).expression as Parser.CallExpression
+  ).arguments[0] as Parser.Identifier;
+  assert.equal(result.symbolOf(firstPrintArg), firstSymbol);
+
+  const secondPrintArg = (
+    (chunk.body[3] as Parser.CallStatement).expression as Parser.CallExpression
+  ).arguments[0] as Parser.Identifier;
+  assert.equal(result.symbolOf(secondPrintArg), secondSymbol);
+});
+
+void test("a function parameter shadows an outer local of the same name", () => {
+  const chunk = parse(`
+    local x = 1
+    local function f(x)
+      return x
+    end
+  `);
+  const result = resolveScopes(chunk);
+
+  const outerSymbol = result.symbolOf(
+    (chunk.body[0] as Parser.LocalStatement).variables[0],
+  );
+  const fnDecl = chunk.body[1] as Parser.FunctionDeclaration;
+  const paramSymbol = result.symbolOf(
+    fnDecl.parameters[0] as Parser.Identifier,
+  );
+  assert.ok(outerSymbol);
+  assert.ok(paramSymbol);
+  assert.notEqual(paramSymbol, outerSymbol);
+  assert.equal(paramSymbol.kind, "param");
+
+  const returnArg = (fnDecl.body[0] as Parser.ReturnStatement)
+    .arguments[0] as Parser.Identifier;
+  assert.equal(result.symbolOf(returnArg), paramSymbol);
+});
+
+void test("a local function can refer to itself recursively", () => {
+  const chunk = parse(`
+    local function fact(n)
+      if n <= 1 then return 1 end
+      return n * fact(n - 1)
+    end
+  `);
+  const result = resolveScopes(chunk);
+
+  const fnDecl = chunk.body[0] as Parser.FunctionDeclaration;
+  const declSymbol = result.symbolOf(fnDecl.identifier as Parser.Identifier);
+  assert.ok(declSymbol);
+  assert.equal(declSymbol.kind, "local");
+
+  const returnStatement = fnDecl.body[1] as Parser.ReturnStatement;
+  const multiplyExpr = returnStatement.arguments[0] as Parser.BinaryExpression;
+  const callExpr = multiplyExpr.right as Parser.CallExpression;
+  const callee = callExpr.base as Parser.Identifier;
+  assert.equal(result.symbolOf(callee), declSymbol);
+});
+
+void test("a numeric for-loop variable is scoped to the loop body only", () => {
+  const chunk = parse(`
+    for i = 1, 10 do
+      print(i)
+    end
+    print(i)
+  `);
+  const result = resolveScopes(chunk);
+
+  const forStatement = chunk.body[0] as Parser.ForNumericStatement;
+  const loopVarSymbol = result.symbolOf(forStatement.variable);
+  assert.ok(loopVarSymbol);
+  assert.equal(loopVarSymbol.kind, "for");
+
+  const insideArg = (
+    (forStatement.body[0] as Parser.CallStatement)
+      .expression as Parser.CallExpression
+  ).arguments[0] as Parser.Identifier;
+  assert.equal(result.symbolOf(insideArg), loopVarSymbol);
+
+  // ループの外側にある同名の参照は、ループ変数のシンボルとは無関係でグローバル扱いになる
+  const afterArg = (
+    (chunk.body[1] as Parser.CallStatement).expression as Parser.CallExpression
+  ).arguments[0] as Parser.Identifier;
+  assert.equal(result.symbolOf(afterArg), undefined);
+  assert.ok(result.globals.has("i"));
+});
+
+void test("unresolved identifiers are collected as globals, not symbols, and field/key names are ignored", () => {
+  const chunk = parse(`
+    screen.setColor(1, 2, 3)
+    local w, h = screen.getWidth(), screen.getHeight()
+    local t = { x = 1 }
+  `);
+  const result = resolveScopes(chunk);
+
+  // "screen" はどこにも宣言されていないためグローバル参照が3回集計される
+  const screenBinding = result.globals.get("screen");
+  assert.ok(screenBinding);
+  assert.equal(screenBinding.references.length, 3);
+
+  // フィールド名（setColor/getWidth/getHeight）やテーブルキー名（x）は
+  // 変数参照ではないため、グローバルにもシンボルにも現れない
+  assert.equal(result.globals.size, 1);
+  assert.ok(!result.symbols.some((s) => s.name === "screen"));
+  assert.ok(!result.symbols.some((s) => s.name === "x"));
+
+  assert.deepEqual(
+    result.symbols
+      .filter((s) => s.kind === "local")
+      .map((s) => s.name)
+      .sort(),
+    ["h", "t", "w"],
+  );
+});


### PR DESCRIPTION
## 概要

Issue #19（[Phase 1] Resolveパス: スコープ解析とシンボルテーブルの構築）の対応。

現行実装にはスコープの概念がなく、`identifierMap`（`src/minifier.ts`）は「元の名前 → 短縮名」のグローバル1枚マップになっている（#12の識別子衝突バグの根本原因）。これを、宣言ごとに一意なシンボルを持つスコープツリーに置き換えるための最初のステップとして、独立したResolveパス（`src/resolver.ts`）を追加した。

## やったこと

- `src/resolver.ts` を新規追加し、`resolveScopes(chunk)` を実装
  - チャンク / 関数 / ブロック（`do`, `if`, `while`, `for`, `repeat`）ごとのスコープツリーを構築
  - `local` 宣言・関数パラメータ・for変数・ラベルをそれぞれ一意なシンボルとして登録（同名でも宣言が違えば別シンボル）
  - 識別子の参照を、Luaの通常のシャドーイング規則（同一ブロック内の再宣言・ネストしたブロックでのシャドーイング・`local function`の自己再帰参照など）に従って対応する宣言シンボルへ解決
  - ラベルはブロック内の宣言位置によらず参照できる（前方goto）ため、ブロック処理前に先読みで登録
  - どの束縛にも解決できない識別子はグローバル参照として `globals` に集計（フィールド名・テーブルキー名は変数参照として扱わない）
  - luaparseの `scope: true` が吐く `isLocal` 等の情報には依存せず、自前で検証可能なスコープ構造として実装
- `test/resolver.test.ts` を新規追加し、以下を単体テストで検証
  - 宣言と参照の対応（`local x` の宣言と、後続の参照・代入が同一シンボルに解決されること）
  - シャドーイング（ネストしたブロックでの再宣言、同一ブロック内での再宣言、関数パラメータによるシャドーイング、for変数のスコープがループ本体に限定されること）
  - グローバル判定（未宣言の識別子がグローバルとして集計され、フィールド名やテーブルキー名が誤って変数参照扱いされないこと）

## 完了条件との対応

Issue #19 の完了条件（宣言と参照の対応・シャドーイング・グローバル判定をアサートする単体テストが通ること）を満たす7件のテストを追加し、全てパスすることを確認済み。

このパスは解析のみを行い、`printer`（`ast2lua.ts`）や `minifier.ts` には未接続。既存の出力（スナップショット・ラウンドトリップ・識別子衝突検知テストを含む既存42件）に変更はない。

続くRenameパス（#20）が、このResolveパスのシンボルテーブルを使って識別子の短縮名割当（#12の本修正）を行う想定。

## テスト

- `npm run lint` — 変更なし・エラーなし
- `npx prettier --check .` — 変更なし
- `npx tsc --noEmit` — エラーなし
- `npm test` — 全42件パス（既存35件 + 新規7件）


---
_Generated by [Claude Code](https://claude.ai/code/session_01SzqZs7iDo1W1gmy6NzVZSA)_