### PR TITLE
未使用ローカル削除を複数宣言へ拡張する

### DIFF
--- a/src/ast2lua.ts
+++ b/src/ast2lua.ts
@@ -507,6 +507,15 @@ export class MinifyFile {
     if (!moduleRef || moduleRef.kind !== "require") {
       return undefined;
     }
+    // 戻り値を使わないrequireでは、依存モジュール末尾のreturn式も不要になる。
+    // return文ごと展開すると呼び出し元を途中でreturnし、後続文がある場合は
+    // 構文上も不正になるため、分離可能なら副作用を持つ先行文だけを出力する。
+    const spliced = this.minifier.splitModuleForStatementSplice(
+      moduleRef.moduleName,
+    );
+    if (spliced) {
+      return spliced.statements;
+    }
     return this.minifier.printModuleInline(moduleRef.moduleName);
   }
 

--- a/src/removeUnused.ts
+++ b/src/removeUnused.ts
@@ -22,11 +22,8 @@ function nestedBodies(statement: Parser.Statement): Parser.Statement[][] {
   }
 }
 
-function removableInitializer(statement: Parser.LocalStatement): boolean {
-  if (statement.variables.length !== 1) return false;
-  if (statement.init.length === 0) return true;
-  if (statement.init.length !== 1) return false;
-  switch (statement.init[0].type) {
+function isDiscardableInitializer(expression: Parser.Expression): boolean {
+  switch (expression.type) {
     case "NilLiteral":
     case "BooleanLiteral":
     case "NumericLiteral":
@@ -36,6 +33,33 @@ function removableInitializer(statement: Parser.LocalStatement): boolean {
     default:
       return false;
   }
+}
+
+function isStatementCall(
+  expression: Parser.Expression,
+): expression is
+  | Parser.CallExpression
+  | Parser.TableCallExpression
+  | Parser.StringCallExpression {
+  return (
+    expression.type === "CallExpression" ||
+    expression.type === "TableCallExpression" ||
+    expression.type === "StringCallExpression"
+  );
+}
+
+function callStatement(
+  expression:
+    | Parser.CallExpression
+    | Parser.TableCallExpression
+    | Parser.StringCallExpression,
+): Parser.CallStatement {
+  return {
+    type: "CallStatement",
+    expression,
+    loc: expression.loc,
+    range: rangeOf(expression),
+  } as Parser.CallStatement;
 }
 
 function hasExternalReference(
@@ -64,9 +88,9 @@ function removeFromBlock(
     });
   });
 
-  const removed = new Set<Parser.Statement>();
-  const kept = body.filter((statement) => {
-    if (metadata.annotationsOf(statement).keep) return true;
+  const replacements = new Map<Parser.Statement, Parser.Statement[]>();
+  body.forEach((statement) => {
+    if (metadata.annotationsOf(statement).keep) return;
     if (
       statement.type === "FunctionDeclaration" &&
       statement.isLocal &&
@@ -75,32 +99,95 @@ function removeFromBlock(
       const symbol = resolved.symbolOf(statement.identifier);
       if (symbol && !hasExternalReference(statement, symbol.references)) {
         changed = true;
-        removed.add(statement);
-        return false;
+        replacements.set(statement, []);
+        return;
       }
     }
-    if (
-      statement.type === "LocalStatement" &&
-      removableInitializer(statement)
-    ) {
-      const symbol = resolved.symbolOf(statement.variables[0]);
-      if (symbol && symbol.references.length === 0) {
-        changed = true;
-        removed.add(statement);
-        return false;
-      }
-    }
-    return true;
-  });
-  if (kept.length !== body.length) {
-    body.forEach((statement, index) => {
-      if (!removed.has(statement)) return;
-      const next = body
-        .slice(index + 1)
-        .find((candidate) => !removed.has(candidate));
-      metadata.removeStatement(statement, next);
+    if (statement.type !== "LocalStatement") return;
+
+    const unused = statement.variables.map((variable) => {
+      const symbol = resolved.symbolOf(variable);
+      return Boolean(symbol && symbol.references.length === 0);
     });
-    body.splice(0, body.length, ...kept);
+    if (!unused.some(Boolean)) return;
+
+    if (unused.every(Boolean)) {
+      if (
+        statement.init.every(
+          (expression) =>
+            isDiscardableInitializer(expression) || isStatementCall(expression),
+        )
+      ) {
+        const calls = statement.init.filter(isStatementCall).map(callStatement);
+        changed = true;
+        replacements.set(statement, calls);
+      }
+      return;
+    }
+
+    let variables = [...statement.variables];
+    let init = [...statement.init];
+    let unusedAfterPairRemoval = [...unused];
+
+    // 初期値なしなら全変数の値はnilで固定され、位置対応を維持する必要がない。
+    if (init.length === 0) {
+      variables = variables.filter((_, index) => !unused[index]);
+      unusedAfterPairRemoval = unused.filter((value) => !value);
+    }
+
+    // 要素数が一致するときだけ、変数とRHSの対応を崩さず安全なペアを抜ける。
+    if (init.length > 0 && variables.length === init.length) {
+      const retainedIndexes = variables
+        .map((_, index) => index)
+        .filter(
+          (index) => !(unused[index] && isDiscardableInitializer(init[index])),
+        );
+      variables = retainedIndexes.map((index) => variables[index]);
+      init = retainedIndexes.map((index) => init[index]);
+      unusedAfterPairRemoval = retainedIndexes.map((index) => unused[index]);
+    }
+
+    // 末尾の未使用名は、対応RHSを余剰式として評価させたまま名前だけ除ける。
+    let retainedVariableCount = variables.length;
+    while (
+      retainedVariableCount > 0 &&
+      unusedAfterPairRemoval[retainedVariableCount - 1]
+    ) {
+      retainedVariableCount--;
+    }
+    variables = variables.slice(0, retainedVariableCount);
+
+    if (variables.length === statement.variables.length) return;
+    changed = true;
+    const replacement = {
+      ...statement,
+      variables,
+      init,
+    } as Parser.LocalStatement;
+    replacements.set(statement, [replacement]);
+  });
+
+  if (replacements.size > 0) {
+    const nextBody: Parser.Statement[] = [];
+    body.forEach((statement, index) => {
+      const replacement = replacements.get(statement);
+      if (!replacement) {
+        nextBody.push(statement);
+        return;
+      }
+      if (replacement.length > 0) {
+        metadata.replaceStatement(statement, replacement);
+        nextBody.push(...replacement);
+        return;
+      }
+      const next = body.slice(index + 1).find((candidate) => {
+        const candidateReplacement = replacements.get(candidate);
+        return !candidateReplacement || candidateReplacement.length > 0;
+      });
+      const nextReplacement = next ? replacements.get(next) : undefined;
+      metadata.removeStatement(statement, nextReplacement?.[0] ?? next);
+    });
+    body.splice(0, body.length, ...nextBody);
   }
   return changed;
 }

--- a/src/sourceMetadata.ts
+++ b/src/sourceMetadata.ts
@@ -239,6 +239,35 @@ export class SourceMetadata {
     }
   }
 
+  /**
+   * 1つの文を複数文へ置換するとき、文境界に属する情報を外側の境界へ移す。
+   * leading/detachedは最初、trailingは最後へ置くことで、置換後もコメントの
+   * 前後関係を変えない。アノテーションは変換判断に使った後も、後続パスが
+   * 同じ保護指定を観測できるよう全置換文へ引き継ぐ。
+   */
+  replaceStatement(
+    source: Parser.Statement,
+    replacements: readonly Parser.Statement[],
+  ): void {
+    if (replacements.length === 0) return;
+    const first = replacements[0];
+    const last = replacements[replacements.length - 1];
+
+    const detached = this.detachedBefore.get(source);
+    const before = this.before.get(source);
+    const trailing = this.trailing.get(source);
+    if (detached?.length) this.detachedBefore.set(first, detached);
+    if (before?.length) this.before.set(first, before);
+    if (trailing?.length) this.trailing.set(last, trailing);
+
+    const annotations = this.annotations.get(source);
+    if (annotations) {
+      replacements.forEach((statement) =>
+        this.annotations.set(statement, annotations),
+      );
+    }
+  }
+
   removeStatement(
     statement: Parser.Statement,
     nextStatement?: Parser.Statement,

--- a/test/fixtures/unused-stage4/dep.lua
+++ b/test/fixtures/unused-stage4/dep.lua
@@ -1,0 +1,2 @@
+dependencyEffect()
+return 42

--- a/test/fixtures/unused-stage4/main.lua
+++ b/test/fixtures/unused-stage4/main.lua
@@ -1,0 +1,8 @@
+--# before effects
+local unusedModule, unusedResult = require("dep"), sideEffect() --# after effects
+
+--@storm keep-name
+local removableName = 1
+
+local retained, removable = produce(), 2
+print(retained)

--- a/test/removeUnused.integration.test.ts
+++ b/test/removeUnused.integration.test.ts
@@ -1,0 +1,60 @@
+import { test } from "vitest";
+import assert from "node:assert/strict";
+import Parser from "luaparse";
+import { SourceMapConsumer } from "source-map";
+import { runMinifier } from "./lib/helpers";
+
+test("stage 4 composes with require splicing, comments, rename, and local merging", async () => {
+  const { code, map } = runMinifier({
+    label: "unused stage 4 integration",
+    fixture: "unused-stage4",
+    mode: { moduleLikeLua: false },
+  });
+
+  assert.doesNotThrow(() => Parser.parse(code, { luaVersion: "5.3" }));
+  assert.match(code, /--# before effects\ndependencyEffect\(\)/);
+  assert.match(code, /sideEffect\(\) --# after effects/);
+  assert.doesNotMatch(code, /removableName|removable/);
+  assert.match(code, /local [a-zA-Z_]=produce\(\)/);
+
+  const generatedIndex = code.indexOf("sideEffect");
+  assert.notEqual(generatedIndex, -1);
+  await SourceMapConsumer.with(map, null, (consumer) => {
+    const original = consumer.originalPositionFor({
+      line: code.slice(0, generatedIndex).split("\n").length,
+      column: generatedIndex - (code.lastIndexOf("\n", generatedIndex) + 1),
+    });
+    assert.equal(original.source, "main.lua");
+    assert.equal(original.line, 2);
+    assert.equal(original.name, "sideEffect");
+
+    const retainedIndex = code.indexOf("local ") + "local ".length;
+    const retained = consumer.originalPositionFor({
+      line: code.slice(0, retainedIndex).split("\n").length,
+      column: retainedIndex - (code.lastIndexOf("\n", retainedIndex) + 1),
+    });
+    assert.equal(retained.source, "main.lua");
+    assert.equal(retained.line, 7);
+    assert.equal(retained.name, "retained");
+  });
+});
+
+test("removeUnused false disables all stage 4 transformations", () => {
+  const { code } = runMinifier({
+    label: "unused stage 4 disabled",
+    fixture: "unused-stage4",
+    mode: {
+      moduleLikeLua: true,
+      removeUnused: false,
+      rename: false,
+      mergeLocals: false,
+      globalAlias: false,
+    },
+  });
+  assert.match(
+    code,
+    /local unusedModule,unusedResult=require\("dep"\),sideEffect\(\)/,
+  );
+  assert.match(code, /local removableName=1/);
+  assert.match(code, /local retained,removable=produce\(\),2/);
+});

--- a/test/removeUnused.test.ts
+++ b/test/removeUnused.test.ts
@@ -50,10 +50,111 @@ test("keeps used, annotated, effectful, multi-variable, and expandable locals", 
     local tableValue = {}
     local calculated = 1 + 2
     local indexed = object.value
-    local a, b = 1, 2
     local c = ...
   `);
-  assert.equal(chunk.body.length, 9);
+  assert.equal(chunk.body.length, 8);
+});
+
+test("turns direct initializers of wholly unused declarations into statements", () => {
+  const chunk = remove(`
+    local a, b, c, d, e = 1, first(), function() end, second {}, third "x"
+  `);
+  assert.deepEqual(
+    chunk.body.map((statement) => statement.type),
+    ["CallStatement", "CallStatement", "CallStatement"],
+  );
+  assert.deepEqual(
+    chunk.body.map((statement) => {
+      const expression = (statement as Parser.CallStatement).expression;
+      return expression.base.type === "Identifier" ? expression.base.name : "";
+    }),
+    ["first", "second", "third"],
+  );
+});
+
+test("removes discardable pairs without shifting values of retained locals", () => {
+  const chunk = remove(`
+    local first, unused, last = makeFirst(), 1, makeLast()
+    print(first, last)
+  `);
+  const declaration = chunk.body[0] as Parser.LocalStatement;
+  assert.deepEqual(
+    declaration.variables.map((variable) => variable.name),
+    ["first", "last"],
+  );
+  assert.deepEqual(
+    declaration.init.map((expression) => expression.type),
+    ["CallExpression", "CallExpression"],
+  );
+});
+
+test("removes unused names anywhere when a declaration has no initializers", () => {
+  const chunk = remove(`
+    local first, unused, last
+    print(first, last)
+  `);
+  const declaration = chunk.body[0] as Parser.LocalStatement;
+  assert.deepEqual(
+    declaration.variables.map((variable) => variable.name),
+    ["first", "last"],
+  );
+  assert.equal(declaration.init.length, 0);
+});
+
+test("removes an unused suffix while preserving surplus RHS evaluation", () => {
+  const chunk = remove(`
+    local used, unused = first(), second()
+    print(used)
+  `);
+  const declaration = chunk.body[0] as Parser.LocalStatement;
+  assert.deepEqual(
+    declaration.variables.map((variable) => variable.name),
+    ["used"],
+  );
+  assert.equal(declaration.init.length, 2);
+});
+
+test("handles fewer and excess initializers without changing their order", () => {
+  const fewer = remove(`
+    local used, unused = values()
+    print(used)
+  `).body[0] as Parser.LocalStatement;
+  assert.equal(fewer.variables.length, 1);
+  assert.equal(fewer.init.length, 1);
+
+  const excess = remove(`
+    local used, unused = first(), second(), third()
+    print(used)
+  `).body[0] as Parser.LocalStatement;
+  assert.equal(excess.variables.length, 1);
+  assert.equal(excess.init.length, 3);
+});
+
+test("keeps unsafe middle values, expandable expressions, and protected declarations", () => {
+  const chunk = remove(`
+    local usedA, unsafe, usedB = first(), side(), third()
+    print(usedA, usedB)
+    local tableValue, calculated, indexed, expanded = {}, 1 + 2, object.value, ...
+    --@storm keep
+    local keptA, keptB = 1, second()
+    --@storm export
+    local exportedA, exportedB = 1, third()
+  `);
+  assert.equal((chunk.body[0] as Parser.LocalStatement).variables.length, 3);
+  assert.equal((chunk.body[2] as Parser.LocalStatement).variables.length, 4);
+  assert.equal((chunk.body[3] as Parser.LocalStatement).variables.length, 2);
+  assert.equal((chunk.body[4] as Parser.LocalStatement).variables.length, 2);
+});
+
+test("keep-name alone does not prevent unused removal", () => {
+  const chunk = remove(`
+    --@storm keep-name
+    local unusedA, unusedB = 1, call()
+  `);
+  assert.deepEqual(
+    chunk.body.map((statement) => statement.type),
+    ["CallStatement"],
+  );
 });
 
 test("recurses through nested blocks and distinguishes shadowed symbols", () => {

--- a/test/sourceMetadata.test.ts
+++ b/test/sourceMetadata.test.ts
@@ -88,3 +88,25 @@ local b = call()`;
     ["--# first", "--# second"],
   );
 });
+
+test("moves outer comments to the first and last statement of a replacement", () => {
+  const code = `--# leading
+local a, b = first(), second() --# trailing`;
+  const { chunk, metadata: result } = metadata(code);
+  const source = chunk.body[0];
+  const original = source as Parser.LocalStatement;
+  const replacements = original.init.map(
+    (expression) =>
+      ({ type: "CallStatement", expression }) as Parser.CallStatement,
+  );
+  result.replaceStatement(source, replacements);
+  assert.deepEqual(
+    result.beforeOf(replacements[0]).map((comment) => comment.raw),
+    ["--# leading"],
+  );
+  assert.deepEqual(
+    result.trailingOf(replacements[1]).map((comment) => comment.raw),
+    ["--# trailing"],
+  );
+  assert.equal(result.trailingOf(replacements[0]).length, 0);
+});


### PR DESCRIPTION
## 概要

Issue 43の第4段階として、既存の未使用ローカル削除を複数変数宣言と直接呼び出しへ保守的に拡張します。LuaのRHS評価順、ローカル束縛のタイミング、末尾式の多値展開を変えないと確認できる場合だけ変換します。

## 変更内容

- 全変数が未使用で、各初期値が副作用なく破棄可能か直接呼び出しの場合、宣言を除去
  - nil、boolean、number、string、関数リテラルは破棄
  - 通常・テーブル・文字列呼び出しは元の順序の呼び出し文として保持
- 変数数と初期値数が一致する場合、未使用変数と破棄可能な初期値のペアだけを除去
- 初期値なしの宣言では、位置を問わず未使用変数を除去
- 未使用変数が末尾の連続サフィックスなら、RHSを余剰式として残したまま変数名だけを除去
- 中央の副作用候補、一般式、vararg、値対応を証明できない形は変更せず保持
- `keep` / `export` は文全体を保護し、`keep-name` 単独は未使用削除を妨げない
- 1文を複数の呼び出し文へ置換するとき、leading・detachedコメントを先頭、trailingコメントを末尾へ移送
- 縮小時は既存ノードと位置情報を再利用し、Source MapとRename用メタデータを維持
- 戻り値を捨てるbare requireのSL展開では、依存モジュールの副作用文だけを出力し、末尾の返却式を展開しない

CLIおよび公開APIの追加変更はありません。`--no-remove-unused` / `removeUnused:false` で今回の変換も一括して無効になります。

## 評価

代表fixtureでは、未使用除去無効時419 bytesに対し有効時337 bytesとなり、82 bytes（約19.6%）削減しました。副作用呼び出しの回数・順序、保持コメント、Source Map、Rename/Mergeとの組み合わせ、require展開、生成Luaの再パースを確認しています。

## 検証

- `pnpm test`: 17 files / 126 tests passed
- `pnpm build`
- `pnpm exec eslint . --ignore-pattern .claude`
- `pnpm format:check`
- `pnpm pack --dry-run`
- `git diff --check`

## 今回含めないもの

- 未使用グローバル削除
- 通常の代入文の削減
- 一般的な式の純粋性解析
- 一時変数を導入する値位置の再構成

Issueは閉じません。後続の第5段階では、現行パーサーが今後の圧縮改善に与える制約を評価し、今回安全性を証明できず見送った圧縮例を具体的なLuaコードとともにIssueへ記録します。