### PR TITLE
requireラッパーをAST化し、損失のない必須空白をLFにする

### DIFF
--- a/src/ast2lua.ts
+++ b/src/ast2lua.ts
@@ -9,6 +9,7 @@ import { staticStringArgument } from "./linker";
 import { KeywordLocator } from "./keywordLocator";
 import { originalNameOf } from "./transform";
 import { isPreservedComment } from "./sourceMetadata";
+import { GeneratedStatement } from "./generatedAst";
 
 export type Chunk = Parser.Chunk & {
   globals?: (Parser.Base<"Identifer"> & {
@@ -225,10 +226,22 @@ interface ExpressionOptoions {
   parent?: string | undefined;
 }
 
+const requiredWhitespaceByNode = new WeakMap<SourceNode, " " | "\n">();
+
+function whitespaceOf(...values: (string | SourceNode)[]): " " | "\n" {
+  for (const value of values) {
+    if (value instanceof SourceNode) {
+      const whitespace = requiredWhitespaceByNode.get(value);
+      if (whitespace) return whitespace;
+    }
+  }
+  return "\n";
+}
+
 function addWithSeparator(
   val: SourceNode,
   adding: (string | SourceNode)[] | SourceNode | string,
-  separator = " ",
+  separator = whitespaceOf(val),
 ) {
   if (
     isNeedSeparator(
@@ -247,7 +260,7 @@ function addWithSeparator(
 function prependWithSeparator(
   val: SourceNode,
   prepending: (string | SourceNode)[] | SourceNode | string,
-  separator = " ",
+  separator = whitespaceOf(val),
 ) {
   if (
     isNeedSeparator(
@@ -266,7 +279,7 @@ function prependWithSeparator(
 function insertSeparator(
   a: string | SourceNode,
   b: string | SourceNode,
-  separator = " ",
+  separator = whitespaceOf(a, b),
 ) {
   return isNeedSeparator(a.toString(), b.toString()) ? separator : undefined;
 }
@@ -277,6 +290,7 @@ export class MinifyFile {
   private ast: Chunk;
   private minifier: Minifier;
   private mode: MinifierMode;
+  private requiredWhitespace: " " | "\n";
 
   constructor(
     fileName: string,
@@ -290,6 +304,12 @@ export class MinifyFile {
     this.ast = ast;
     this.minifier = minifier;
     this.mode = mode;
+    this.requiredWhitespace = mode.requiredWhitespace ?? "\n";
+  }
+
+  /** 合成文同士の境界も、通常の文リストと同じ区切り判定で出力する。 */
+  printGeneratedStatements(statements: GeneratedStatement[]): SourceNode {
+    return this.formatStatementList(statements);
   }
 
   parse() {
@@ -352,13 +372,15 @@ export class MinifyFile {
     const column = node?.loc?.start.column;
     // this.fileNameは常にこのMinifyFileインスタンスが担当するモジュール自身の
     // ファイル名（Linkパスで解決済み）なので、ここで出力するノードの由来ファイルとして正しい。
-    return new SourceNode(
+    const sourceNode = new SourceNode(
       line == undefined ? null : line,
       column == undefined ? null : column,
       this.fileName,
       chuncks,
       name,
     );
+    requiredWhitespaceByNode.set(sourceNode, this.requiredWhitespace);
+    return sourceNode;
   }
 
   private _keywordLocator: KeywordLocator | undefined;
@@ -391,6 +413,9 @@ export class MinifyFile {
    * （入れ子の`if...then`等）を誤って拾うことはない。
    */
   private keywordAfter(anchor: Parser.Node, value: string): SourceNode {
+    if (!anchor.loc?.end) {
+      return this.sourceNodeHelper(undefined, value);
+    }
     return this.keywordFrom(anchor.loc?.end, value);
   }
 
@@ -423,13 +448,14 @@ export class MinifyFile {
     );
   }
 
-  private formatStatementList(body: Parser.Statement[] | Parser.Statement) {
+  private formatStatementList(body: GeneratedStatement[] | GeneratedStatement) {
     const result = this.sourceNodeHelper(undefined, []);
     const metadata = this.minifier.getSourceMetadata(this.moduleName);
     wrapArray(body).forEach((statement) => {
       const statementNode = this.sourceNodeHelper(undefined, []);
-      metadata
-        .beforeOf(statement)
+      const sourceStatement =
+        statement.type === "ModuleSplice" ? undefined : statement;
+      (sourceStatement ? metadata.beforeOf(sourceStatement) : [])
         .filter(isPreservedComment)
         .forEach((comment) => {
           statementNode.add([
@@ -438,12 +464,11 @@ export class MinifyFile {
           ]);
         });
       statementNode.add(this.formatStatement(statement));
-      metadata
-        .trailingOf(statement)
+      (sourceStatement ? metadata.trailingOf(sourceStatement) : [])
         .filter(isPreservedComment)
         .forEach((comment) => {
           statementNode.add([
-            " ",
+            this.requiredWhitespace,
             this.sourceNodeHelper(comment, comment.raw),
             "\n",
           ]);
@@ -493,7 +518,10 @@ export class MinifyFile {
 
     const result = this.sourceNodeHelper(statement, []);
     addWithSeparator(result, spliced.statements);
-    addWithSeparator(result, isLocal ? ["local ", targetNode] : [targetNode]);
+    if (isLocal) {
+      addWithSeparator(result, "local");
+    }
+    addWithSeparator(result, targetNode);
     addWithSeparator(result, "=");
     addWithSeparator(result, spliced.finalExpression);
     return result;
@@ -529,7 +557,10 @@ export class MinifyFile {
     return this.minifier.printModuleInline(moduleRef.moduleName);
   }
 
-  private formatStatement(statement: Parser.Statement): SourceNode {
+  private formatStatement(statement: GeneratedStatement): SourceNode {
+    if (statement.type === "ModuleSplice") {
+      return this.minifier.printModuleInline(statement.moduleName);
+    }
     if (
       statement.type == "AssignmentStatement" ||
       statement.type == "LocalStatement"
@@ -562,10 +593,11 @@ export class MinifyFile {
       const variables = statement.variables
         .map((variable) => [this.formatExpression(variable), ","])
         .flat();
-      const result = this.sourceNodeHelper(statement, [
-        "local ",
+      const result = this.sourceNodeHelper(statement, "local");
+      addWithSeparator(
+        result,
         this.sourceNodeHelper(undefined, variables.slice(0, -1)),
-      ]);
+      );
 
       if (statement.init.length) {
         const inits = statement.init
@@ -651,8 +683,11 @@ export class MinifyFile {
     } else if (statement.type == "FunctionDeclaration") {
       const result = this.sourceNodeHelper(
         statement,
-        (statement.isLocal ? "local " : "") + "function ",
+        statement.isLocal ? "local" : "function",
       );
+      if (statement.isLocal) {
+        addWithSeparator(result, "function");
+      }
       if (statement.identifier) {
         addWithSeparator(result, this.formatExpression(statement.identifier));
       }
@@ -728,10 +763,9 @@ export class MinifyFile {
       ]);
     } else if (statement.type == "GotoStatement") {
       // The identifier names in a `GotoStatement` can safely be renamed
-      return this.sourceNodeHelper(statement, [
-        "goto ",
-        this.generateIdentifier(statement.label),
-      ]);
+      const result = this.sourceNodeHelper(statement, "goto");
+      addWithSeparator(result, this.generateIdentifier(statement.label));
+      return result;
     } else {
       throw TypeError(
         "Unknown statement type: `" + JSON.stringify(statement) + "`",
@@ -1053,11 +1087,11 @@ export class MinifyFile {
       // （挙動互換性のため、ホイストした共有ローカルへの参照にはしない）。
       // 式の位置に置けるようにIIFEで包む。
       const body = this.minifier.printModuleInline(ref.moduleName);
-      return this.sourceNodeHelper(expression, [
-        "(function() ",
-        body,
-        " end)()",
-      ]);
+      const result = this.sourceNodeHelper(expression, "(function()");
+      addWithSeparator(result, body);
+      addWithSeparator(result, "end");
+      result.add(")()");
+      return result;
     }
 
     // -mモードのrequireはそのまま呼び出しとして出力し、実行時のrequire関数に委ねる

--- a/src/generatedAst.ts
+++ b/src/generatedAst.ts
@@ -1,0 +1,152 @@
+import Parser from "luaparse";
+
+/**
+ * リンク後に合成するASTで、対象モジュールの本体をこの位置へ挿入することを表す。
+ * 生成済み文字列を保持しないため、将来はコード生成より前に通常ASTへ実体化できる。
+ */
+export interface ModuleSplice {
+  type: "ModuleSplice";
+  moduleName: string;
+}
+
+export type GeneratedStatement = Parser.Statement | ModuleSplice;
+
+const identifier = (name: string): Parser.Identifier => ({
+  type: "Identifier",
+  name,
+});
+
+const member = (
+  base: Parser.Expression,
+  name: string,
+): Parser.MemberExpression => ({
+  type: "MemberExpression",
+  indexer: ".",
+  identifier: identifier(name),
+  base,
+});
+
+const index = (
+  base: Parser.Expression,
+  key: Parser.Expression,
+): Parser.IndexExpression => ({ type: "IndexExpression", base, index: key });
+
+const loaded = (): Parser.MemberExpression =>
+  member(identifier("package"), "loaded");
+
+const loadedAtM = (): Parser.IndexExpression =>
+  index(loaded(), identifier("m"));
+
+const assignment = (
+  variable:
+    Parser.Identifier | Parser.MemberExpression | Parser.IndexExpression,
+  value: Parser.Expression,
+): Parser.AssignmentStatement => ({
+  type: "AssignmentStatement",
+  variables: [variable],
+  init: [value],
+});
+
+const logical = (
+  operator: "and" | "or",
+  left: Parser.Expression,
+  right: Parser.Expression,
+): Parser.LogicalExpression => ({
+  type: "LogicalExpression",
+  operator,
+  left,
+  right,
+});
+
+const truth: Parser.BooleanLiteral = {
+  type: "BooleanLiteral",
+  value: true,
+  raw: "true",
+};
+
+function moduleClause(moduleName: string): Parser.IfStatement {
+  const moduleString: Parser.StringLiteral = {
+    type: "StringLiteral",
+    value: moduleName,
+    raw: JSON.stringify(moduleName),
+  };
+  const moduleBody: ModuleSplice = { type: "ModuleSplice", moduleName };
+  const loader: Parser.FunctionDeclaration = {
+    type: "FunctionDeclaration",
+    identifier: null,
+    isLocal: false,
+    parameters: [],
+    // luaparseの公開型は拡張ノードを含まない。コード生成前だけ存在する内部ASTとして
+    // FunctionDeclarationのbodyへ保持し、printer側でModuleSpliceを明示的に処理する。
+    body: [moduleBody as unknown as Parser.Statement],
+  };
+  const callLoader: Parser.CallExpression = {
+    type: "CallExpression",
+    base: loader,
+    arguments: [],
+  };
+  return {
+    type: "IfStatement",
+    clauses: [
+      {
+        type: "IfClause",
+        condition: {
+          type: "BinaryExpression",
+          operator: "==",
+          left: identifier("m"),
+          right: moduleString,
+        },
+        body: [assignment(identifier("r"), callLoader)],
+      },
+    ],
+  };
+}
+
+/** require互換関数を、入力ソースに由来しない合成ASTとして構築する。 */
+export function buildRequireWrapperAst(
+  moduleNames: readonly string[],
+): Parser.FunctionDeclaration {
+  const emptyLoadedTable: Parser.TableConstructorExpression = {
+    type: "TableConstructorExpression",
+    fields: [],
+  };
+  const packageFallback: Parser.TableConstructorExpression = {
+    type: "TableConstructorExpression",
+    fields: [
+      {
+        type: "TableKeyString",
+        key: identifier("loaded"),
+        value: emptyLoadedTable,
+      },
+    ],
+  };
+
+  return {
+    type: "FunctionDeclaration",
+    identifier: identifier("require"),
+    isLocal: false,
+    parameters: [identifier("m"), identifier("r")],
+    body: [
+      assignment(
+        identifier("package"),
+        logical("or", identifier("package"), packageFallback),
+      ),
+      {
+        type: "IfStatement",
+        clauses: [
+          {
+            type: "IfClause",
+            condition: loadedAtM(),
+            body: [{ type: "ReturnStatement", arguments: [loadedAtM()] }],
+          },
+        ],
+      },
+      ...moduleNames.map(moduleClause),
+      assignment(
+        loadedAtM(),
+        logical("or", logical("or", loadedAtM(), identifier("r")), truth),
+      ),
+      { type: "ReturnStatement", arguments: [loadedAtM()] },
+    ],
+  };
+}

--- a/src/minifier.ts
+++ b/src/minifier.ts
@@ -11,9 +11,13 @@ import { mergeLocalDeclarations, insertGlobalAliases } from "./transform";
 import { SourceMetadata } from "./sourceMetadata";
 import { removeUnusedLocals } from "./removeUnused";
 import { foldConstants } from "./constantFold";
+import { buildRequireWrapperAst, GeneratedStatement } from "./generatedAst";
 
 export interface MinifierMode {
   moduleLikeLua: boolean;
+  // 字句の結合を防ぐために必要な1バイトの空白。省略時は、出力サイズを
+  // 増やさずStormworksの行単位診断を改善できるLFを使う。
+  requiredWhitespace?: " " | "\n";
   // 識別子の短縮(リネーム)を行うかどうか。デバッグ用途でfalseにできる。省略時はtrue扱い。
   rename?: boolean;
   // 内部でのみ使用するグローバル識別子の短縮（#8a）を行うかどうか。省略時はfalse扱い。
@@ -93,15 +97,9 @@ export class Minifier {
     this.transformAll();
     this.renameAll();
 
-    const parts: (SourceNode | string)[] = [];
-
-    if (this.mode.moduleLikeLua) {
-      parts.push(this.buildRequireWrapper());
-    }
-
-    parts.push(this.printModule(this.entryModule));
-
-    const result = new SourceNode(null, null, null, parts);
+    const result = this.mode.moduleLikeLua
+      ? this.printModuleWithRequireWrapper()
+      : this.printModule(this.entryModule);
 
     this.moduleSourceText.forEach((v, k) => {
       const fileName = this.moduleNameAndFileName.get(k);
@@ -441,26 +439,28 @@ export class Minifier {
     return targets;
   }
 
-  private buildRequireWrapper(): SourceNode {
+  private printModuleWithRequireWrapper(): SourceNode {
     const targets = this.collectRequireTargets();
-    const parts: (SourceNode | string)[] = [
-      "function require(m,r)package=package or{loaded={}};if package.loaded[m]then return package.loaded[m]end\n",
-    ];
-    this.linkOrder.forEach((moduleName) => {
-      if (moduleName === this.entryModule || !targets.has(moduleName)) {
-        return;
-      }
-      parts.push(
-        'if m=="',
-        moduleName,
-        '"then r=(function() ',
-        this.printModule(moduleName),
-        " end)()end\n",
-      );
-    });
-    parts.push(
-      "package.loaded[m]=package.loaded[m]or r or true;return package.loaded[m]end\n",
+    const moduleNames = this.linkOrder.filter(
+      (moduleName) =>
+        moduleName !== this.entryModule && targets.has(moduleName),
     );
-    return new SourceNode(null, null, null, parts);
+    const wrapperAst = buildRequireWrapperAst(moduleNames);
+    const entryAst = this.moduleAST.get(this.entryModule);
+    const entryFileName = this.moduleNameAndFileName.get(this.entryModule);
+    if (!entryAst || !entryFileName) {
+      throw new Error(this.entryModule + " is not found");
+    }
+    const statements: GeneratedStatement[] = [
+      wrapperAst,
+      { type: "ModuleSplice", moduleName: this.entryModule },
+    ];
+    return new MinifyFile(
+      entryFileName,
+      this.entryModule,
+      entryAst,
+      this,
+      this.mode,
+    ).printGeneratedStatements(statements);
   }
 }

--- a/test/annotations.test.ts
+++ b/test/annotations.test.ts
@@ -9,11 +9,11 @@ test("annotations protect declarations and preserved comments stay near their st
     fixture: "annotations",
     mode: { moduleLikeLua: false, mergeLocals: false, globalAlias: false },
   });
-  assert.match(code, /--# file header\nfunction onTick/);
-  assert.match(code, /local descriptive=2/);
+  assert.match(code, /--# file header\nfunction\nonTick/);
+  assert.match(code, /local\ndescriptive=2/);
   assert.doesNotMatch(code, /retained/);
   assert.match(code, /--# before call\nprint\([a-zA-Z_]\)/);
-  assert.match(code, /print\([a-zA-Z_]\) --# after call/);
+  assert.match(code, /print\([a-zA-Z_]\)\n--# after call/);
   assert.doesNotThrow(() => Parser.parse(code, { luaVersion: "5.3" }));
   assert.doesNotMatch(code, /unused/);
 });
@@ -29,7 +29,7 @@ test("annotation and configured global-name protection are combined", () => {
       neverRenameGlobals: new Set(["configuredGlobal"]),
     },
   });
-  assert.match(code, /function onTick/);
+  assert.match(code, /function\nonTick/);
   assert.match(code, /configuredGlobal=4/);
 });
 
@@ -65,7 +65,7 @@ test("removeUnused false preserves otherwise removable locals", () => {
       globalAlias: false,
     },
   });
-  assert.match(code, /local [a-zA-Z_]=3/);
+  assert.match(code, /local\n[a-zA-Z_]=3/);
 });
 
 test("disabling future global removal does not disable local removal", () => {

--- a/test/layout.test.ts
+++ b/test/layout.test.ts
@@ -1,0 +1,42 @@
+import { test } from "vitest";
+import assert from "node:assert/strict";
+import Parser from "luaparse";
+import { runMinifier } from "./lib/helpers";
+
+test("必須空白は既定でLFになり、半角スペースへ切り替えても出力サイズは変わらない", () => {
+  const lineFeed = runMinifier({
+    label: "required whitespace LF",
+    fixture: "single-file",
+    mode: { moduleLikeLua: false },
+  }).code;
+  const space = runMinifier({
+    label: "required whitespace space",
+    fixture: "single-file",
+    mode: { moduleLikeLua: false, requiredWhitespace: " " },
+  }).code;
+
+  assert.match(lineFeed, /local\nfunction/);
+  assert.match(space, /local function/);
+  assert.equal(Buffer.byteLength(lineFeed), Buffer.byteLength(space));
+  assert.doesNotThrow(() => Parser.parse(lineFeed, { luaVersion: "5.3" }));
+  assert.doesNotThrow(() => Parser.parse(space, { luaVersion: "5.3" }));
+});
+
+test("AST化したrequireラッパーにも同じ必須空白ポリシーを適用する", () => {
+  const lineFeed = runMinifier({
+    label: "require wrapper LF",
+    fixture: "require-call",
+    mode: { moduleLikeLua: true },
+  }).code;
+  const space = runMinifier({
+    label: "require wrapper space",
+    fixture: "require-call",
+    mode: { moduleLikeLua: true, requiredWhitespace: " " },
+  }).code;
+
+  assert.match(lineFeed, /^function\nrequire\(m,r\)/);
+  assert.match(space, /^function require\(m,r\)/);
+  assert.equal(Buffer.byteLength(lineFeed), Buffer.byteLength(space));
+  assert.doesNotThrow(() => Parser.parse(lineFeed, { luaVersion: "5.3" }));
+  assert.doesNotThrow(() => Parser.parse(space, { luaVersion: "5.3" }));
+});

--- a/test/no-rename.test.ts
+++ b/test/no-rename.test.ts
@@ -12,8 +12,8 @@ test("mode.rename = false disables identifier shortening", () => {
     mode: { moduleLikeLua: false, rename: false },
   });
 
-  assert.match(code, /local function add\(first,second\)/);
-  assert.match(code, /local total=0/);
-  assert.match(code, /for index=1,10 do total=add\(total,index\)end/);
+  assert.match(code, /local\nfunction\nadd\(first,second\)/);
+  assert.match(code, /local\ntotal=0/);
+  assert.match(code, /for\nindex=1,10\ndo\ntotal=add\(total,index\)end/);
   assert.match(code, /print\(total,i\)/);
 });

--- a/test/precedence.test.ts
+++ b/test/precedence.test.ts
@@ -57,16 +57,16 @@ test("ビット演算子・整数除算の優先順序が壊れない (#27)", ()
 // オペランドとして現れるときは丸括弧が要る。括弧が落ちると`0.5 % (2 .. 16)`が
 // `0.5%2 ..16`になり、値が0.5から"0.516"へエラーにならないまま変わる。
 test("連結を含む式が優先順位の高い演算子のオペランドになるとき括弧が保たれる (#52)", () => {
-  assert.match(minifyExpression("0.5 % (2 .. 16)"), /0\.5%\(2 ?\.\.16\)/);
-  assert.match(minifyExpression("(1 .. 2) + 3"), /\(1 ?\.\.2\)\+3/);
-  assert.match(minifyExpression("-(1 .. 2)"), /-\(1 ?\.\.2\)/);
-  assert.match(minifyExpression("#(1 .. 2)"), /#\(1 ?\.\.2\)/);
+  assert.match(minifyExpression("0.5 % (2 .. 16)"), /0\.5%\(2[ \n]\.\.16\)/);
+  assert.match(minifyExpression("(1 .. 2) + 3"), /\(1[ \n]\.\.2\)\+3/);
+  assert.match(minifyExpression("-(1 .. 2)"), /-\(1[ \n]\.\.2\)/);
+  assert.match(minifyExpression("#(1 .. 2)"), /#\(1[ \n]\.\.2\)/);
 
   // `..`のほうが優先順位の高い相手では、括弧が無いのが正しい。
-  assert.match(minifyExpression("(1 .. 2) < 3"), /1 ?\.\.2<3/);
-  assert.match(minifyExpression("(1 + 2) .. 3"), /1\+2 ?\.\.3/);
+  assert.match(minifyExpression("(1 .. 2) < 3"), /1[ \n]\.\.2<3/);
+  assert.match(minifyExpression("(1 + 2) .. 3"), /1\+2[ \n]\.\.3/);
   // `..`は右結合なので、右側の括弧は落としてよい。
-  assert.match(minifyExpression("1 .. (2 .. 3)"), /1 ?\.\.2 ?\.\.3/);
+  assert.match(minifyExpression("1 .. (2 .. 3)"), /1[ \n]\.\.2[ \n]\.\.3/);
 });
 
 // #52と同じ原因（結合則の決定が丸括弧の判定を素通りしていた）で、右結合の`^`でも

--- a/test/removeUnused.integration.test.ts
+++ b/test/removeUnused.integration.test.ts
@@ -13,9 +13,9 @@ test("stage 4 composes with require splicing, comments, rename, and local mergin
 
   assert.doesNotThrow(() => Parser.parse(code, { luaVersion: "5.3" }));
   assert.match(code, /--# before effects\ndependencyEffect\(\)/);
-  assert.match(code, /sideEffect\(\) --# after effects/);
+  assert.match(code, /sideEffect\(\)\n--# after effects/);
   assert.doesNotMatch(code, /removableName|removable/);
-  assert.match(code, /local [a-zA-Z_]=produce\(\)/);
+  assert.match(code, /local\n[a-zA-Z_]=produce\(\)/);
 
   const generatedIndex = code.indexOf("sideEffect");
   assert.notEqual(generatedIndex, -1);
@@ -28,7 +28,7 @@ test("stage 4 composes with require splicing, comments, rename, and local mergin
     assert.equal(original.line, 2);
     assert.equal(original.name, "sideEffect");
 
-    const retainedIndex = code.indexOf("local ") + "local ".length;
+    const retainedIndex = code.indexOf("=produce") - 1;
     const retained = consumer.originalPositionFor({
       line: code.slice(0, retainedIndex).split("\n").length,
       column: retainedIndex - (code.lastIndexOf("\n", retainedIndex) + 1),
@@ -53,8 +53,8 @@ test("removeUnused false disables all stage 4 transformations", () => {
   });
   assert.match(
     code,
-    /local unusedModule,unusedResult=require\("dep"\),sideEffect\(\)/,
+    /local\nunusedModule,unusedResult=require\("dep"\),sideEffect\(\)/,
   );
-  assert.match(code, /local removableName=1/);
-  assert.match(code, /local retained,removable=produce\(\),2/);
+  assert.match(code, /local\nremovableName=1/);
+  assert.match(code, /local\nretained,removable=produce\(\),2/);
 });

--- a/test/snapshots/bitwise-precedence.sl.lua
+++ b/test/snapshots/bitwise-precedence.sl.lua
@@ -1,2 +1,3 @@
-local a,b,c,d=print,1,2,3
+local
+a,b,c,d=print,1,2,3
 a(b|c&d)a((b|c)&d)a(b&c|d)a(b~c&d)a(b<<c+d)a((b<<c)+d)a(b//c//d)a(~b&c)

--- a/test/snapshots/const-fold.sl.lua
+++ b/test/snapshots/const-fold.sl.lua
@@ -1,5 +1,9 @@
-local a=print
-a(3,3,3.0,"Hello, world!")a(200)a(1,1,1)local c=1+sideEffect()a(c)local b=5
+local
+a=print
+a(3,3,3.0,"Hello, world!")a(200)a(1,1,1)local
+c=1+sideEffect()a(c)local
+b=5
 b=b+1
-a(b)local d=42
+a(b)local
+d=42
 a(d)a(("ab"):upper())a(-5)a(4,true)

--- a/test/snapshots/entry-scope-many-requires.m.lua
+++ b/test/snapshots/entry-scope-many-requires.m.lua
@@ -1,14 +1,58 @@
-function require(m,r)package=package or{loaded={}};if package.loaded[m]then return package.loaded[m]end
-if m=="dep_alpha"then r=(function() local a="dep_alpha"return{id=a} end)()end
-if m=="dep_bravo"then r=(function() local b="dep_bravo"return{id=b} end)()end
-if m=="dep_charlie"then r=(function() local c="dep_charlie"return{id=c} end)()end
-if m=="dep_delta"then r=(function() local d="dep_delta"return{id=d} end)()end
-if m=="dep_echo"then r=(function() local e="dep_echo"return{id=e} end)()end
-if m=="dep_foxtrot"then r=(function() local f="dep_foxtrot"return{id=f} end)()end
-if m=="dep_golf"then r=(function() local g="dep_golf"return{id=g} end)()end
-if m=="dep_hotel"then r=(function() local h="dep_hotel"return{id=h} end)()end
-if m=="dep_india"then r=(function() local i="dep_india"return{id=i} end)()end
-if m=="dep_juliet"then r=(function() local j="dep_juliet"return{id=j} end)()end
-if m=="dep_kilo"then r=(function() local k="dep_kilo"return{id=k} end)()end
-package.loaded[m]=package.loaded[m]or r or true;return package.loaded[m]end
-local l,m,n,o,p,q,r,s,t,u,v=require("dep_alpha"),require("dep_bravo"),require("dep_charlie"),require("dep_delta"),require("dep_echo"),require("dep_foxtrot"),require("dep_golf"),require("dep_hotel"),require("dep_india"),require("dep_juliet"),require("dep_kilo")print(l,m,n,o,p,q,r,s,t,u,v)
+function
+require(m,r)package=package
+or{loaded={}}if
+package.loaded[m]then
+return
+package.loaded[m]end
+if
+m=="dep_alpha"then
+r=(function()local
+a="dep_alpha"return{id=a}end)()end
+if
+m=="dep_bravo"then
+r=(function()local
+b="dep_bravo"return{id=b}end)()end
+if
+m=="dep_charlie"then
+r=(function()local
+c="dep_charlie"return{id=c}end)()end
+if
+m=="dep_delta"then
+r=(function()local
+d="dep_delta"return{id=d}end)()end
+if
+m=="dep_echo"then
+r=(function()local
+e="dep_echo"return{id=e}end)()end
+if
+m=="dep_foxtrot"then
+r=(function()local
+f="dep_foxtrot"return{id=f}end)()end
+if
+m=="dep_golf"then
+r=(function()local
+g="dep_golf"return{id=g}end)()end
+if
+m=="dep_hotel"then
+r=(function()local
+h="dep_hotel"return{id=h}end)()end
+if
+m=="dep_india"then
+r=(function()local
+i="dep_india"return{id=i}end)()end
+if
+m=="dep_juliet"then
+r=(function()local
+j="dep_juliet"return{id=j}end)()end
+if
+m=="dep_kilo"then
+r=(function()local
+k="dep_kilo"return{id=k}end)()end
+package.loaded[m]=package.loaded[m]or
+r
+or
+true
+return
+package.loaded[m]end
+local
+l,m,n,o,p,q,r,s,t,u,v=require("dep_alpha"),require("dep_bravo"),require("dep_charlie"),require("dep_delta"),require("dep_echo"),require("dep_foxtrot"),require("dep_golf"),require("dep_hotel"),require("dep_india"),require("dep_juliet"),require("dep_kilo")print(l,m,n,o,p,q,r,s,t,u,v)

--- a/test/snapshots/global-alias.sl.lua
+++ b/test/snapshots/global-alias.sl.lua
@@ -1,2 +1,3 @@
-local a=screen
+local
+a=screen
 a.setColor(255,0,0)a.drawText(0,0,"hello")a.drawText(1,1,"world")a.drawText(2,2,"again")a.setColor(0,255,0)

--- a/test/snapshots/merge-locals.m.lua
+++ b/test/snapshots/merge-locals.m.lua
@@ -1,8 +1,27 @@
-function require(m,r)package=package or{loaded={}};if package.loaded[m]then return package.loaded[m]end
-if m=="dep1"then r=(function() return{id="dep1"} end)()end
-if m=="dep2"then r=(function() return{id="dep2"} end)()end
-if m=="dep3"then r=(function() return{id="dep3"} end)()end
-package.loaded[m]=package.loaded[m]or r or true;return package.loaded[m]end
-local a,b,c=require("dep1"),require("dep2"),require("dep3")print(a,b,c)local d=1
-local e=d+1
+function
+require(m,r)package=package
+or{loaded={}}if
+package.loaded[m]then
+return
+package.loaded[m]end
+if
+m=="dep1"then
+r=(function()return{id="dep1"}end)()end
+if
+m=="dep2"then
+r=(function()return{id="dep2"}end)()end
+if
+m=="dep3"then
+r=(function()return{id="dep3"}end)()end
+package.loaded[m]=package.loaded[m]or
+r
+or
+true
+return
+package.loaded[m]end
+local
+a,b,c=require("dep1"),require("dep2"),require("dep3")print(a,b,c)local
+d=1
+local
+e=d+1
 print(e)

--- a/test/snapshots/merge-locals.sl.lua
+++ b/test/snapshots/merge-locals.sl.lua
@@ -1,3 +1,8 @@
-local a={id="dep1"}local b={id="dep2"}local c={id="dep3"}print(a,b,c)local d=1
-local e=d+1
+local
+a={id="dep1"}local
+b={id="dep2"}local
+c={id="dep3"}print(a,b,c)local
+d=1
+local
+e=d+1
 print(e)

--- a/test/snapshots/multi-require.m.lua
+++ b/test/snapshots/multi-require.m.lua
@@ -1,4 +1,17 @@
-function require(m,r)package=package or{loaded={}};if package.loaded[m]then return package.loaded[m]end
-if m=="common"then r=(function() return{value=42} end)()end
-package.loaded[m]=package.loaded[m]or r or true;return package.loaded[m]end
-local a,b=require("common"),require("common")print(a.value,b.value)
+function
+require(m,r)package=package
+or{loaded={}}if
+package.loaded[m]then
+return
+package.loaded[m]end
+if
+m=="common"then
+r=(function()return{value=42}end)()end
+package.loaded[m]=package.loaded[m]or
+r
+or
+true
+return
+package.loaded[m]end
+local
+a,b=require("common"),require("common")print(a.value,b.value)

--- a/test/snapshots/multi-require.sl.lua
+++ b/test/snapshots/multi-require.sl.lua
@@ -1,1 +1,3 @@
-local a={value=42}local b={value=42}print(a.value,b.value)
+local
+a={value=42}local
+b={value=42}print(a.value,b.value)

--- a/test/snapshots/nested-module.m.lua
+++ b/test/snapshots/nested-module.m.lua
@@ -1,4 +1,17 @@
-function require(m,r)package=package or{loaded={}};if package.loaded[m]then return package.loaded[m]end
-if m=="sub.deep"then r=(function() return{value=1} end)()end
-package.loaded[m]=package.loaded[m]or r or true;return package.loaded[m]end
-local a=require("sub.deep")print(a.value)
+function
+require(m,r)package=package
+or{loaded={}}if
+package.loaded[m]then
+return
+package.loaded[m]end
+if
+m=="sub.deep"then
+r=(function()return{value=1}end)()end
+package.loaded[m]=package.loaded[m]or
+r
+or
+true
+return
+package.loaded[m]end
+local
+a=require("sub.deep")print(a.value)

--- a/test/snapshots/require-call.m.lua
+++ b/test/snapshots/require-call.m.lua
@@ -1,5 +1,20 @@
-function require(m,r)package=package or{loaded={}};if package.loaded[m]then return package.loaded[m]end
-if m=="mod"then r=(function() local function a()return"hello"end
-return{hello=a} end)()end
-package.loaded[m]=package.loaded[m]or r or true;return package.loaded[m]end
-local b=require("mod")print(b.hello())
+function
+require(m,r)package=package
+or{loaded={}}if
+package.loaded[m]then
+return
+package.loaded[m]end
+if
+m=="mod"then
+r=(function()local
+function
+a()return"hello"end
+return{hello=a}end)()end
+package.loaded[m]=package.loaded[m]or
+r
+or
+true
+return
+package.loaded[m]end
+local
+b=require("mod")print(b.hello())

--- a/test/snapshots/require-call.sl.lua
+++ b/test/snapshots/require-call.sl.lua
@@ -1,1 +1,5 @@
-local function a()return"hello"end local b={hello=a}print(b.hello())
+local
+function
+a()return"hello"end
+local
+b={hello=a}print(b.hello())

--- a/test/snapshots/require-in-expression.sl.lua
+++ b/test/snapshots/require-in-expression.sl.lua
@@ -1,1 +1,1 @@
-print((function() return{hello=function()return"hello"end} end)().hello())
+print((function()return{hello=function()return"hello"end}end)().hello())

--- a/test/snapshots/require-string-call.m.lua
+++ b/test/snapshots/require-string-call.m.lua
@@ -1,5 +1,20 @@
-function require(m,r)package=package or{loaded={}};if package.loaded[m]then return package.loaded[m]end
-if m=="mod"then r=(function() local function a()return"hello"end
-return{hello=a} end)()end
-package.loaded[m]=package.loaded[m]or r or true;return package.loaded[m]end
-local b=require"mod"print(b.hello())
+function
+require(m,r)package=package
+or{loaded={}}if
+package.loaded[m]then
+return
+package.loaded[m]end
+if
+m=="mod"then
+r=(function()local
+function
+a()return"hello"end
+return{hello=a}end)()end
+package.loaded[m]=package.loaded[m]or
+r
+or
+true
+return
+package.loaded[m]end
+local
+b=require"mod"print(b.hello())

--- a/test/snapshots/single-file.sl.lua
+++ b/test/snapshots/single-file.sl.lua
@@ -1,6 +1,19 @@
-local function d(b,e)return b+e end
-local c=0
-for b=1,10 do c=d(c,b)end
-local a=0
-while a<3 do a=a+1 end
+local
+function
+d(b,e)return
+b+e
+end
+local
+c=0
+for
+b=1,10
+do
+c=d(c,b)end
+local
+a=0
+while
+a<3
+do
+a=a+1
+end
 print(c,a)


### PR DESCRIPTION
## 概要

Stormworksの行単位エラーを追いやすくするため、字句の結合防止に必要な1バイトの空白を、既定で半角スペースからLFへ変更します。区切りが不要だった箇所には新しいLFを挿入せず、短縮サイズは増やしません。

あわせて、固定文字列だったrequireラッパーを合成ASTへ移し、通常コードと同じprinter・空白方針を通すようにしました。

## 変更内容

- `MinifierMode.requiredWhitespace` を追加
  - 省略時はLF
  - `" "` を指定すると半角スペースへ切り替え可能
- requireラッパーの固定部分を標準Lua ASTとして構築
- モジュール本体の挿入位置を内部ノード `ModuleSplice` で表現
  - 生成済み文字列や `SourceNode` は保持しない
  - 将来はコード生成前に通常ASTへ実体化できる
- ラッパーとエントリモジュールも一つの合成文リストとして出力
- 保存コメント、IIFE、`local`、`function`、`goto` などの必須空白を共通方針へ統合
- 新しい既定出力に合わせてスナップショットと空白依存テストを更新

## 不変条件

- LFと半角スペースはいずれもUTF-8で1バイトであり、切り替えても生成サイズは同じ
- 区切り文字が不要な箇所には文字を追加しない
- 合成requireラッパーには入力ソースの位置情報を付けない
- `ModuleSplice`で展開するモジュール本体は既存のSource Map情報を維持する

## 検証

- `pnpm test`: 192 tests passed
- `pnpm run lint`: passed
- `pnpm run format:check`: passed

Closes #57