### PR TITLE
test: #14のキーワードマッピングテストをvitest移行後の形式に合わせる

### DIFF
--- a/test/sourcemap.test.ts
+++ b/test/sourcemap.test.ts
@@ -123,8 +123,10 @@ function locateInOriginal(
   return locateInGenerated(source, needle, occurrence);
 }
 
-void test("sourcemap: if/then/elseif/else/end等のキーワードトークンが、それぞれ独立して元ソース上の自身の出現位置にマップされる (#14)", () => {
+test("sourcemap: if/then/elseif/else/end等のキーワードトークンが、それぞれ独立して元ソース上の自身の出現位置にマップされる (#14)", () => {
   const { code, map } = runMinifier({
+    label:
+      "sourcemap: if/then/elseif/else/end等のキーワードトークンが、それぞれ独立して元ソース上の自身の出現位置にマップされる (#14)",
     fixture: "control-flow-keywords",
     mode: { moduleLikeLua: false },
   });


### PR DESCRIPTION
## Summary

PR #39（#14: キーワードトークンのSource Mapマッピング修正）が PR #38（#23: vitest移行）より先にdevelopへマージされたため、develop上の現状では以下が未対応のまま残っていた:

- `test/sourcemap.test.ts`に#14で追加したテストが`void test(...)`（node:test形式）のままだった
- #38で`FixtureCase.label`が必須化されたが、#14で追加したテストの`runMinifier(...)`呼び出しがこれを渡していなかった

develop上の`npm test`は現在`npx tsc -p tsconfig.eslint.json && npx vitest run`の2段構成になっており、`test/**/*.ts`も型チェック対象に含まれるため、上記のまま放置すると`label`省略が型エラーになる（`tsc`段階で失敗する）。

## 変更内容

- `void test(...)` → `test(...)`
- `runMinifier(...)`呼び出しに`label`を追加（他のテストと同じ形式に統一）

## Test plan

- [x] `npm ci`（developの現状に合わせてvitestを含む依存関係を再インストール）
- [x] `npm test`（`tsc -p tsconfig.eslint.json && vitest run`）が62件全てパス
- [x] `npm run lint` / `npm run format:check`
- [x] `npx tsc --noEmit`（build相当）

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ECBv78Pn99C2TJwpgVn6rb