### PR TITLE
Renameパス: シンボル単位の識別子短縮を実装 (#20)

### DIFF
--- a/src/ast2lua.ts
+++ b/src/ast2lua.ts
@@ -260,17 +260,20 @@ function insertSeparator(
 
 export class MinifyFile {
   private fileName: string;
+  private moduleName: string;
   private ast: Chunk;
   private minifier: Minifier;
   private mode: MinifierMode;
 
   constructor(
     fileName: string,
+    moduleName: string,
     ast: Chunk,
     minifier: Minifier,
     mode: MinifierMode,
   ) {
     this.fileName = fileName;
+    this.moduleName = moduleName;
     this.ast = ast;
     this.minifier = minifier;
     this.mode = mode;
@@ -618,15 +621,7 @@ export class MinifyFile {
     argOptions?: ExpressionOptoions,
   ): SourceNode {
     if (expression.type == "Identifier") {
-      return this.sourceNodeHelper(
-        expression,
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        //@ts-ignore
-        expression.isLocal
-          ? this.generateIdentifier(expression, true)
-          : expression.name,
-        expression.name,
-      );
+      return this.generateIdentifier(expression);
     } else if (
       expression.type == "StringLiteral" ||
       expression.type == "NumericLiteral" ||
@@ -928,16 +923,16 @@ export class MinifyFile {
     return undefined;
   }
 
-  private generateIdentifier(
-    nameItem: Parser.Identifier,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- #19/#20で対応予定のネストスコープ追跡用に予約
-    nested = false,
-  ): SourceNode {
-    if (nameItem.name === "self") {
-      return this.sourceNodeHelper(nameItem, "self", "self");
-    }
-
-    const id = this.minifier.allocateIdentifier(nameItem.name);
-    return this.sourceNodeHelper(nameItem, id, nameItem.name);
+  // Renameパス（#20）が解決済みシンボルテーブルをもとに割り当てた短縮名を参照する。
+  // 対応するローカルシンボルが無い場合（グローバル参照や"self"）は元の名前のまま出力する。
+  private generateIdentifier(nameItem: Parser.Identifier): SourceNode {
+    const renamed = this.minifier
+      .getRenameResult(this.moduleName)
+      .nameOf(nameItem);
+    return this.sourceNodeHelper(
+      nameItem,
+      renamed ?? nameItem.name,
+      nameItem.name,
+    );
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,6 +14,10 @@ program
   .option(
     "-m, --module-like-lua",
     "require・dofileの動作を実際のLuaに近づけます",
+  )
+  .option(
+    "--no-rename",
+    "識別子の短縮(リネーム)を無効にします（デバッグ用途）",
   );
 
 program.parse(process.argv);

--- a/src/minifier.ts
+++ b/src/minifier.ts
@@ -2,15 +2,23 @@ import Parser, { Options } from "luaparse";
 import path from "path";
 import fs from "fs";
 import { SourceNode } from "source-map";
-import { Chunk, MinifyFile, IDENTIFIER_PARTS, isKeyword } from "./ast2lua";
+import { Chunk, MinifyFile } from "./ast2lua";
 import { findModuleReferences } from "./linker";
+import { resolveScopes, ResolveResult } from "./resolver";
+import { assignRenames, RenameResult } from "./renamer";
 
 export interface MinifierMode {
   moduleLikeLua: boolean;
+  // 識別子の短縮(リネーム)を行うかどうか。デバッグ用途でfalseにできる。省略時はtrue扱い。
+  rename?: boolean;
 }
 
+const NO_RENAME: RenameResult = {
+  nameOf: () => undefined,
+  usedNames: new Set(),
+};
+
 export class Minifier {
-  readonly identifierMap: Map<string, string>;
   readonly identifiersInUse: Set<string>;
   readonly moduleSourceText: Map<string, string>;
   readonly moduleAST: Map<string, Chunk>;
@@ -20,16 +28,18 @@ export class Minifier {
   readonly mode: MinifierMode;
   readonly luaParseSettings: Partial<Options>;
 
-  private currentIdentifier = 0;
   // Linkパスで解決されたモジュール名を、依存されている側が先に来る順序で並べたもの
   private readonly linkOrder: string[] = [];
+  // モジュールごとのResolveパスの結果（Linkパスで一度だけ計算し使い回す）
+  private readonly moduleResolve = new Map<string, ResolveResult>();
+  // モジュールごとのRenameパスの結果（初回アクセス時に計算しキャッシュする）
+  private readonly renameCache = new Map<string, RenameResult>();
 
   constructor(
     entryFilePath: string,
     luaParseSettings: Partial<Options>,
     mode: MinifierMode,
   ) {
-    this.identifierMap = new Map<string, string>();
     this.identifiersInUse = new Set<string>();
     this.moduleSourceText = new Map<string, string>();
     this.moduleAST = new Map<string, Chunk>();
@@ -43,6 +53,7 @@ export class Minifier {
 
   parse(): SourceNode {
     this.link();
+    this.renameAll();
 
     const parts: (SourceNode | string)[] = [];
 
@@ -104,35 +115,53 @@ export class Minifier {
     }
     return new MinifyFile(
       fileName,
+      moduleName,
       ast,
       this,
       this.mode,
     ).parseAsStatementsAndFinalExpression(moduleName === this.entryModule);
   }
 
-  allocateIdentifier(key: string): string {
-    const defined = this.identifierMap.get(key);
-    if (defined) {
-      return defined;
+  /**
+   * 指定モジュールのRenameパス結果を返す。`renameAll`で事前に計算済みの
+   * ものをそのまま返すだけの参照用アクセサ。
+   */
+  getRenameResult(moduleName: string): RenameResult {
+    if (this.mode.rename === false) {
+      return NO_RENAME;
     }
-    if (this.identifiersInUse.has(key)) {
-      return key;
+    const cached = this.renameCache.get(moduleName);
+    if (!cached) {
+      throw new Error(moduleName + " is not found");
     }
+    return cached;
+  }
 
-    let id = "";
-    do {
-      let p = this.currentIdentifier++;
-      const l = IDENTIFIER_PARTS.length;
-      id = IDENTIFIER_PARTS[p % l];
-      p = Math.floor(p / l);
-      while (p >= l) {
-        id += IDENTIFIER_PARTS[p % l];
-        p = Math.floor(p / l);
+  /**
+   * Renameパス（#20）: linkOrder（依存されている側が先）の順にモジュールごとの
+   * 短縮名を割り当てる。
+   *
+   * dofileやSLモードのrequireその場展開は、呼び出し元と同じLuaスコープに
+   * 関数で包まずに直接展開されるため、モジュールをまたいで同じ短縮名を
+   * 再利用すると本来無関係な変数同士が衝突しうる（#12）。これを安全に防ぐため、
+   * あるモジュールが実際に使った短縮名は、後続モジュールを処理する前に
+   * `identifiersInUse`（予約名の集合）へ積み増す。これにより短縮名は
+   * プログラム全体で重複しなくなる（モジュール間での再利用による圧縮は
+   * 犠牲になるが、モジュール内でのスコープに基づく再利用は維持される）。
+   */
+  private renameAll() {
+    if (this.mode.rename === false) {
+      return;
+    }
+    this.linkOrder.forEach((moduleName) => {
+      const resolved = this.moduleResolve.get(moduleName);
+      if (!resolved) {
+        throw new Error(moduleName + " is not found");
       }
-    } while (isKeyword(id) || this.identifiersInUse.has(id));
-
-    this.identifierMap.set(key, id);
-    return id;
+      const result = assignRenames(resolved, this.identifiersInUse);
+      this.renameCache.set(moduleName, result);
+      result.usedNames.forEach((name) => this.identifiersInUse.add(name));
+    });
   }
 
   private printModule(moduleName: string): SourceNode {
@@ -141,7 +170,7 @@ export class Minifier {
     if (!ast || !fileName) {
       throw new Error(moduleName + " is not found");
     }
-    return new MinifyFile(fileName, ast, this, this.mode).parse(
+    return new MinifyFile(fileName, moduleName, ast, this, this.mode).parse(
       moduleName === this.entryModule,
     );
   }
@@ -179,10 +208,15 @@ export class Minifier {
       }
       const code = fs.readFileSync(fullResolvePath).toString();
       const ast = Parser.parse(code, this.luaParseSettings) as Chunk;
-      if (!("globals" in ast)) {
-        throw new Error(moduleName + " is not found");
-      }
-      ast.globals?.forEach((v) => this.identifiersInUse.add(v.name));
+
+      // Resolveパス（#19）: このモジュールのスコープ/シンボルを解析し、Renameパスの
+      // 入力として使い回せるようキャッシュする。グローバル参照はプログラム全体で
+      // 予約すべき名前（identifiersInUse）としてここで集計する。
+      const resolved = resolveScopes(ast);
+      this.moduleResolve.set(moduleName, resolved);
+      resolved.globals.forEach((binding) =>
+        this.identifiersInUse.add(binding.name),
+      );
 
       this.moduleSourceText.set(moduleName, code);
       this.moduleAST.set(moduleName, ast);

--- a/src/renamer.ts
+++ b/src/renamer.ts
@@ -1,0 +1,134 @@
+// Renameパス（#20）: Resolveパス（#19）が構築したシンボルテーブルをもとに、
+// シンボル単位で短縮識別子を割り当てる。printer（ast2lua.ts）は出力時の
+// その場リネームを行わず、このパスが決めた名前を参照するだけになる。
+//
+// 割当は2段階で行う。
+//   1. スロット割当: スコープ木を辿り、各シンボルに整数のスロットを割り当てる。
+//      兄弟スコープ同士（親子関係にないスコープ同士）は生存区間が重ならないため、
+//      同じスロットを再利用できる（圧縮率の向上）。同一スコープ内のシンボル同士・
+//      祖先スコープのシンボルとは必ず異なるスロットになるため、シンボルの生存
+//      スコープ内で名前が衝突することはない。
+//   2. 名前割当: スロットごとの参照回数（頻度）を集計し、頻度の高いスロットから
+//      順に短い名前を割り当てる。頻度の高いシンボルほど短い名前になるため、
+//      同じスロット数でも出力サイズが最小化される。
+//
+// 予約語・"self"・呼び出し側が指定する予約名（グローバル参照やStormworks APIなど）
+// は、どのシンボルにも割り当てられない。
+import Parser from "luaparse";
+import { Scope, Symbol, ResolveResult } from "./resolver";
+import { IDENTIFIER_PARTS, isKeyword } from "./ast2lua";
+
+export interface RenameResult {
+  // identifierがResolveパスで解決済みのローカルシンボルに対応する場合、
+  // 割り当てられた短縮名を返す。グローバル参照やフィールド名など対応する
+  // シンボルが無い場合はundefinedを返す（呼び出し側は元の名前を使う）。
+  nameOf(identifier: Parser.Identifier): string | undefined;
+  // このモジュールが実際に割り当てた短縮名の集合。requireの展開先が
+  // 呼び出し元と同じLuaスコープに直接展開される場合（dofile等、関数で
+  // 包まれない展開）があるため、他モジュールの割当と衝突しないよう
+  // 呼び出し側（Minifier）はこれを後続モジュールの予約名に積み増す。
+  readonly usedNames: ReadonlySet<string>;
+}
+
+function isAvailable(id: string, reserved: ReadonlySet<string>): boolean {
+  return id !== "self" && !isKeyword(id) && !reserved.has(id);
+}
+
+// 0始まりのカウンタから短縮名候補を生成する（バイジェクティブ基数記数法）。
+// 通常の位取り記数法と違い同じ文字列を2つのカウンタ値が指すことがないため、
+// カウンタを増やし続けるだけで重複なく識別子候補を列挙できる。
+function generateCandidate(counter: number): string {
+  const l = IDENTIFIER_PARTS.length;
+  let num = counter + 1;
+  let id = "";
+  while (num > 0) {
+    const rem = (num - 1) % l;
+    id = IDENTIFIER_PARTS[rem] + id;
+    num = Math.floor((num - 1) / l);
+  }
+  return id;
+}
+
+/**
+ * スコープ木のDFSでシンボルごとにスロット番号を割り当てる。
+ * `active`は祖先スコープ（自分を含む）で既に使われているスロットの集合。
+ * 兄弟スコープには同じ`active`のコピーが渡されるため、互いの割当は影響しない。
+ */
+function assignSlots(
+  scope: Scope,
+  active: ReadonlySet<number>,
+): Map<Symbol, number> {
+  const slotOf = new Map<Symbol, number>();
+  const used = new Set(active);
+
+  scope.symbols.forEach((symbol) => {
+    let slot = 0;
+    while (used.has(slot)) {
+      slot++;
+    }
+    slotOf.set(symbol, slot);
+    used.add(slot);
+  });
+
+  scope.children.forEach((child) => {
+    assignSlots(child, used).forEach((slot, symbol) => {
+      slotOf.set(symbol, slot);
+    });
+  });
+
+  return slotOf;
+}
+
+export function assignRenames(
+  resolveResult: ResolveResult,
+  reserved: ReadonlySet<string>,
+): RenameResult {
+  const slotOf = assignSlots(resolveResult.chunkScope, new Set());
+
+  // スロットの通算参照回数（宣言自体も1回として数える）を集計する。
+  const weightOfSlot = new Map<number, number>();
+  resolveResult.symbols.forEach((symbol) => {
+    const slot = slotOf.get(symbol);
+    if (slot === undefined) {
+      return;
+    }
+    const weight = symbol.references.length + 1;
+    weightOfSlot.set(slot, (weightOfSlot.get(slot) ?? 0) + weight);
+  });
+
+  const orderedSlots = [...weightOfSlot.keys()].sort(
+    (a, b) => (weightOfSlot.get(b) ?? 0) - (weightOfSlot.get(a) ?? 0),
+  );
+
+  const nameOfSlot = new Map<number, string>();
+  let counter = 0;
+  orderedSlots.forEach((slot) => {
+    let candidate: string;
+    do {
+      candidate = generateCandidate(counter++);
+    } while (!isAvailable(candidate, reserved));
+    nameOfSlot.set(slot, candidate);
+  });
+
+  const nameOfSymbol = new Map<Symbol, string>();
+  slotOf.forEach((slot, symbol) => {
+    const name = nameOfSlot.get(slot);
+    if (name !== undefined) {
+      nameOfSymbol.set(symbol, name);
+    }
+  });
+
+  return {
+    nameOf: (identifier) => {
+      // メソッド定義の暗黙のselfパラメータは慣習的な名前のため常に維持する
+      // （呼び出し側から見える名前ではないため短縮しても安全ではあるが、
+      // 可読性のために元の名前のままにする）。
+      if (identifier.name === "self") {
+        return undefined;
+      }
+      const symbol = resolveResult.symbolOf(identifier);
+      return symbol ? nameOfSymbol.get(symbol) : undefined;
+    },
+    usedNames: new Set(nameOfSlot.values()),
+  };
+}

--- a/test/no-rename.test.ts
+++ b/test/no-rename.test.ts
@@ -1,0 +1,19 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { runMinifier } from "./lib/helpers";
+
+// #20: CLIオプション(--no-rename)相当の`mode.rename = false`で識別子の短縮を
+// 無効化できることを確認する（デバッグ用途）。局所変数名は元のまま出力され、
+// 空白の除去などそれ以外のminify処理はそのまま行われる。
+void test("mode.rename = false disables identifier shortening", () => {
+  const { code } = runMinifier({
+    label: "single-file (no rename)",
+    fixture: "single-file",
+    mode: { moduleLikeLua: false, rename: false },
+  });
+
+  assert.match(code, /local function add\(first,second\)/);
+  assert.match(code, /local total=0/);
+  assert.match(code, /for index=1,10 do total=add\(total,index\)end/);
+  assert.match(code, /print\(total,i\)/);
+});

--- a/test/renamer.test.ts
+++ b/test/renamer.test.ts
@@ -1,0 +1,130 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import Parser from "luaparse";
+import { resolveScopes } from "../src/resolver";
+import { assignRenames } from "../src/renamer";
+
+// Renameパス（#20）の単体テスト。スコープに基づくスロット再利用、頻度順の名前割当、
+// 予約名との非衝突を検証する。
+
+function parse(code: string): Parser.Chunk {
+  return Parser.parse(code, { luaVersion: "5.3" });
+}
+
+void test("sibling scopes (non-overlapping) reuse the same short name", () => {
+  const chunk = parse(`
+    do
+      local x = 1
+      print(x)
+    end
+    do
+      local y = 2
+      print(y)
+    end
+  `);
+  const resolved = resolveScopes(chunk);
+  const result = assignRenames(resolved, new Set());
+
+  const firstDecl = (
+    (chunk.body[0] as Parser.DoStatement).body[0] as Parser.LocalStatement
+  ).variables[0];
+  const secondDecl = (
+    (chunk.body[1] as Parser.DoStatement).body[0] as Parser.LocalStatement
+  ).variables[0];
+
+  const firstName = result.nameOf(firstDecl);
+  const secondName = result.nameOf(secondDecl);
+  assert.ok(firstName);
+  assert.equal(firstName, secondName);
+});
+
+void test("symbols live in the same scope never receive the same short name", () => {
+  const chunk = parse(`
+    local a = 1
+    local b = 2
+    local c = 3
+    print(a, b, c)
+  `);
+  const resolved = resolveScopes(chunk);
+  const result = assignRenames(resolved, new Set());
+
+  const names = (chunk.body.slice(0, 3) as Parser.LocalStatement[]).map((s) =>
+    result.nameOf(s.variables[0]),
+  );
+  assert.equal(new Set(names).size, 3);
+});
+
+void test("more frequently referenced symbols get shorter names", () => {
+  const chunk = parse(`
+    local hot = 1
+    local cold = 2
+    print(hot, hot, hot, hot)
+    print(cold)
+  `);
+  const resolved = resolveScopes(chunk);
+  const result = assignRenames(resolved, new Set());
+
+  const hotDecl = (chunk.body[0] as Parser.LocalStatement).variables[0];
+  const coldDecl = (chunk.body[1] as Parser.LocalStatement).variables[0];
+
+  const hotName = result.nameOf(hotDecl);
+  const coldName = result.nameOf(coldDecl);
+  assert.ok(hotName);
+  assert.ok(coldName);
+  assert.ok(hotName.length <= coldName.length);
+  assert.notEqual(hotName, coldName);
+});
+
+void test("reserved names (globals/keywords) are never assigned to a symbol", () => {
+  const chunk = parse(`
+    local x = 1
+    print(x)
+  `);
+  const resolved = resolveScopes(chunk);
+  // "a" は本来最初に割り当てられるはずの名前。予約済みとして渡すと避けられる。
+  const result = assignRenames(resolved, new Set(["a"]));
+
+  const decl = (chunk.body[0] as Parser.LocalStatement).variables[0];
+  assert.notEqual(result.nameOf(decl), "a");
+});
+
+void test("self is never renamed and never assigned to another symbol", () => {
+  const chunk = parse(`
+    local function m(self, x)
+      return self, x
+    end
+  `);
+  const resolved = resolveScopes(chunk);
+  const result = assignRenames(resolved, new Set());
+
+  const fnDecl = chunk.body[0] as Parser.FunctionDeclaration;
+  const selfParam = fnDecl.parameters[0] as Parser.Identifier;
+  const xParam = fnDecl.parameters[1] as Parser.Identifier;
+
+  assert.equal(result.nameOf(selfParam), undefined);
+  assert.notEqual(result.nameOf(xParam), "self");
+});
+
+void test("usedNames reflects exactly the short names handed out", () => {
+  const chunk = parse(`
+    local x = 1
+    do
+      local y = 2
+      print(y)
+    end
+    print(x)
+  `);
+  const resolved = resolveScopes(chunk);
+  const result = assignRenames(resolved, new Set());
+
+  const xDecl = (chunk.body[0] as Parser.LocalStatement).variables[0];
+  const yDecl = (
+    (chunk.body[1] as Parser.DoStatement).body[0] as Parser.LocalStatement
+  ).variables[0];
+
+  const xName = result.nameOf(xDecl);
+  const yName = result.nameOf(yDecl);
+  assert.ok(xName);
+  assert.ok(yName);
+  assert.deepEqual(result.usedNames, new Set([xName, yName]));
+});

--- a/test/snapshots/single-file.sl.lua
+++ b/test/snapshots/single-file.sl.lua
@@ -1,6 +1,6 @@
-local function a(b,c)return b+c end
-local d=0
-for e=1,10 do d=a(d,e)end
-local f=0
-while f<3 do f=f+1 end
-print(d,f)
+local function d(b,e)return b+e end
+local c=0
+for b=1,10 do c=d(c,b)end
+local a=0
+while a<3 do a=a+1 end
+print(c,a)


### PR DESCRIPTION
## Summary

親Issue #15（Phase 1: コア書き直し）のうち #20（Renameパス）を実装した。Resolveパス（#19、`src/resolver.ts`）が構築したスコープ木・シンボルテーブルをもとに、出力時のその場リネーム（`identifierMap` / `currentIdentifier` / `allocateIdentifier`、598ca06での暫定回避）を置き換える独立したRenameパス（`src/renamer.ts`）を実装した。

- スコープ木をDFSで辿り、シンボルごとに整数の「スロット」を割り当てる。兄弟スコープ同士（親子関係にないスコープ）は生存区間が重ならないため同じスロットを再利用でき（圧縮率向上）、同一スコープ内・祖先スコープのシンボルとは必ず異なるスロットになる。
- スロットの通算参照回数（頻度）を集計し、頻度の高いスロットから短い名前を割り当てる。
- キーワード・`self`・グローバル参照（Stormworks APIを含む）など呼び出し側が指定する予約名は、どのシンボルにも割り当てない。
- `dofile`やSLモードのrequireその場展開は、呼び出し元と同じLuaスコープに関数で包まずに直接展開されるため、モジュールをまたいだ短縮名の再利用は安全ではない（実装中に発見。既存のsnapshotテストが実際にこの衝突を再現した）。`Minifier.renameAll`で`linkOrder`（依存関係順）にモジュールを処理し、あるモジュールが実際に使った短縮名を後続モジュールの予約名（`identifiersInUse`）へ積み増すことで、プログラム全体で短縮名が重複しないようにした。
- CLIに`--no-rename`オプションを追加し、デバッグ用途で識別子短縮を無効化できるようにした。
- printerの`generateIdentifier`は`isLocal`（luaparseの`scope:true`が吐く情報）への依存をやめ、Resolveパスのシンボルテーブル（`symbolOf`）を直接参照するようにした。

## Test plan

- [x] `npm test`（型チェック込み、49件）が全てパス
- [x] `npm run lint` / `npm run format:check` が通ること
- [x] `npx tsc --noEmit` でエラーが無いこと
- [x] 既存のスナップショット（`entry-scope-many-requires`等、#12回帰防止フィクスチャ含む）・識別子衝突検知テスト（`test/identifier-collision.test.ts`）が全てパス
- [x] Renameパスの単体テスト（`test/renamer.test.ts`）を追加：兄弟スコープでの短縮名再利用、同一スコープ内の非衝突、頻度順割当、予約名回避、`self`の非リネーム
- [x] `--no-rename`相当の動作確認テスト（`test/no-rename.test.ts`）を追加
- [x] Lua 5.3インタプリタをセットアップし、全WORKING_CASESフィクスチャ（`-m`モード／SLモード双方）をビルド済みCLIでminifyして実際に実行し、リネーム前の挙動と出力結果が一致することを確認

## 完了条件（#20より）

598ca06 / 3e1c6c7 の暫定回避コードは撤去済み。`identifierMap` / `currentIdentifier` / `allocateIdentifier`は削除し、printerはRenameパスの結果を参照するだけになった。


---
_Generated by [Claude Code](https://claude.ai/code/session_0118DPppXnqagcWHAMifiN2E)_