### PR TITLE
Implement effect-aware non-adjacent compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Luaコード内で完結し、意味論を変更しない最適化は既定で�
 
 対象は、算術・比較・連結・論理演算（`and`／`or`／`not`）・ビット演算・長さ演算子（`#`）です。畳み込んでもプログラムの意味は変わりません。整数と浮動小数点数の区別も保たれ、`3/1`は`3`ではなく`3.0`になります（Luaの`/`は常に浮動小数点数を返すため）。
 
-定数として扱う文字列は、エスケープを含まない印字可能ASCIIのリテラルに限っています。この形なら1文字が1バイトに対応するので、連結・比較・長さのいずれもLuaでの結果と一致します。エスケープや長括弧（`[[...]]`）を含む文字列は、この保証が崩れるため対象外です。
+文字列はLua 5.3のquoted escape、decimal／hex byte、`\z`、改行escape、Unicode escape、長括弧を共有byte decoderで復元します。連結、比較、`#`はJavaScriptの文字数ではなくLua byte列に対して評価し、生成literalは再decode可能な表記へ戻します。不正または判定不能なliteralは畳み込みません。
 
 次の式は畳み込みません。いずれも、畳み込むとプログラムの意味が変わるためです。
 
@@ -113,7 +113,12 @@ Luaコード内で完結し、意味論を変更しない最適化は既定で�
 pnpm ci
 pnpm run build
 pnpm test
+pnpm run verify:lua-budget       # Windowsのluac53で49/50/51境界を確認
+pnpm run verify:effect-semantics # Windowsのlua53で変換前後を差分実行
+pnpm run report:optimizer        # 候補・拒否理由・最終byte比較をJSON出力
 ```
+
+ライブラリAPIで`collectOptimizationDiagnostics: true`を指定すると、`Minifier.optimizationDiagnostics`からruntime／module／pass別の候補採否を取得できます。既定はoffで、on/offによって生成コードとSource Mapは変化しません。`selectTransactionalMinifierVariant`はbaselineとtrialを別Minifierへ隔離し、最終Rename／Print後に厳密に短いartifactだけを選択する高度な調査・planner統合用APIです。
 
 # Lint / Format
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,27 @@ npx storm-lua-minify script.lua
 
 - `-m`オプションを付加すると、モジュールの挙動をLuaの実際の挙動に近づけます
 
+## 実行環境と効果解析最適化
+
+CLIはStormworks向けツールとして、`--runtime-profile stormworks`を既定にします。このprofileでは、非連続な`local`宣言やfresh tableの安定したreadを効果解析でまとめる、意味保存の最適化が既定で有効です。ライブラリAPIで`runtimeProfile`を省略した場合だけは、既存利用との互換性のため`lua53`として扱います。
+
+| 実行環境          | 効果解析最適化の既定 | 変更方法                                                                 |
+| ----------------- | -------------------- | ------------------------------------------------------------------------ |
+| CLI / Stormworks  | 有効                 | 個別の`--no-*`、または`--no-effect-aware-transforms`で無効化             |
+| CLI / Lua 5.3     | 無効                 | `--runtime-profile lua53 --allow-local-lifetime-changes`で明示的に有効化 |
+| API / profile省略 | 無効                 | `runtimeProfile: "stormworks"`、またはLua用opt-inを指定                  |
+
+純Luaでは`debug.getlocal`やdebug hookから`local`の生存期間を観測できるため、通常の計算結果が同じでも宣言位置の変更が観測され得ます。この差を許可する`--allow-local-lifetime-changes`はopt-inです。未知のcall、alias、escape、動的table key、変更可能なmetatableを安全だと仮定する最適化は、このオプションでは有効になりません。
+
+- `--runtime-profile <stormworks|lua53>`: 効果解析が前提とする実行環境を選びます。CLI既定は`stormworks`です
+- `--no-effect-aware-transforms`: 効果解析による最適化をすべて無効にします
+- `--no-effect-aware-local-hoist`: 非連続`local`宣言のまとめ上げだけを無効にします
+- `--no-effect-aware-table-reads`: fresh・nonescape tableの安定したreadのまとめ上げだけを無効にします
+- `--no-field-sensitive-table-effects`: tableの変更追跡をstatic key単位からtable全体へ戻します
+- `--allow-local-lifetime-changes`: Lua 5.3 profileで、debug APIから観測可能な`local`生存期間の変更を許可します
+
+`-m` / `--module-like-lua`は`require`・`dofile`の出力方式を選ぶオプションであり、runtime profileとは独立です。また、現時点では未知の副作用を無視するような意味変更オプションは実装していません。将来追加する場合も、上記の意味保存オプションとは分けてopt-inにします。
+
 # Source Map
 
 このツールは、ミニファイ後のコードと合わせて [Source Map](https://tc39.es/source-map/) (`.lua.map`) を出力します。

--- a/docs/issue-47-effect-analysis.md
+++ b/docs/issue-47-effect-analysis.md
@@ -92,9 +92,9 @@ table は fresh・nonescape を table 全体で dirty 管理し、次に static 
 
 非連続 local は Rename と同じ予約名・module 順で provisional name を割り当て、その名前長を追加代入の上界に使う。変換で候補 Symbol の参照重みだけが増える限り、最終 Rename は旧割当を維持する案より悪くならない。一方、既存の連続 local merge と競合すると比較基準自体が変わるため、#42 で統合 planner を作るまでは、前後に local が隣接しない宣言だけを #47 の候補にする。
 
-table read merge は `local` と `=` の重複が消える固定構文差を使う。runtime semantics と compiler resource policy は別の capability とし、planner は中央の判定結果だけを参照する。一文の arity は既定で50以下へ分割し、Lua compilerのlocal／register上限に保守的な余裕を残す。この値は正確なregister推定とは称さず、`conservative-policy`としてfail-closedに扱う。
+table read merge は `local` と `=` の重複が消える固定構文差を使う。runtime semantics と compiler resource policy は別の capability とし、planner は中央の判定結果だけを参照する。字句block／functionごとのactive local数を文位置で数え、local上限、register上限、保守policyの最小headroomからarityを導出する。Windowsの`luac53`では、既存150 localsに対する49／50受理と51拒否を`pnpm run verify:lua-budget`で再現する。Stormworks compilerの詳細を導出できない場合は、このLua 5.3上限以下へfail-closedにfallbackする。
 
-#47 の二変換は、Symbol数・scope・利用可能な短縮名集合を変えない範囲で局所的なサイズ上界を証明している。最終 Rename／Print を試行するtransactionは、この証明が成立しない将来の競合planner向けであり、現行#47の正しさやサイズ非増加を補う残作業ではない。組合せテストで有効時の増加反例が出た場合だけ、この切り分けを撤回する。
+#47 の二変換は、Symbol数・scope・利用可能な短縮名集合を変えない範囲で局所的なサイズ上界を証明している。加えて、baselineとtrialを別Minifierへ隔離し、全moduleを同じRename／Print条件で比較するtransaction基盤を実装した。厳密に短いtrialだけを選び、同長、増加、trial失敗ではbaselineのAST、Resolve、SourceMetadata、annotation、rename cacheへ触れない。現行#47の局所証明を必須transactionへ置き換えず、将来の競合plannerが利用する。
 
 ## Source Map
 
@@ -132,10 +132,11 @@ table read merge は `local` と `=` の重複が消える固定構文差を使�
 - 共通 AST walker と、Symbol 単位の declaration／read／write facts
 - fresh table allocation、static key、dirty、alias／call／return／store／capture escape の解析
 - certified linear region、allocation identity、直線regionのreaching-definition／alias facts
-- Lua 5.3 lexical ruleに従う共有byte string decoder
-- runtime semanticsとcompiler resource policyを分離したcapability判定
-- `changed`／`invalidatesResolve`とResolve世代を集中管理するpass orchestrator
-- 候補の採否理由・件数・推定削減量を、出力非影響で収集するoptimizer diagnostics
+- Lua 5.3 lexical ruleに従い、table effectとconstant foldが共用するbyte string decoder／encoder
+- active localとregister headroomを含むruntime resource判定、実`luac53`境界harness
+- `changed`／`invalidatesResolve`とResolve世代を集中管理し、#44、remove-unused、global alias、#47、#9を通すpass orchestrator
+- runtime／module／pass別の候補採否理由・件数・推定削減量と、再現可能なfixture report
+- 最終Rename／Print済みartifactを隔離比較するtransactional variant selector
 - RHS を元位置に残す、孤立した非連続 local 宣言の hoist
 - fresh・nonescape tableの安定したstatic-key readを一つのlocal文へまとめる変換
 - table全体／static-key単位dirtyの個別切替、master／変換別opt-out
@@ -170,7 +171,7 @@ Lua 5.3 safe ケースは可能な範囲で実行結果を差分検証する。S
 
 ## 独立した後続 Issue
 
-この節は、#47の実装結果を前提にした独立拡張だけを残す。#47候補の採否理由はdiagnosticsで測定できるため、仮説だけで対象を増やさない。再代入、同一unitのlocal alias、byte string decoder、resource policy、pass invalidation、候補計測は#47へ吸収済みであり、後続Issueには残さない。
+この節は、#47の実装結果を前提にした独立拡張だけを残す。#47候補の採否理由はdiagnosticsで測定でき、基準値は[optimizer計測レポート](./issue-47-optimizer-report.md)に残す。再代入、同一unitのlocal alias、byte string decoder、resource導出、pass invalidation、候補計測、最終出力transaction基盤は#47へ吸収済みであり、後続Issueには残さない。
 
 ### #63 branch／loop／goto を扱う CFG
 
@@ -179,12 +180,12 @@ Lua 5.3 safe ケースは可能な範囲で実行結果を差分検証する。S
 - **必要な基盤:** Lua の goto／local scope 制約を表す CFG、dominance、block 単位の effect summary、解析不能 edge の保守的表現。
 - **完了条件案:** if、各 loop、break、return、label／goto の代表反例で評価順と scope legality を保存する。未到達、irreducible、解析不能な flow は変換しない。
 
-### #65 Rename／Print 後の transactional cost 判定
+### #65 競合plannerへのtransactional cost接続
 
-- **問題と保留理由:** #47の現行変換には局所的な非増加証明がある。今後、scope／slot集合を変える候補や複数plannerの競合を選ぶ場合は、その証明を一般化できず、Rename／Print後の全体byte差が必要になる。
+- **問題と保留理由:** 隔離variantの最終出力比較は#47で実装済み。今後、scope／slot集合を変える候補や複数plannerの競合を候補単位で列挙する場合、そのplannerからvariant selectorへ接続する必要がある。
 - **起票トリガー:** 多数 Symbol、複数 module、予約名衝突を含む差分テストで、有効時の出力が無効時より長くなる反例が得られたとき。または複数の変換パスが同じ概算ロジックを持ち始めたとき。
-- **必要な基盤:** AST／resolver／metadata を安全に複製またはロールバックする仕組み、同一 print 条件での UTF-8 byte 計測、変換ごとの採否を再現できる deterministic pipeline。
-- **完了条件案:** 候補適用前後を最終 Rename／Print と同条件で比較し、厳密に短い場合だけ commit する。Source Map と annotation の所有権も rollback で失わない。
+- **既存基盤:** `selectTransactionalMinifierVariant`が全状態を共有しないbaseline／trialを最終Rename／Printまで評価し、UTF-8 byteで選択する。
+- **完了条件案:** #42等が競合候補variantを決定論的に列挙し、selectorへ渡す。候補の組合せ爆発を制御し、現行の局所証明済み#47候補を退行させない。
 
 ### #67 debug／introspection 保存モード
 

--- a/docs/issue-47-effect-analysis.md
+++ b/docs/issue-47-effect-analysis.md
@@ -91,7 +91,11 @@ table は fresh・nonescape を table 全体で dirty 管理し、次に static 
 
 ## コスト
 
-printer と共有できる syntax byte cost API を用意し、保守的な上下界で変換後が厳密に短いと判断できる場合だけ適用する。判定不能なら拒否する。概算定数を各変換へ散在させない。統合テストでは変換有効時の UTF-8 byte length が無効時より長くならないことを確認する。
+適用する各変換は、出力構文の byte 差を保守的に計算し、厳密に短いと判断できる場合だけ適用する。判定不能なら拒否する。統合テストでは変換有効時の UTF-8 byte length が無効時より長くならないことを確認する。
+
+非連続 local は Rename と同じ予約名・module 順で provisional name を割り当て、その名前長を追加代入の上界に使う。変換で候補 Symbol の参照重みだけが増える限り、最終 Rename は旧割当を維持する案より悪くならない。一方、既存の連続 local merge と競合すると比較基準自体が変わるため、#42 で統合 planner を作るまでは、前後に local が隣接しない宣言だけを #47 の候補にする。
+
+table read merge は `local` と `=` の重複が消える固定構文差を使う。ただし一文の arity は 50 以下へ分割し、Lua compiler の local／register 上限に保守的な余裕を残す。正確な register pressure と Rename／Print 後の transactional cost は、実測トリガーを満たした場合の後続 Issue 候補とする。
 
 ## Source Map
 
@@ -121,6 +125,21 @@ printer と共有できる syntax byte cost API を用意し、保守的な上�
 11. fixture、差分実行、Source Map、roundtrip、出力長、CLI/API 文書、全 CI 検証。
 
 段階 10 は unsafe 機能を必ず作るという意味ではない。意味変更で初めて得られる有効な候補を計測し、導入するなら safe と別オプション・別コミットにする境界である。
+
+## 実装到達点
+
+#47 では次を実装した。
+
+- 共通 AST walker と、Symbol 単位の declaration／read／write facts
+- fresh table allocation、static key、dirty、alias／call／return／store／capture escape の解析
+- RHS を元位置に残す、孤立した非連続 local 宣言の hoist
+- fresh・nonescape tableの安定したstatic-key readを一つのlocal文へまとめる変換
+- table全体／static-key単位dirtyの個別切替、master／変換別opt-out
+- CLIのStormworks既定、APIのLua 5.3互換既定、純Lua lifetime変更の個別opt-in
+- 構造変更後の再Resolve、合成Identifierのprovenance、table統合を含むSource Mapテスト
+- moduleLikeLuaの両方式、複数module、#44、remove-unused、global alias、既存local mergeとの組合せテスト
+
+未知のcallやaliasが変更しないと仮定するsemantic-changing transformは、実測上の必要性を確認できなかったため追加していない。意味変更を許可する包括的な`aggressive`オプションも設けていない。純Luaの`allowLocalLifetimeChanges`はdebug APIからのlocal lifetime観測差だけを許可し、heap効果やmetatableの仮定を緩めない。
 
 ## テスト行列
 

--- a/docs/issue-47-effect-analysis.md
+++ b/docs/issue-47-effect-analysis.md
@@ -142,6 +142,66 @@ Lua 5.3 safe ケースは可能な範囲で実行結果を差分検証する。S
 
 安全な候補の大半がこれらだけで拒否され、推定削減量が実装・保守コストを上回ると実コーパスで確認できた場合に再検討する。
 
+## 後続 Issue 候補
+
+この節は、#47 の完了を妨げない将来課題を、後から独立 Issue に切り出すための設計メモである。ここへ記載しただけでは実装を約束しない。起票トリガーを満たす証拠が得られたとき、対象コーパス、期待削減量、意味論上の境界を添えて Issue 化する。
+
+### 再代入を扱う flow-sensitive points-to
+
+- **問題と保留理由:** 現在は fresh table を保持する Symbol に一度でも write があれば、その Symbol の table read merge をすべて拒否する。元の allocation と現在値を文ごとに対応付ける points-to／CFG がない状態で、「再代入より前だけ安全」などの部分判定を加えると誤認しやすいためである。
+- **起票トリガー:** 実コーパスで、この保守的拒否が安全候補の主要な取りこぼしになり、見込める byte 削減量を具体例と計測値で示せたとき。
+- **必要な基盤:** 文位置を持つ binding write、allocation identity、直線 region 内の reaching-definition。branch を越えるなら後述の CFG も必要になる。
+- **完了条件案:** 再代入前後で allocation を区別し、元 table、別 fresh table、外部値、`setmetatable` を含む反例を安全に分類する。解析不能な join は拒否し、既存の全 Symbol 拒否より出力を悪化させない。
+
+### register pressure に基づく merge 上限
+
+- **問題と保留理由:** 現在は一つの local 文へまとめる arity を 50 に制限する。Lua 5.3 の local 上限 200 と register 上限 255 に対して余裕を残す固定値であり、関数内の既存 local、RHS 一時 register、コンパイラ実装差までは数えていない。
+- **起票トリガー:** 50 分割が目立つ出力増を生む、または対象 Lua／Stormworks コンパイラで 50 未満でも register overflow を再現したとき。
+- **必要な基盤:** 対象コンパイラごとの制限を明記した runtime capability、関数単位の local／式一時値の保守的上界、コンパイル可能性を検証する fixture。
+- **完了条件案:** 対象 runtime ごとに安全な arity を導出し、限界直前と限界超過を自動検証する。導出不能時は現在の固定上限以下へフォールバックする。
+
+### branch／loop／goto を扱う CFG
+
+- **問題と保留理由:** #47 は同じ `Statement[]` の直線 region に限定し、分岐、loop、label、goto を barrier とする。一般的な code motion には支配関係、到達定義、loop 効果の固定点が必要で、局所的な条件追加では安全性を維持しにくい。
+- **起票トリガー:** barrier 越しの候補が実コーパスの削減機会を支配し、直線 region の改善では回収できないと測定されたとき。
+- **必要な基盤:** Lua の goto／local scope 制約を表す CFG、dominance、block 単位の effect summary、解析不能 edge の保守的表現。
+- **完了条件案:** if、各 loop、break、return、label／goto の代表反例で評価順と scope legality を保存する。未到達、irreducible、解析不能な flow は変換しない。
+
+### 限定 alias 解析
+
+- **問題と保留理由:** fresh table を別 local、call、return、外部 table へ渡すと escape とし、以後を拒否する。汎用 points-to は複雑だが、単純な一対一 local alias には安全に追跡できる余地がある。
+- **起票トリガー:** `local alias = table` のような限定形が主要な取りこぼしとなり、alias を追跡しても候補当たりの解析費用が妥当だと確認できたとき。
+- **必要な基盤:** allocation identity、alias の生成・kill、capture／call／store での escape propagation、再代入を扱う reaching-definition。
+- **完了条件案:** 対応する local alias 集合に dirty／escape を伝播し、分岐 join、alias 再代入、nested closure、外部 call の反例は保守的に拒否する。
+
+### Rename／Print 後の transactional cost 判定
+
+- **問題と保留理由:** 現在の planner は構文上の削減量と provisional rename を用いる。変換で参照重みや名前割当順が変わる場合、Rename／Print 後の厳密な全体 byte 差を planner 単体で証明するのは難しい。
+- **起票トリガー:** 多数 Symbol、複数 module、予約名衝突を含む差分テストで、有効時の出力が無効時より長くなる反例が得られたとき。または複数の変換パスが同じ概算ロジックを持ち始めたとき。
+- **必要な基盤:** AST／resolver／metadata を安全に複製またはロールバックする仕組み、同一 print 条件での UTF-8 byte 計測、変換ごとの採否を再現できる deterministic pipeline。
+- **完了条件案:** 候補適用前後を最終 Rename／Print と同条件で比較し、厳密に短い場合だけ commit する。Source Map と annotation の所有権も rollback で失わない。
+
+### debug／introspection 保存モード
+
+- **問題と保留理由:** local 宣言 hoist は通常の実行結果を保存しても、`debug.getlocal`、hook、エラースタックから観測される local の生存期間を変える。完全保存は rename や既存 minify とも衝突し、#47 の safe 定義には含めない。
+- **起票トリガー:** debug API を使用する利用者から再現例が提示され、rename を含むどの観測を保証すべきか合意できたとき。
+- **必要な基盤:** runtime profile ごとの debug API 能力、観測対象の明文化、debug-sensitive construct の検出。
+- **完了条件案:** 保証範囲を API／CLI に明記し、保存モードでは該当変換を拒否する。保証できない観測は診断または文書で明示する。
+
+### static string key の完全な decoder
+
+- **問題と保留理由:** `.x` と単純な `['x']`／`["x"]` は同じ static key に正規化するが、escape を含む Lua string literal は動的 key として扱う。parser 表現から値を復元する decoder を局所実装すると、escape、10 進 byte、改行、長括弧文字列で不一致を起こし得る。
+- **起票トリガー:** escaped string key が実コーパスで頻出し、field-sensitive dirty の主要な取りこぼしだと測定されたとき。
+- **必要な基盤:** Lua 5.3 lexical rule に従う共有 string decoder、parser／printer roundtrip fixture、byte string と JavaScript string の境界定義。
+- **完了条件案:** 同値な全 literal 表記を同じ byte key に正規化し、不正 escape と runtime 依存表現を拒否する。decoder は constant fold 等からも再利用できる位置に置く。
+
+### pass orchestration と #42 planner の統合
+
+- **問題と保留理由:** #47 は必要箇所で Resolve をやり直しているが、各パスが invalidation と cost 判定を個別に組み立てると、#42 や後続 optimizer で順序依存が増える。#42 自体が未実装のため、先に抽象化すると要求を誤る可能性がある。
+- **起票トリガー:** #42 実装時に同じ region、effect、cost、再 Resolve 制御を再利用できることが確認される、または三つ以上の構造変更パスが同型の orchestration を持ったとき。
+- **必要な基盤:** `changed`／`invalidatesResolve` を返す pass 契約、共有 effect facts、候補単位の cost interface、パス間テスト行列。
+- **完了条件案:** #42 と #47 が同じ planner 契約を使い、Resolve の更新点が中央で決まる。個別 opt-out、Source Map、出力長不増の性質を統合後も維持する。
+
 ## 完了条件
 
 - #44 と連続 local merge だけでは生成できない、非連続文または table key を含む圧縮がある。

--- a/docs/issue-47-effect-analysis.md
+++ b/docs/issue-47-effect-analysis.md
@@ -16,17 +16,17 @@ Issue #44 の定数伝搬・畳み込みは実装済みである。Issue #42 の
 
 `moduleLikeLua` は require の出力方式であり、実行環境の意味論ではない。公開名は実装時に確定するが、次の三軸を混ぜない。
 
-| 軸                            | 役割                                         | 既定                                                                |
-| ----------------------------- | -------------------------------------------- | ------------------------------------------------------------------- |
-| runtime profile               | `stormworks` / `lua53` の能力を選ぶ          | CLI は `stormworks`。API の省略時だけ従来互換の `lua53`             |
-| safe effect transforms        | 選択環境で通常の観測可能な意味を保存する変換 | Stormworks では有効・opt-out。Lua では保守的な範囲だけ有効・opt-out |
-| semantic-changing assumptions | 未知の call や alias が変更しない等の仮定    | 無効・opt-in                                                        |
+| 軸                            | 役割                                         | 既定                                                              |
+| ----------------------------- | -------------------------------------------- | ----------------------------------------------------------------- |
+| runtime profile               | `stormworks` / `lua53` の能力を選ぶ          | CLI は `stormworks`。API の省略時だけ従来互換の `lua53`           |
+| safe effect transforms        | 選択環境で通常の観測可能な意味を保存する変換 | Stormworks では有効・opt-out。Lua では lifetime 許可を個別 opt-in |
+| semantic-changing assumptions | 未知の call や alias が変更しない等の仮定    | 無効・opt-in                                                      |
 
 Issue 本文の一律 opt-in より、今回指定された条件を優先する。Stormworks で意味が変わらない変換は opt-out、変わり得る変換は opt-in とする。純 Lua と Stormworks で安全範囲が異なる機能も単一の `aggressive` フラグへ混ぜない。
 
 safe は、結果だけでなくエラーの有無と順序、call 順、metamethod、字句束縛、複数戻り値、goto の可否を保存する。ただし純 Lua の `debug.getlocal` 等による local の生存期間・名前の観測は宣言 hoist と両立しない。safe が通常のプログラム意味論を対象とし、debug/introspection を保証しないことを API 文書に明記し、必要なら変換全体を opt-out できるようにする。
 
-Stormworks profile では、実行中に metatable を編集できず、組み込み metatable が固定されるという条件を使ってよい。この条件は解析へ埋め込まず、profile の capability として参照する。
+Stormworks profile では、実行中に metatable を編集できず、組み込み metatable が固定されるという条件を将来の候補拡張で使ってよい。#47 の実装候補は両 profile 共通の fresh・nonescape table に限定され、この差をまだ適用範囲拡大には使わない。将来使う場合も解析へ直接埋め込まず、profile の capability として参照する。
 
 公開オプション名は `runtimeProfile`、`effectAwareTransforms`、`effectAwareLocalHoist`、`effectAwareTableReads`、`fieldSensitiveTableEffects`、`allowLocalLifetimeChanges` とする。最後の一つだけが純 Lua で local lifetime の観測差を許可する opt-in であり、未知の副作用を無視する許可ではない。現段階では、実測上の必要性がないため、それ以外の semantic-changing transform は実装しない。
 
@@ -34,15 +34,12 @@ Stormworks profile では、実行中に metatable を編集できず、組み�
 
 ```text
 Link / Resolve
-→ #44 foldConstants
-→ Resolve when changed
-→ removeUnused fixed point
-→ Resolve when changed
-→ shared local/effect planning (#42 slot)
-→ #47 effect-aware transforms
-→ Resolve when structure or bindings changed
-→ existing alias / merge integration
-→ Resolve when changed
+→ #44 foldConstants → Resolve when changed
+→ removeUnused fixed point → Resolve when changed
+→ global rename classification / global alias → Resolve when changed
+→ #47 table read merge → Resolve when changed
+→ #47 non-adjacent local hoist → Resolve when changed
+→ existing adjacent local merge (#9)
 → Rename
 → Print
 ```

--- a/docs/issue-47-effect-analysis.md
+++ b/docs/issue-47-effect-analysis.md
@@ -18,7 +18,7 @@ Issue #44 の定数伝搬・畳み込みは実装済みである。Issue #42 の
 
 | 軸                            | 役割                                         | 既定                                                                |
 | ----------------------------- | -------------------------------------------- | ------------------------------------------------------------------- |
-| runtime profile               | `stormworks` / `lua53` の能力を選ぶ          | 従来互換の `lua53`                                                  |
+| runtime profile               | `stormworks` / `lua53` の能力を選ぶ          | CLI は `stormworks`。API の省略時だけ従来互換の `lua53`             |
 | safe effect transforms        | 選択環境で通常の観測可能な意味を保存する変換 | Stormworks では有効・opt-out。Lua では保守的な範囲だけ有効・opt-out |
 | semantic-changing assumptions | 未知の call や alias が変更しない等の仮定    | 無効・opt-in                                                        |
 
@@ -27,6 +27,8 @@ Issue 本文の一律 opt-in より、今回指定された条件を優先する
 safe は、結果だけでなくエラーの有無と順序、call 順、metamethod、字句束縛、複数戻り値、goto の可否を保存する。ただし純 Lua の `debug.getlocal` 等による local の生存期間・名前の観測は宣言 hoist と両立しない。safe が通常のプログラム意味論を対象とし、debug/introspection を保証しないことを API 文書に明記し、必要なら変換全体を opt-out できるようにする。
 
 Stormworks profile では、実行中に metatable を編集できず、組み込み metatable が固定されるという条件を使ってよい。この条件は解析へ埋め込まず、profile の capability として参照する。
+
+公開オプション名は `runtimeProfile`、`effectAwareTransforms`、`effectAwareLocalHoist`、`effectAwareTableReads`、`fieldSensitiveTableEffects`、`allowLocalLifetimeChanges` とする。最後の一つだけが純 Lua で local lifetime の観測差を許可する opt-in であり、未知の副作用を無視する許可ではない。現段階では、実測上の必要性がないため、それ以外の semantic-changing transform は実装しない。
 
 ## パス順と invalidation
 

--- a/docs/issue-47-effect-analysis.md
+++ b/docs/issue-47-effect-analysis.md
@@ -22,7 +22,7 @@ Issue #44 の定数伝搬・畳み込みは実装済みである。Issue #42 の
 | safe effect transforms        | 選択環境で通常の観測可能な意味を保存する変換 | Stormworks では有効・opt-out。Lua では lifetime 許可を個別 opt-in |
 | semantic-changing assumptions | 未知の call や alias が変更しない等の仮定    | 無効・opt-in                                                      |
 
-Issue 本文の一律 opt-in より、今回指定された条件を優先する。Stormworks で意味が変わらない変換は opt-out、変わり得る変換は opt-in とする。純 Lua と Stormworks で安全範囲が異なる機能も単一の `aggressive` フラグへ混ぜない。
+Issue 本文の一律 opt-in より、今回指定された条件を優先する。Stormworks で意味が変わらない変換は opt-out、変わり得る変換は opt-in とする。純 Lua と Stormworks で安全範囲が異なる機能も単一の `aggressive` フラグへ混ぜない。意味を変える仮定は、圧縮率が高くても safe 層へ混入させない。
 
 safe は、結果だけでなくエラーの有無と順序、call 順、metamethod、字句束縛、複数戻り値、goto の可否を保存する。ただし純 Lua の `debug.getlocal` 等による local の生存期間・名前の観測は宣言 hoist と両立しない。safe が通常のプログラム意味論を対象とし、debug/introspection を保証しないことを API 文書に明記し、必要なら変換全体を opt-out できるようにする。
 
@@ -48,7 +48,7 @@ Link / Resolve
 
 ## 解析モデル
 
-最初の region は同じ `Statement[]` 内の直線区間とする。if／loop／function の境界、label、goto、break、return、require splice、未対応 AST は region 境界とし、初期段階では越えない。各 nested block は独立に解析する。
+`ControlFlowAnalysis` は chunk と各 function を execution unit に分け、同じ `Statement[]` 内で移動可能性を証明した直線区間を `certified LinearRegion` として公開する。if／loop／function の境界、label、goto、break、return、未対応 AST は region 境界とし、越えられない場合は `undefined` を返す。未構築の完全 CFG を装わず `complete: false` と明示する。
 
 Resolver の `symbolOf(identifier)` を使い、名前ではなく Symbol 単位で次を記録する。
 
@@ -59,9 +59,9 @@ Resolver の `symbolOf(identifier)` を使い、名前ではなく Symbol 単位
 - table value の alias / capture / escape
 - control-flow barrier
 
-heap location は table 全体から始め、次に `(table symbol, static key)` へ精密化する。`t.x` と `t["x"]` は同じ key `"x"` とする。動的 key は table 全体を dirty にする。未知の call、alias、escape は該当 table、判定不能なら追跡中 heap 全体を保守的に invalid とする。
+heap location は Symbol ではなく table constructor ごとの allocation identity と static key で表す。直線 region の reaching-definition は `local t={}`、`local alias=t`、再代入、nil、unknown を区別する。`t.x`、`t["x"]`、escaped literal、long bracket literal は Lua byte 列として同じ key へ正規化する。動的 key は table 全体を dirty にする。
 
-table constructor から直接作られ、追跡 local 以外へ渡っていない値を fresh とする。call 引数、return、global／外部 table への格納、別 local への alias、nested function の capture、未対応操作で nonescape 性を失う。純 Lua では `setmetatable`、未知の call、escape 後の access の副作用を否定しない。Stormworks でも alias や call による値の変更までは無視しない。
+table constructor から直接作られた値を fresh とする。同一 execution unit で追跡できる `local alias=t` は同じ allocation としてdirtyを共有し、escapeにはしない。call 引数、return、global／外部 table への格納、代入による公開、nested function の capture、未対応操作では nonescape 性を失う。解析不能な join と execution unit 入口は unknown とし、「影響なし」と解釈しない。純 Luaでは `setmetatable`、未知のcall、escape後のaccessの副作用を否定せず、Stormworksでもaliasやcallによる値の変更までは無視しない。
 
 ## 変換
 
@@ -92,7 +92,9 @@ table は fresh・nonescape を table 全体で dirty 管理し、次に static 
 
 非連続 local は Rename と同じ予約名・module 順で provisional name を割り当て、その名前長を追加代入の上界に使う。変換で候補 Symbol の参照重みだけが増える限り、最終 Rename は旧割当を維持する案より悪くならない。一方、既存の連続 local merge と競合すると比較基準自体が変わるため、#42 で統合 planner を作るまでは、前後に local が隣接しない宣言だけを #47 の候補にする。
 
-table read merge は `local` と `=` の重複が消える固定構文差を使う。ただし一文の arity は 50 以下へ分割し、Lua compiler の local／register 上限に保守的な余裕を残す。正確な register pressure と Rename／Print 後の transactional cost は、実測トリガーを満たした場合の後続 Issue 候補とする。
+table read merge は `local` と `=` の重複が消える固定構文差を使う。runtime semantics と compiler resource policy は別の capability とし、planner は中央の判定結果だけを参照する。一文の arity は既定で50以下へ分割し、Lua compilerのlocal／register上限に保守的な余裕を残す。この値は正確なregister推定とは称さず、`conservative-policy`としてfail-closedに扱う。
+
+#47 の二変換は、Symbol数・scope・利用可能な短縮名集合を変えない範囲で局所的なサイズ上界を証明している。最終 Rename／Print を試行するtransactionは、この証明が成立しない将来の競合planner向けであり、現行#47の正しさやサイズ非増加を補う残作業ではない。組合せテストで有効時の増加反例が出た場合だけ、この切り分けを撤回する。
 
 ## Source Map
 
@@ -129,12 +131,18 @@ table read merge は `local` と `=` の重複が消える固定構文差を使�
 
 - 共通 AST walker と、Symbol 単位の declaration／read／write facts
 - fresh table allocation、static key、dirty、alias／call／return／store／capture escape の解析
+- certified linear region、allocation identity、直線regionのreaching-definition／alias facts
+- Lua 5.3 lexical ruleに従う共有byte string decoder
+- runtime semanticsとcompiler resource policyを分離したcapability判定
+- `changed`／`invalidatesResolve`とResolve世代を集中管理するpass orchestrator
+- 候補の採否理由・件数・推定削減量を、出力非影響で収集するoptimizer diagnostics
 - RHS を元位置に残す、孤立した非連続 local 宣言の hoist
 - fresh・nonescape tableの安定したstatic-key readを一つのlocal文へまとめる変換
 - table全体／static-key単位dirtyの個別切替、master／変換別opt-out
 - CLIのStormworks既定、APIのLua 5.3互換既定、純Lua lifetime変更の個別opt-in
 - 構造変更後の再Resolve、合成Identifierのprovenance、table統合を含むSource Mapテスト
 - moduleLikeLuaの両方式、複数module、#44、remove-unused、global alias、既存local mergeとの組合せテスト
+- local alias経由のread/write、fresh table再代入前後の部分最適化、closureによるalias公開の拒否
 
 未知のcallやaliasが変更しないと仮定するsemantic-changing transformは、実測上の必要性を確認できなかったため追加していない。意味変更を許可する包括的な`aggressive`オプションも設けていない。純Luaの`allowLocalLifetimeChanges`はdebug APIからのlocal lifetime観測差だけを許可し、heap効果やmetatableの仮定を緩めない。
 
@@ -150,75 +158,40 @@ table read merge は `local` と `=` の重複が消える固定構文差を使�
 
 Lua 5.3 safe ケースは可能な範囲で実行結果を差分検証する。Stormworks 固有 capability は、metatable を使う反例が Lua では拒否され、Stormworks profile だけで許可される解析テストで示す。
 
-## 非対象
+## #47 の変換対象外
 
 - 全関数の SSA／CFG
 - branch／loop をまたぐ一般的 code motion
-- 汎用 points-to／alias 解析
+- 分岐joinを含む汎用SSA／points-to解析
 - debug API による local 観測の保存
 - 未知の C API やホスト環境の効果推論
 
-安全な候補の大半がこれらだけで拒否され、推定削減量が実装・保守コストを上回ると実コーパスで確認できた場合に再検討する。
+これらは#47の未完ではない。#47で必要な解析境界、allocation追跡、測定手段は実装済みであり、以下は別の観測保証または対象領域を増やす独立機能である。
 
-## 後続 Issue 候補
+## 独立した後続 Issue
 
-この節は、#47 の完了を妨げない将来課題を、後から独立 Issue に切り出すための設計メモである。ここへ記載しただけでは実装を約束しない。起票トリガーを満たす証拠が得られたとき、対象コーパス、期待削減量、意味論上の境界を添えて Issue 化する。
+この節は、#47の実装結果を前提にした独立拡張だけを残す。#47候補の採否理由はdiagnosticsで測定できるため、仮説だけで対象を増やさない。再代入、同一unitのlocal alias、byte string decoder、resource policy、pass invalidation、候補計測は#47へ吸収済みであり、後続Issueには残さない。
 
-### 再代入を扱う flow-sensitive points-to
-
-- **問題と保留理由:** 現在は fresh table を保持する Symbol に一度でも write があれば、その Symbol の table read merge をすべて拒否する。元の allocation と現在値を文ごとに対応付ける points-to／CFG がない状態で、「再代入より前だけ安全」などの部分判定を加えると誤認しやすいためである。
-- **起票トリガー:** 実コーパスで、この保守的拒否が安全候補の主要な取りこぼしになり、見込める byte 削減量を具体例と計測値で示せたとき。
-- **必要な基盤:** 文位置を持つ binding write、allocation identity、直線 region 内の reaching-definition。branch を越えるなら後述の CFG も必要になる。
-- **完了条件案:** 再代入前後で allocation を区別し、元 table、別 fresh table、外部値、`setmetatable` を含む反例を安全に分類する。解析不能な join は拒否し、既存の全 Symbol 拒否より出力を悪化させない。
-
-### register pressure に基づく merge 上限
-
-- **問題と保留理由:** 現在は一つの local 文へまとめる arity を 50 に制限する。Lua 5.3 の local 上限 200 と register 上限 255 に対して余裕を残す固定値であり、関数内の既存 local、RHS 一時 register、コンパイラ実装差までは数えていない。
-- **起票トリガー:** 50 分割が目立つ出力増を生む、または対象 Lua／Stormworks コンパイラで 50 未満でも register overflow を再現したとき。
-- **必要な基盤:** 対象コンパイラごとの制限を明記した runtime capability、関数単位の local／式一時値の保守的上界、コンパイル可能性を検証する fixture。
-- **完了条件案:** 対象 runtime ごとに安全な arity を導出し、限界直前と限界超過を自動検証する。導出不能時は現在の固定上限以下へフォールバックする。
-
-### branch／loop／goto を扱う CFG
+### #63 branch／loop／goto を扱う CFG
 
 - **問題と保留理由:** #47 は同じ `Statement[]` の直線 region に限定し、分岐、loop、label、goto を barrier とする。一般的な code motion には支配関係、到達定義、loop 効果の固定点が必要で、局所的な条件追加では安全性を維持しにくい。
 - **起票トリガー:** barrier 越しの候補が実コーパスの削減機会を支配し、直線 region の改善では回収できないと測定されたとき。
 - **必要な基盤:** Lua の goto／local scope 制約を表す CFG、dominance、block 単位の effect summary、解析不能 edge の保守的表現。
 - **完了条件案:** if、各 loop、break、return、label／goto の代表反例で評価順と scope legality を保存する。未到達、irreducible、解析不能な flow は変換しない。
 
-### 限定 alias 解析
+### #65 Rename／Print 後の transactional cost 判定
 
-- **問題と保留理由:** fresh table を別 local、call、return、外部 table へ渡すと escape とし、以後を拒否する。汎用 points-to は複雑だが、単純な一対一 local alias には安全に追跡できる余地がある。
-- **起票トリガー:** `local alias = table` のような限定形が主要な取りこぼしとなり、alias を追跡しても候補当たりの解析費用が妥当だと確認できたとき。
-- **必要な基盤:** allocation identity、alias の生成・kill、capture／call／store での escape propagation、再代入を扱う reaching-definition。
-- **完了条件案:** 対応する local alias 集合に dirty／escape を伝播し、分岐 join、alias 再代入、nested closure、外部 call の反例は保守的に拒否する。
-
-### Rename／Print 後の transactional cost 判定
-
-- **問題と保留理由:** 現在の planner は構文上の削減量と provisional rename を用いる。変換で参照重みや名前割当順が変わる場合、Rename／Print 後の厳密な全体 byte 差を planner 単体で証明するのは難しい。
+- **問題と保留理由:** #47の現行変換には局所的な非増加証明がある。今後、scope／slot集合を変える候補や複数plannerの競合を選ぶ場合は、その証明を一般化できず、Rename／Print後の全体byte差が必要になる。
 - **起票トリガー:** 多数 Symbol、複数 module、予約名衝突を含む差分テストで、有効時の出力が無効時より長くなる反例が得られたとき。または複数の変換パスが同じ概算ロジックを持ち始めたとき。
 - **必要な基盤:** AST／resolver／metadata を安全に複製またはロールバックする仕組み、同一 print 条件での UTF-8 byte 計測、変換ごとの採否を再現できる deterministic pipeline。
 - **完了条件案:** 候補適用前後を最終 Rename／Print と同条件で比較し、厳密に短い場合だけ commit する。Source Map と annotation の所有権も rollback で失わない。
 
-### debug／introspection 保存モード
+### #67 debug／introspection 保存モード
 
 - **問題と保留理由:** local 宣言 hoist は通常の実行結果を保存しても、`debug.getlocal`、hook、エラースタックから観測される local の生存期間を変える。完全保存は rename や既存 minify とも衝突し、#47 の safe 定義には含めない。
 - **起票トリガー:** debug API を使用する利用者から再現例が提示され、rename を含むどの観測を保証すべきか合意できたとき。
 - **必要な基盤:** runtime profile ごとの debug API 能力、観測対象の明文化、debug-sensitive construct の検出。
 - **完了条件案:** 保証範囲を API／CLI に明記し、保存モードでは該当変換を拒否する。保証できない観測は診断または文書で明示する。
-
-### static string key の完全な decoder
-
-- **問題と保留理由:** `.x` と単純な `['x']`／`["x"]` は同じ static key に正規化するが、escape を含む Lua string literal は動的 key として扱う。parser 表現から値を復元する decoder を局所実装すると、escape、10 進 byte、改行、長括弧文字列で不一致を起こし得る。
-- **起票トリガー:** escaped string key が実コーパスで頻出し、field-sensitive dirty の主要な取りこぼしだと測定されたとき。
-- **必要な基盤:** Lua 5.3 lexical rule に従う共有 string decoder、parser／printer roundtrip fixture、byte string と JavaScript string の境界定義。
-- **完了条件案:** 同値な全 literal 表記を同じ byte key に正規化し、不正 escape と runtime 依存表現を拒否する。decoder は constant fold 等からも再利用できる位置に置く。
-
-### pass orchestration と #42 planner の統合
-
-- **問題と保留理由:** #47 は必要箇所で Resolve をやり直しているが、各パスが invalidation と cost 判定を個別に組み立てると、#42 や後続 optimizer で順序依存が増える。#42 自体が未実装のため、先に抽象化すると要求を誤る可能性がある。
-- **起票トリガー:** #42 実装時に同じ region、effect、cost、再 Resolve 制御を再利用できることが確認される、または三つ以上の構造変更パスが同型の orchestration を持ったとき。
-- **必要な基盤:** `changed`／`invalidatesResolve` を返す pass 契約、共有 effect facts、候補単位の cost interface、パス間テスト行列。
-- **完了条件案:** #42 と #47 が同じ planner 契約を使い、Resolve の更新点が中央で決まる。個別 opt-out、Source Map、出力長不増の性質を統合後も維持する。
 
 ## 完了条件
 

--- a/docs/issue-47-effect-analysis.md
+++ b/docs/issue-47-effect-analysis.md
@@ -1,0 +1,154 @@
+# Issue #47 効果解析と非連続 local／table 圧縮
+
+この文書は Issue #47 の長期実装で、会話履歴に依存せず設計判断と次の作業を復元するための仕様書である。実装が判断を具体化したときは更新する。
+
+## 目的
+
+連続していない local 宣言と table access を、read／write、escape、未知の副作用を解析して短縮する。候補は次をすべて満たす場合だけ変換する。
+
+1. 選択した実行環境と安全性レベルで許される。
+2. 評価順、字句束縛、複数戻り値、制御フローの制約を満たす。
+3. 最終出力が厳密に短くなる。
+
+Issue #44 の定数伝搬・畳み込みは実装済みである。Issue #42 の local-run planner は未実装だが、#47 をその完了待ちにはしない。両 Issue が使える効果・コスト基盤を先に作り、連続・非連続候補の局所実装を重複させない。全面的な SSA、CFG、汎用 alias 解析は実測で必要になるまで導入しない。
+
+## 意味論とオプション
+
+`moduleLikeLua` は require の出力方式であり、実行環境の意味論ではない。公開名は実装時に確定するが、次の三軸を混ぜない。
+
+| 軸                            | 役割                                         | 既定                                                                |
+| ----------------------------- | -------------------------------------------- | ------------------------------------------------------------------- |
+| runtime profile               | `stormworks` / `lua53` の能力を選ぶ          | 従来互換の `lua53`                                                  |
+| safe effect transforms        | 選択環境で通常の観測可能な意味を保存する変換 | Stormworks では有効・opt-out。Lua では保守的な範囲だけ有効・opt-out |
+| semantic-changing assumptions | 未知の call や alias が変更しない等の仮定    | 無効・opt-in                                                        |
+
+Issue 本文の一律 opt-in より、今回指定された条件を優先する。Stormworks で意味が変わらない変換は opt-out、変わり得る変換は opt-in とする。純 Lua と Stormworks で安全範囲が異なる機能も単一の `aggressive` フラグへ混ぜない。
+
+safe は、結果だけでなくエラーの有無と順序、call 順、metamethod、字句束縛、複数戻り値、goto の可否を保存する。ただし純 Lua の `debug.getlocal` 等による local の生存期間・名前の観測は宣言 hoist と両立しない。safe が通常のプログラム意味論を対象とし、debug/introspection を保証しないことを API 文書に明記し、必要なら変換全体を opt-out できるようにする。
+
+Stormworks profile では、実行中に metatable を編集できず、組み込み metatable が固定されるという条件を使ってよい。この条件は解析へ埋め込まず、profile の capability として参照する。
+
+## パス順と invalidation
+
+```text
+Link / Resolve
+→ #44 foldConstants
+→ Resolve when changed
+→ removeUnused fixed point
+→ Resolve when changed
+→ shared local/effect planning (#42 slot)
+→ #47 effect-aware transforms
+→ Resolve when structure or bindings changed
+→ existing alias / merge integration
+→ Resolve when changed
+→ Rename
+→ Print
+```
+
+各変換パスは少なくとも `changed` と `invalidatesResolve` を返す。Identifier の生成、宣言位置の変更、宣言から代入への分離は Resolve を無効化する。古い `ResolveResult` を後続へ渡してはならない。
+
+## 解析モデル
+
+最初の region は同じ `Statement[]` 内の直線区間とする。if／loop／function の境界、label、goto、break、return、require splice、未対応 AST は region 境界とし、初期段階では越えない。各 nested block は独立に解析する。
+
+Resolver の `symbolOf(identifier)` を使い、名前ではなく Symbol 単位で次を記録する。
+
+- local の declaration / read / write
+- global read / write
+- heap location の read / write
+- call と未知の効果
+- table value の alias / capture / escape
+- control-flow barrier
+
+heap location は table 全体から始め、次に `(table symbol, static key)` へ精密化する。`t.x` と `t["x"]` は同じ key `"x"` とする。動的 key は table 全体を dirty にする。未知の call、alias、escape は該当 table、判定不能なら追跡中 heap 全体を保守的に invalid とする。
+
+table constructor から直接作られ、追跡 local 以外へ渡っていない値を fresh とする。call 引数、return、global／外部 table への格納、別 local への alias、nested function の capture、未対応操作で nonescape 性を失う。純 Lua では `setmetatable`、未知の call、escape 後の access の副作用を否定しない。Stormworks でも alias や call による値の変更までは無視しない。
+
+## 変換
+
+最初の変換は宣言だけを earlier local declaration にまとめ、初期化を元位置に残す。
+
+```lua
+local a = f()
+side_effect()
+local b = g()
+```
+
+```lua
+local a,b
+a = f()
+side_effect()
+b = g()
+```
+
+RHS を動かさないため評価順を保てるが、宣言を早めて介在コードの同名 outer local/global を shadow する場合、goto が新しい local scope へ飛び込む場合は拒否する。
+
+初期段階は 1 variable / 1 initializer だけを対象にする。`local a,b=f()`、末尾式の複数戻り値、vararg、nil 補完は専用の同値変換が入るまで拒否する。closure capture、local 上限、repeat-until scope も検査する。式の移動は effect-free、介在 write なし、エラー順不変を証明できる場合だけ後段で追加する。
+
+table は fresh・nonescape を table 全体で dirty 管理し、次に static key 単位へ精密化する。純 Lua で metamethod を否定できない access の移動・削除は safe 層で行わない。Stormworks 固定 metatable で追加的に安全になるものは Stormworks safe 層、未知 call 等を無視するものは semantic-changing 層に置く。
+
+## コスト
+
+printer と共有できる syntax byte cost API を用意し、保守的な上下界で変換後が厳密に短いと判断できる場合だけ適用する。判定不能なら拒否する。概算定数を各変換へ散在させない。統合テストでは変換有効時の UTF-8 byte length が無効時より長くならないことを確認する。
+
+## Source Map
+
+- hoist 後の宣言文: 最初に統合した元 local 文
+- 各宣言 Identifier: 対応する元宣言 Identifier
+- 元位置の assignment 文: 対応する元 local 文
+- assignment 左辺: 対応する元宣言 Identifier
+- RHS: 元ノードを再利用して元位置を維持
+- 合成 nil 等: 対応する元宣言か RHS。対応がなければ unmapped
+
+同じ Identifier ノードを宣言と代入左辺へ再利用しない。合成 Identifier は元 location/range と Source Map name の由来を持つ。保存コメントと annotation は `SourceMetadata` の所有関係を使い、意味上対応する後継文へ一度だけ移す。
+
+## 段階とコミット
+
+各段階を一つ以上の独立コミットにし、必要ならさらに細分化する。各コミットで Windows の `cmd.exe` から Windows 版 pnpm を呼び、対象テストと全テストを通す。
+
+1. 本仕様書と基準検証。
+2. 共通 AST walker と effect fact 型。変換はしない。
+3. Symbol 単位の read/write と region/barrier 解析。
+4. 1 variable / 1 initializer の非連続 planner と cost gate。
+5. 宣言 hoist／初期化分離、再 Resolve、Source Map provenance。
+6. #44、remove-unused、merge、global alias の組合せ固定。
+7. fresh・nonescape table の table 全体 dirty。
+8. static key 正規化と field-sensitive dirty。
+9. Lua／Stormworks profile、safe の既定と opt-out を公開。
+10. 実測で有効な semantic-changing assumption だけを個別 opt-in で追加。
+11. fixture、差分実行、Source Map、roundtrip、出力長、CLI/API 文書、全 CI 検証。
+
+段階 10 は unsafe 機能を必ず作るという意味ではない。意味変更で初めて得られる有効な候補を計測し、導入するなら safe と別オプション・別コミットにする境界である。
+
+## テスト行列
+
+- identifier: intervening read/write、outer/global 同名、shadow、capture、nested block、label/goto、local 上限
+- value/order: pure literal、call、error、short circuit、multiple return、nil padding、vararg、LHS base/index/RHS 順
+- table: `.x` / `["x"]`、same/different/dynamic key、alias、call、return、global/outer table escape、capture、metatable
+- runtime: lua53 safe、Stormworks safe、semantic-changing opt-in、各 opt-out
+- pipeline: #44、remove-unused、merge、global alias の on/off と再 Resolve
+- linking: module-like Lua と SL require splice
+- output: Source Map origin/name、roundtrip、identifier collision、byte length
+
+Lua 5.3 safe ケースは可能な範囲で実行結果を差分検証する。Stormworks 固有 capability は、metatable を使う反例が Lua では拒否され、Stormworks profile だけで許可される解析テストで示す。
+
+## 非対象
+
+- 全関数の SSA／CFG
+- branch／loop をまたぐ一般的 code motion
+- 汎用 points-to／alias 解析
+- debug API による local 観測の保存
+- 未知の C API やホスト環境の効果推論
+
+安全な候補の大半がこれらだけで拒否され、推定削減量が実装・保守コストを上回ると実コーパスで確認できた場合に再検討する。
+
+## 完了条件
+
+- #44 と連続 local merge だけでは生成できない、非連続文または table key を含む圧縮がある。
+- safe 層で評価順、字句束縛、複数戻り値、副作用が保存される。
+- 未知 call、alias、escape、動的 key、純 Lua の metatable に保守的である。
+- 短くなる候補だけを適用する。
+- Stormworks safe は opt-out、意味変更は opt-in、純 Lua 差異は別軸である。
+- 合成ノードの Source Map 由来が仕様とテストで固定される。
+- 関連パスの組合せと再 Resolve がテストされる。
+- Windows 版 pnpm で build、lint、format check、test、pack dry-run が成功する。

--- a/docs/issue-47-optimizer-report.md
+++ b/docs/issue-47-optimizer-report.md
@@ -1,0 +1,25 @@
+# Issue #47 optimizer 計測レポート
+
+このレポートは `pnpm run report:optimizer` で再生成できる。5個の固定fixtureを、Windows版pnpm、Stormworks profile、同一Rename／Print条件で計測した2026-08-25時点の基準値である。
+
+## 結果
+
+| pass        | decision | reason                        | candidates |     推定bytes |
+| ----------- | -------- | ----------------------------- | ---------: | ------------: |
+| table reads | accepted | profitable group              |          2 |         5削減 |
+| table reads | rejected | call escape                   |          1 |             0 |
+| table reads | rejected | dynamic key                   |          1 |             0 |
+| local hoist | rejected | adjacent local owned by merge |          4 |             0 |
+| local hoist | rejected | control-flow barrier          |          1 |             0 |
+| local hoist | rejected | insufficient group            |          1 |             0 |
+| local hoist | rejected | nonpositive cost              |          4 | 4 opportunity |
+
+全体では14候補中2候補を採用し、planner上の推定削減は5 bytesだった。最終出力transactionでは、採用fixtureが55 bytesから49 bytesへ6 bytes短縮された。他の4 fixtureは同長でbaselineが選ばれ、増加するtrialはなかった。
+
+## 後続Issueの判断
+
+- #63: control-flow barrier拒否は1候補あったが、単独候補で推定削減機会は0 bytesだった。CFG基盤を直ちに変換へ接続する根拠にはならず、branch／loop越しという新しい対象領域の独立Issueとして維持する。
+- #65: 隔離Minifierによる最終Rename／Print transaction基盤は#47で実装した。現fixtureで局所cost証明の破綻はなく、残る仕事は#42等の競合plannerへ候補選択を接続する独立統合作業である。
+- #67: debug／introspectionは通常実行結果の候補計測では判定できない別の観測保証である。Stormworks既定を弱めず、利用者要求が得られた場合だけ扱う。
+
+この小規模fixtureは実利用コーパスの頻度を代表しない。reason分類と再現手段の基準であり、後続Issueの着手判断では対象コーパスを追加して同じcommandで再計測する。

--- a/package.json
+++ b/package.json
@@ -35,6 +35,8 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "verify:lua-budget": "node scripts/verify-lua-resource-budget.cjs",
+    "report:optimizer": "pnpm run build && node scripts/report-optimizer-diagnostics.cjs",
+    "verify:effect-semantics": "pnpm run build && node scripts/verify-effect-semantics.cjs",
     "prepack": "pnpm run build"
   },
   "author": "Nona Takahara <nona_t_2612@yahoo.co.jp>",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "lint": "eslint .",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
+    "verify:lua-budget": "node scripts/verify-lua-resource-budget.cjs",
     "prepack": "pnpm run build"
   },
   "author": "Nona Takahara <nona_t_2612@yahoo.co.jp>",

--- a/scripts/report-optimizer-diagnostics.cjs
+++ b/scripts/report-optimizer-diagnostics.cjs
@@ -1,0 +1,89 @@
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { Minifier } = require("../dist/minifier.js");
+const {
+  summarizeOptimizationDiagnostics,
+} = require("../dist/optimizerDiagnostics.js");
+const {
+  selectTransactionalMinifierVariant,
+} = require("../dist/optimizerTransaction.js");
+
+const fixtures = [
+  {
+    name: "accepted-table",
+    source: "local t={x=1,y=2} local a=t.x tick() local b=t.y use(a,b)",
+  },
+  { name: "dynamic-key", source: "local t={} local a=t[key] use(a)" },
+  {
+    name: "call-escape",
+    source: "local t={x=1} consume(t) local a=t.x use(a)",
+  },
+  {
+    name: "control-flow",
+    source: "local a=1 tick() if ready then use(a) end local b=2 use(b)",
+  },
+  {
+    name: "cost",
+    source: "local first=1 tick() local second=2 use(first,second)",
+  },
+];
+
+const directory = fs.mkdtempSync(
+  path.join(os.tmpdir(), "storm-optimizer-report-"),
+);
+try {
+  const diagnostics = [];
+  const transactions = [];
+  fixtures.forEach((fixture) => {
+    const fixtureDirectory = path.join(directory, fixture.name);
+    fs.mkdirSync(fixtureDirectory);
+    const entry = path.join(fixtureDirectory, "main.lua");
+    fs.writeFileSync(entry, fixture.source);
+    const minifier = new Minifier(
+      entry,
+      { luaVersion: "5.3" },
+      {
+        moduleLikeLua: false,
+        runtimeProfile: "stormworks",
+        collectOptimizationDiagnostics: true,
+      },
+    );
+    minifier.parse();
+    diagnostics.push(...minifier.optimizationDiagnostics);
+    const transaction = selectTransactionalMinifierVariant({
+      entryFilePath: entry,
+      luaParseSettings: { luaVersion: "5.3" },
+      baselineMode: {
+        moduleLikeLua: false,
+        runtimeProfile: "stormworks",
+        effectAwareTransforms: false,
+      },
+      trialMode: {
+        moduleLikeLua: false,
+        runtimeProfile: "stormworks",
+      },
+    });
+    transactions.push({
+      fixture: fixture.name,
+      accepted: transaction.accepted,
+      reason: transaction.accepted ? undefined : transaction.reason,
+      baselineBytes: transaction.baseline.byteLength,
+      trialBytes: transaction.trial?.byteLength,
+      byteSavings: transaction.byteSavings,
+    });
+  });
+  process.stdout.write(
+    JSON.stringify(
+      {
+        fixtureCount: fixtures.length,
+        diagnostics: summarizeOptimizationDiagnostics(diagnostics),
+        transactions,
+      },
+      null,
+      2,
+    ) + "\n",
+  );
+} finally {
+  fs.rmSync(directory, { recursive: true, force: true });
+}

--- a/scripts/verify-effect-semantics.cjs
+++ b/scripts/verify-effect-semantics.cjs
@@ -1,0 +1,85 @@
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+const { Minifier } = require("../dist/minifier.js");
+
+const lua = process.env.LUA53 || "lua53";
+const fixtures = [
+  `
+local log={}
+function tick() log[#log+1]="tick" end
+function use(a,b) print(a,b,table.concat(log,",")) end
+local t={x=1,y=2}
+local alias=t
+local first=alias.x
+tick()
+local second=t.y
+use(first,second)
+`,
+  `
+local t
+local function evil() t.y=9 end
+local function make()
+  t={x=1,y=2}
+  local first=t.x
+  evil()
+  local second=t.y
+  print(first,second)
+end
+make()
+`,
+  `
+local outer=7
+local first=(function() print("first") return outer end)()
+print("middle",outer)
+local second=(function() print("second") return outer end)()
+print(first,second)
+`,
+  `
+local function values() print("values") return 1,2,3 end
+local a,b=values()
+print(a,b)
+`,
+];
+
+const directory = fs.mkdtempSync(
+  path.join(os.tmpdir(), "storm-effect-semantics-"),
+);
+function execute(file) {
+  const result = spawnSync(lua, [file], { encoding: "utf8" });
+  if (result.error) throw result.error;
+  return {
+    status: result.status,
+    stdout: result.stdout,
+    stderr: result.stderr,
+  };
+}
+
+try {
+  fixtures.forEach((source, index) => {
+    const sourceFile = path.join(directory, `source-${String(index)}.lua`);
+    const minifiedFile = path.join(directory, `minified-${String(index)}.lua`);
+    fs.writeFileSync(sourceFile, source);
+    const code = new Minifier(
+      sourceFile,
+      { luaVersion: "5.3" },
+      { moduleLikeLua: false, runtimeProfile: "stormworks" },
+    )
+      .parse()
+      .toStringWithSourceMap({ file: path.basename(minifiedFile) }).code;
+    fs.writeFileSync(minifiedFile, code);
+    const original = execute(sourceFile);
+    const minified = execute(minifiedFile);
+    if (JSON.stringify(original) !== JSON.stringify(minified)) {
+      throw new Error(
+        `semantic mismatch in fixture ${String(index)}\noriginal=${JSON.stringify(original)}\nminified=${JSON.stringify(minified)}\ncode=${code}`,
+      );
+    }
+  });
+  process.stdout.write(
+    `${lua}: ${String(fixtures.length)} effect-aware fixtures matched exactly\n`,
+  );
+} finally {
+  fs.rmSync(directory, { recursive: true, force: true });
+}

--- a/scripts/verify-lua-resource-budget.cjs
+++ b/scripts/verify-lua-resource-budget.cjs
@@ -1,0 +1,47 @@
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+
+const compiler = process.env.LUAC53 || "luac53";
+const temporaryDirectory = fs.mkdtempSync(
+  path.join(os.tmpdir(), "storm-lua-budget-"),
+);
+
+function fixture(parallelValues) {
+  const existing = Array.from(
+    { length: 150 },
+    (_, index) => `e${String(index)}`,
+  );
+  const generated = Array.from(
+    { length: parallelValues },
+    (_, index) => `v${String(index)}`,
+  );
+  const rhs = generated.map(() => "0");
+  return `local ${existing.join(",")}\nlocal ${generated.join(",")}=${rhs.join(",")}\n`;
+}
+
+try {
+  const expectations = [
+    { count: 49, accepted: true },
+    { count: 50, accepted: true },
+    { count: 51, accepted: false },
+  ];
+  expectations.forEach(({ count, accepted }) => {
+    const file = path.join(temporaryDirectory, `parallel-${String(count)}.lua`);
+    fs.writeFileSync(file, fixture(count));
+    const result = spawnSync(compiler, ["-p", file], { encoding: "utf8" });
+    if (result.error) throw result.error;
+    const actual = result.status === 0;
+    if (actual !== accepted) {
+      throw new Error(
+        `${compiler} ${accepted ? "rejected" : "accepted"} 150 active + ${String(count)} parallel locals unexpectedly:\n${result.stderr}`,
+      );
+    }
+  });
+  process.stdout.write(
+    `${compiler}: verified 150 active locals with 49/50 accepted and 51 rejected\n`,
+  );
+} finally {
+  fs.rmSync(temporaryDirectory, { recursive: true, force: true });
+}

--- a/src/astWalk.ts
+++ b/src/astWalk.ts
@@ -1,0 +1,161 @@
+import Parser from "luaparse";
+
+/**
+ * ASTを変更せずに、式中の変数参照とnested blockを列挙するための共通walker。
+ * 宣言Identifier、member/table fieldの名前は変数参照ではないため通知しない。
+ * blockの再帰方針は利用側が決める。これにより、同一blockだけを解析するpassと
+ * nested blockまで集めるpassの両方が、同じAST分類を利用できる。
+ */
+export interface AstWalkVisitor {
+  readonly onIdentifierReference?: (id: Parser.Identifier) => void;
+  readonly onBlock?: (body: Parser.Statement[]) => void;
+}
+
+export function walkStatement(
+  statement: Parser.Statement,
+  visitor: AstWalkVisitor,
+): void {
+  switch (statement.type) {
+    case "LocalStatement":
+      statement.init.forEach((expr) => {
+        walkExpression(expr, visitor);
+      });
+      return;
+    case "AssignmentStatement":
+      statement.variables.forEach((variable) => {
+        if (variable.type === "Identifier") {
+          visitor.onIdentifierReference?.(variable);
+        } else {
+          walkExpression(variable, visitor);
+        }
+      });
+      statement.init.forEach((expr) => {
+        walkExpression(expr, visitor);
+      });
+      return;
+    case "CallStatement":
+      walkExpression(statement.expression, visitor);
+      return;
+    case "DoStatement":
+      visitor.onBlock?.(statement.body);
+      return;
+    case "WhileStatement":
+      walkExpression(statement.condition, visitor);
+      visitor.onBlock?.(statement.body);
+      return;
+    case "RepeatStatement":
+      visitor.onBlock?.(statement.body);
+      walkExpression(statement.condition, visitor);
+      return;
+    case "IfStatement":
+      statement.clauses.forEach((clause) => {
+        if (clause.type !== "ElseClause") {
+          walkExpression(clause.condition, visitor);
+        }
+        visitor.onBlock?.(clause.body);
+      });
+      return;
+    case "ForNumericStatement":
+      walkExpression(statement.start, visitor);
+      walkExpression(statement.end, visitor);
+      if (statement.step) walkExpression(statement.step, visitor);
+      visitor.onBlock?.(statement.body);
+      return;
+    case "ForGenericStatement":
+      statement.iterators.forEach((iterator) => {
+        walkExpression(iterator, visitor);
+      });
+      visitor.onBlock?.(statement.body);
+      return;
+    case "FunctionDeclaration":
+      if (statement.identifier) {
+        if (statement.identifier.type === "Identifier") {
+          if (!statement.isLocal) {
+            visitor.onIdentifierReference?.(statement.identifier);
+          }
+        } else {
+          walkExpression(statement.identifier, visitor);
+        }
+      }
+      visitor.onBlock?.(statement.body);
+      return;
+    case "ReturnStatement":
+      statement.arguments.forEach((argument) => {
+        walkExpression(argument, visitor);
+      });
+      return;
+    case "BreakStatement":
+    case "LabelStatement":
+    case "GotoStatement":
+      return;
+    default: {
+      const exhaustive: never = statement;
+      throw new TypeError(
+        "Unknown statement type: `" + JSON.stringify(exhaustive) + "`",
+      );
+    }
+  }
+}
+
+export function walkExpression(
+  expression: Parser.Expression,
+  visitor: AstWalkVisitor,
+): void {
+  switch (expression.type) {
+    case "Identifier":
+      visitor.onIdentifierReference?.(expression);
+      return;
+    case "StringLiteral":
+    case "NumericLiteral":
+    case "BooleanLiteral":
+    case "NilLiteral":
+    case "VarargLiteral":
+      return;
+    case "LogicalExpression":
+    case "BinaryExpression":
+      walkExpression(expression.left, visitor);
+      walkExpression(expression.right, visitor);
+      return;
+    case "UnaryExpression":
+      walkExpression(expression.argument, visitor);
+      return;
+    case "CallExpression":
+      walkExpression(expression.base, visitor);
+      expression.arguments.forEach((argument) => {
+        walkExpression(argument, visitor);
+      });
+      return;
+    case "TableCallExpression":
+      walkExpression(expression.base, visitor);
+      walkExpression(expression.arguments, visitor);
+      return;
+    case "StringCallExpression":
+      walkExpression(expression.base, visitor);
+      walkExpression(expression.argument, visitor);
+      return;
+    case "IndexExpression":
+      walkExpression(expression.base, visitor);
+      walkExpression(expression.index, visitor);
+      return;
+    case "MemberExpression":
+      walkExpression(expression.base, visitor);
+      return;
+    case "FunctionDeclaration":
+      visitor.onBlock?.(expression.body);
+      return;
+    case "TableConstructorExpression":
+      expression.fields.forEach((field) => {
+        if (field.type === "TableKey") {
+          walkExpression(field.key, visitor);
+        }
+        walkExpression(field.value, visitor);
+      });
+      return;
+    default: {
+      const exhaustive: never = expression;
+      throw new TypeError(
+        "Unknown expression type: `" + JSON.stringify(exhaustive) + "`",
+      );
+    }
+  }
+}

--- a/src/astWalk.ts
+++ b/src/astWalk.ts
@@ -9,6 +9,9 @@ import Parser from "luaparse";
 export interface AstWalkVisitor {
   readonly onIdentifierReference?: (id: Parser.Identifier) => void;
   readonly onBlock?: (body: Parser.Statement[]) => void;
+  // Function bodyは遅延実行されるためwalker自身は入らない。必要な解析だけが
+  // 関数を独立したexecution unitとして受け取り、bodyを走査する。
+  readonly onFunction?: (fn: Parser.FunctionDeclaration) => void;
 }
 
 export function walkStatement(
@@ -77,6 +80,7 @@ export function walkStatement(
           walkExpression(statement.identifier, visitor);
         }
       }
+      visitor.onFunction?.(statement);
       visitor.onBlock?.(statement.body);
       return;
     case "ReturnStatement":
@@ -141,6 +145,7 @@ export function walkExpression(
       walkExpression(expression.base, visitor);
       return;
     case "FunctionDeclaration":
+      visitor.onFunction?.(expression);
       visitor.onBlock?.(expression.body);
       return;
     case "TableConstructorExpression":

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,57 +2,12 @@
 
 import fs from "fs";
 import path from "path";
-import { Command } from "commander";
 import { Options } from "luaparse";
 import { Minifier, MinifierMode } from "./minifier";
 import { buildMinifiedOutput, SourceMappingUrlStyle } from "./output";
+import { createCliProgram } from "./cliOptions";
 
-const program = new Command();
-
-program
-  .version("0.3.0")
-  .description("A Lua minifier also outputs source map")
-  .option(
-    "-m, --module-like-lua",
-    "require・dofileの動作を実際のLuaに近づけます",
-  )
-  .option("--no-rename", "識別子の短縮(リネーム)を無効にします（デバッグ用途）")
-  .option(
-    "--global-rename",
-    "代入されているグローバル識別子を内部用とみなして短縮します（外部から名前で参照されるグローバルがある場合は使用しないでください）",
-  )
-  .option(
-    "--no-merge-locals",
-    "連続するローカル変数宣言のまとめ上げを無効にします（デバッグ用途）",
-  )
-  .option(
-    "--no-global-alias",
-    "外部グローバル識別子（リネームできないもの）のローカル代入短縮を無効にします（デバッグ用途）",
-  )
-  .option(
-    "--no-remove-unused",
-    "未使用ローカル宣言の安全な範囲での削除を無効にします",
-  )
-  .option(
-    "--no-remove-unused-globals",
-    "未使用グローバル削除を無効にします（グローバル削除は今後実装予定）",
-  )
-  .option(
-    "--fold-constants",
-    "定数式の事前計算と、定数ローカル変数の伝搬を有効にします（既定では無効）",
-  )
-  .option(
-    "--reserved-globals-config <path>",
-    '代入されていても短縮しないグローバル名を列挙したJSON設定ファイルのパス（{"neverRenameGlobals":["onTick",...]}形式）。エンジン側のコールバック規約名など、常に元の名前のまま残す必要がある識別子を指定します',
-  )
-  .option(
-    "--single-line-source-mapping-url",
-    "sourceMappingURLアノテーションを単一行の--コメントで出力します（Source Map仕様の「最終行」ルールに従いますが、既定の複数行ブロックコメント形式を前提とするツールとは組み合わせられません）",
-  )
-  .option(
-    "--strict-source-mapping-url",
-    "sourceMappingURLアノテーションをLuaコメントで一切包まず、Source Map仕様のマーカー文字列(//# sourceMappingURL=...)そのままを出力します。Luaの文法上この形式と有効なLuaコードは両立できないため、出力ファイルの最終行は有効なLua文ではなくなります",
-  );
+const program = createCliProgram();
 
 program.parse(process.argv);
 

--- a/src/cliOptions.ts
+++ b/src/cliOptions.ts
@@ -1,0 +1,83 @@
+import { Command, Option } from "commander";
+
+/**
+ * CLIの公開オプション定義。I/Oから分離し、既定値とMinifierModeへの名前変換を
+ * 実ファイルを書かずに検証できるようにする。
+ */
+export function createCliProgram(): Command {
+  return new Command()
+    .version("0.3.0")
+    .description("A Lua minifier also outputs source map")
+    .option(
+      "-m, --module-like-lua",
+      "require・dofileの動作を実際のLuaに近づけます（runtime profileとは独立）",
+    )
+    .addOption(
+      new Option(
+        "--runtime-profile <profile>",
+        "効果解析が前提とする実行環境（CLI既定: stormworks）",
+      )
+        .choices(["stormworks", "lua53"])
+        .default("stormworks"),
+    )
+    .option(
+      "--no-effect-aware-transforms",
+      "効果解析による最適化をすべて無効にします",
+    )
+    .option(
+      "--no-effect-aware-local-hoist",
+      "非連続local宣言のまとめ上げだけを無効にします",
+    )
+    .option(
+      "--no-effect-aware-table-reads",
+      "fresh tableの安定したreadのまとめ上げだけを無効にします",
+    )
+    .option(
+      "--no-field-sensitive-table-effects",
+      "tableのdirty判定をstatic key単位からtable全体へ戻します",
+    )
+    .option(
+      "--allow-local-lifetime-changes",
+      "Lua 5.3 profileでdebug APIから観測可能なlocal生存期間の変更を許可します",
+    )
+    .option(
+      "--no-rename",
+      "識別子の短縮(リネーム)を無効にします（デバッグ用途）",
+    )
+    .option(
+      "--global-rename",
+      "代入されているグローバル識別子を内部用とみなして短縮します（外部から名前で参照されるグローバルがある場合は使用しないでください）",
+    )
+    .option(
+      "--no-merge-locals",
+      "連続するローカル変数宣言のまとめ上げを無効にします（デバッグ用途）",
+    )
+    .option(
+      "--no-global-alias",
+      "外部グローバル識別子（リネームできないもの）のローカル代入短縮を無効にします（デバッグ用途）",
+    )
+    .option(
+      "--no-remove-unused",
+      "未使用ローカル宣言の安全な範囲での削除を無効にします",
+    )
+    .option(
+      "--no-remove-unused-globals",
+      "未使用グローバル削除を無効にします（グローバル削除は今後実装予定）",
+    )
+    .option(
+      "--fold-constants",
+      "定数式の事前計算と、定数ローカル変数の伝搬を有効にします（既定では無効）",
+    )
+    .option(
+      "--reserved-globals-config <path>",
+      '代入されていても短縮しないグローバル名を列挙したJSON設定ファイルのパス（{"neverRenameGlobals":["onTick",...]}形式）。エンジン側のコールバック規約名など、常に元の名前のまま残す必要がある識別子を指定します',
+    )
+    .option(
+      "--single-line-source-mapping-url",
+      "sourceMappingURLアノテーションを単一行の--コメントで出力します（Source Map仕様の「最終行」ルールに従いますが、既定の複数行ブロックコメント形式を前提とするツールとは組み合わせられません）",
+    )
+    .option(
+      "--strict-source-mapping-url",
+      "sourceMappingURLアノテーションをLuaコメントで一切包まず、Source Map仕様のマーカー文字列(//# sourceMappingURL=...)そのままを出力します。Luaの文法上この形式と有効なLuaコードは両立できないため、出力ファイルの最終行は有効なLua文ではなくなります",
+    );
+}

--- a/src/constantFold.ts
+++ b/src/constantFold.ts
@@ -13,6 +13,14 @@
 import Parser from "luaparse";
 import { ResolveResult, Symbol } from "./resolver";
 import { SourceMetadata } from "./sourceMetadata";
+import {
+  compareLuaByteStrings,
+  concatLuaByteStrings,
+  decodeLuaStringLiteral,
+  encodeLuaByteString,
+  LuaByteString,
+  luaByteStringKey,
+} from "./luaString";
 
 // ============================================================
 // 定数値の内部表現
@@ -28,7 +36,7 @@ type ConstantValue =
   | { kind: "boolean"; value: boolean }
   | { kind: "int"; value: bigint }
   | { kind: "float"; value: number }
-  | { kind: "string"; value: string; raw: string };
+  | { kind: "string"; value: LuaByteString; raw: string };
 
 const INT64_MIN = -(2n ** 63n);
 
@@ -77,28 +85,10 @@ function numericConstantOf(
 function stringConstantOf(
   node: Parser.StringLiteral,
 ): ConstantValue | undefined {
-  const raw = node.raw;
-  if (raw.length < 2) return undefined;
-  const quote = raw.charAt(0);
-  if (
-    (quote !== '"' && quote !== "'") ||
-    raw.charAt(raw.length - 1) !== quote
-  ) {
-    // 長括弧([[...]])形式などは対象外
-    return undefined;
-  }
-  if (raw.includes("\\")) return undefined;
-  const inner = raw.slice(1, -1);
-  for (let i = 0; i < inner.length; i++) {
-    const code = inner.charCodeAt(i);
-    if (code < 0x20 || code > 0x7e) return undefined;
-  }
-  // node.valueは使わない: このプロジェクトのluaparse設定はencodingModeを指定して
-  // おらず、既定値"none"はdiscardStrings:trueのためStringLiteral.valueは常にnull
-  // になる（他のファイルが文字列の判定・比較に一貫してrawしか使わないのはこのため）。
-  // エスケープの無い印字可能ASCIIだけを
-  // 対象にしているので、raw内側の文字列(inner)がそのままLua側の値と一致する。
-  return { kind: "string", value: inner, raw };
+  const decoded = decodeLuaStringLiteral(node);
+  return decoded.ok
+    ? { kind: "string", value: decoded.value, raw: node.raw }
+    : undefined;
 }
 
 // 式が「今すぐ書き出せる定数」かどうかを判定する。畳み込み・伝搬どちらの判断でも
@@ -233,7 +223,9 @@ function literalNodeFor(
     case "string": {
       const node: Parser.StringLiteral = {
         type: "StringLiteral",
-        value: value.value,
+        // Printerと再解析はrawを使う。luaparse型ではstring必須だが、既定の
+        // discardStrings環境では意味値を保持しないため空文字を入れる。
+        value: "",
         raw: value.raw,
       };
       withOriginPosition(node, origin);
@@ -399,11 +391,9 @@ function evalOrderComparison(
   l: ConstantValue,
   r: ConstantValue,
 ): ConstantValue | undefined {
-  // 文字列同士の比較は、Luaでは1バイトずつの大小で決まる。定数として認めた
-  // 文字列はエスケープを含まない印字可能ASCIIだけなので、JavaScriptの文字列
-  // 比較と同じ順序になる。
   if (l.kind === "string" && r.kind === "string") {
-    return { kind: "boolean", value: compareValues(op, l.value, r.value) };
+    const comparison = compareLuaByteStrings(l.value, r.value);
+    return { kind: "boolean", value: compareValues(op, comparison, 0) };
   }
   // 数値と文字列の比較はLuaでは実行時エラーなので、畳み込んでエラーを消さない。
   if (!isNumeric(l) || !isNumeric(r)) return undefined;
@@ -449,7 +439,11 @@ function valuesEqual(l: ConstantValue, r: ConstantValue): boolean | undefined {
     return l.kind === "boolean" && r.kind === "boolean" && l.value === r.value;
   }
   if (l.kind === "string" || r.kind === "string") {
-    return l.kind === "string" && r.kind === "string" && l.value === r.value;
+    return (
+      l.kind === "string" &&
+      r.kind === "string" &&
+      luaByteStringKey(l.value) === luaByteStringKey(r.value)
+    );
   }
   if (l.kind === "int" && r.kind === "int") return l.value === r.value;
   if (l.kind === "float" && r.kind === "float") return l.value === r.value;
@@ -464,12 +458,12 @@ function evalConcat(
 ): ConstantValue | undefined {
   // 両辺が文字列定数のときだけ。数値との連結は対象外（1と1.0で表記が変わるため）。
   if (l.kind !== "string" || r.kind !== "string") return undefined;
-  const combined = l.value + r.value;
-  const useDouble = !combined.includes('"');
-  const useSingle = !combined.includes("'");
-  if (!useDouble && !useSingle) return undefined; // どちらの引用符も含むなら畳み込まない
-  const quote = useDouble ? '"' : "'";
-  return { kind: "string", value: combined, raw: quote + combined + quote };
+  const combined = concatLuaByteStrings(l.value, r.value);
+  return {
+    kind: "string",
+    value: combined,
+    raw: encodeLuaByteString(combined),
+  };
 }
 
 function isTruthy(v: ConstantValue): boolean {
@@ -594,12 +588,13 @@ function tryFoldUnary(
       expr,
     );
   }
-  // 残るのは`#`。Luaの`#`は文字列のバイト長を返す。定数として認めた文字列は
-  // エスケープを含まない印字可能ASCIIだけなので、1文字が1バイトに対応し、
-  // そのまま長さになる。テーブルへの`#`は要素数の解釈が実行時に決まるので
-  // 対象外（そもそもテーブルは定数として認めていない）。
+  // 残るのは`#`。Lua stringは共有decoderが返すbyte列なので、JavaScriptの
+  // code unit数ではなくbyte数を使う。tableへの`#`は実行時に決まるため対象外。
   if (v.kind !== "string") return undefined;
-  return literalNodeFor({ kind: "int", value: BigInt(v.value.length) }, expr);
+  return literalNodeFor(
+    { kind: "int", value: BigInt(v.value.bytes.length) },
+    expr,
+  );
 }
 
 // ============================================================
@@ -684,7 +679,7 @@ function printedLengthOf(value: ConstantValue): number {
       return (value.value < 0 ? 1 : 0) + raw.length;
     }
     case "string":
-      return value.raw.length; // 引用符込み
+      return new TextEncoder().encode(value.raw).length;
   }
 }
 

--- a/src/controlFlow.ts
+++ b/src/controlFlow.ts
@@ -24,17 +24,35 @@ export interface LinearRegion {
   readonly certified: true;
 }
 
+export interface ControlFlowEdge {
+  readonly from: ControlFlowNode;
+  readonly to: ControlFlowNode;
+  readonly kind: "entry" | "fallthrough" | "unknown" | "exit";
+}
+
+export interface ControlFlowNode {
+  readonly id: number;
+  readonly unit: ExecutionUnit;
+  readonly kind: "entry" | "statement" | "opaque" | "exit";
+  readonly statement?: Parser.Statement;
+  readonly successors: readonly ControlFlowEdge[];
+  readonly predecessors: readonly ControlFlowEdge[];
+}
+
 export interface ControlFlowAnalysis {
   readonly version: number;
   readonly complete: false;
   readonly units: readonly ExecutionUnit[];
   readonly regions: readonly LinearRegion[];
+  readonly nodes: readonly ControlFlowNode[];
   pointOf(statement: Parser.Statement): ProgramPoint | undefined;
+  nodeOf(statement: Parser.Statement): ControlFlowNode | undefined;
   regionOf(statement: Parser.Statement): LinearRegion | undefined;
   pointsBetween(
     first: Parser.Statement,
     last: Parser.Statement,
   ): readonly ProgramPoint[] | undefined;
+  dominates(first: Parser.Statement, last: Parser.Statement): boolean;
 }
 
 export function analyzeControlFlow(
@@ -43,10 +61,44 @@ export function analyzeControlFlow(
 ): ControlFlowAnalysis {
   const units: ExecutionUnit[] = [];
   const regions: LinearRegion[] = [];
+  const nodes: ControlFlowNode[] = [];
   const pointByStatement = new WeakMap<Parser.Statement, ProgramPoint>();
   const regionByStatement = new WeakMap<Parser.Statement, LinearRegion>();
+  const nodeByStatement = new WeakMap<Parser.Statement, ControlFlowNode>();
   let nextUnitId = 0;
   let nextRegionId = 0;
+  let nextNodeId = 0;
+
+  type MutableNode = Omit<ControlFlowNode, "successors" | "predecessors"> & {
+    successors: ControlFlowEdge[];
+    predecessors: ControlFlowEdge[];
+  };
+  const node = (
+    unit: ExecutionUnit,
+    kind: ControlFlowNode["kind"],
+    statement?: Parser.Statement,
+  ): MutableNode => {
+    const created: MutableNode = {
+      id: nextNodeId++,
+      unit,
+      kind,
+      ...(statement ? { statement } : {}),
+      successors: [],
+      predecessors: [],
+    };
+    nodes.push(created);
+    if (statement) nodeByStatement.set(statement, created);
+    return created;
+  };
+  const connect = (
+    from: MutableNode,
+    to: MutableNode,
+    kind: ControlFlowEdge["kind"],
+  ) => {
+    const edge: ControlFlowEdge = { from, to, kind };
+    from.successors.push(edge);
+    to.predecessors.push(edge);
+  };
 
   const analyzeBody = (body: Parser.Statement[], unit: ExecutionUnit) => {
     let pending: ProgramPoint[] = [];
@@ -108,6 +160,27 @@ export function analyzeControlFlow(
     };
     units.push(unit);
     analyzeBody(body, unit);
+    const entry = node(unit, "entry");
+    const exit = node(unit, "exit");
+    let previous = entry;
+    body.forEach((statement) => {
+      const current = node(
+        unit,
+        isCertifiedLinearStatement(statement) ? "statement" : "opaque",
+        statement,
+      );
+      connect(
+        previous,
+        current,
+        previous === entry
+          ? "entry"
+          : previous.kind === "statement" && current.kind === "statement"
+            ? "fallthrough"
+            : "unknown",
+      );
+      previous = current;
+    });
+    connect(previous, exit, previous.kind === "statement" ? "exit" : "unknown");
   };
 
   analyzeUnit(chunk.body, "chunk");
@@ -116,7 +189,9 @@ export function analyzeControlFlow(
     complete: false,
     units,
     regions,
+    nodes,
     pointOf: (statement) => pointByStatement.get(statement),
+    nodeOf: (statement) => nodeByStatement.get(statement),
     regionOf: (statement) => regionByStatement.get(statement),
     pointsBetween: (first, last) => {
       const firstRegion = regionByStatement.get(first);
@@ -132,6 +207,19 @@ export function analyzeControlFlow(
       return from >= 0 && to >= from
         ? firstRegion.points.slice(from, to + 1)
         : undefined;
+    },
+    dominates: (first, last) => {
+      const firstRegion = regionByStatement.get(first);
+      if (!firstRegion || firstRegion !== regionByStatement.get(last)) {
+        return false;
+      }
+      const firstIndex = firstRegion.points.findIndex(
+        (point) => point.statement === first,
+      );
+      const lastIndex = firstRegion.points.findIndex(
+        (point) => point.statement === last,
+      );
+      return firstIndex >= 0 && lastIndex >= firstIndex;
     },
   };
 }

--- a/src/controlFlow.ts
+++ b/src/controlFlow.ts
@@ -1,0 +1,181 @@
+import Parser from "luaparse";
+import { walkStatement } from "./astWalk";
+
+export interface ExecutionUnit {
+  readonly id: number;
+  readonly kind: "chunk" | "function";
+  readonly body: Parser.Statement[];
+  readonly owner?: Parser.FunctionDeclaration;
+  readonly parent?: ExecutionUnit;
+}
+
+export interface ProgramPoint {
+  readonly unit: ExecutionUnit;
+  readonly body: Parser.Statement[];
+  readonly index: number;
+  readonly statement: Parser.Statement;
+}
+
+export interface LinearRegion {
+  readonly id: number;
+  readonly unit: ExecutionUnit;
+  readonly body: Parser.Statement[];
+  readonly points: readonly ProgramPoint[];
+  readonly certified: true;
+}
+
+export interface ControlFlowAnalysis {
+  readonly version: number;
+  readonly complete: false;
+  readonly units: readonly ExecutionUnit[];
+  readonly regions: readonly LinearRegion[];
+  pointOf(statement: Parser.Statement): ProgramPoint | undefined;
+  regionOf(statement: Parser.Statement): LinearRegion | undefined;
+  pointsBetween(
+    first: Parser.Statement,
+    last: Parser.Statement,
+  ): readonly ProgramPoint[] | undefined;
+}
+
+export function analyzeControlFlow(
+  chunk: Parser.Chunk,
+  version = 0,
+): ControlFlowAnalysis {
+  const units: ExecutionUnit[] = [];
+  const regions: LinearRegion[] = [];
+  const pointByStatement = new WeakMap<Parser.Statement, ProgramPoint>();
+  const regionByStatement = new WeakMap<Parser.Statement, LinearRegion>();
+  let nextUnitId = 0;
+  let nextRegionId = 0;
+
+  const analyzeBody = (body: Parser.Statement[], unit: ExecutionUnit) => {
+    let pending: ProgramPoint[] = [];
+    const flush = () => {
+      if (pending.length === 0) return;
+      const region: LinearRegion = {
+        id: nextRegionId++,
+        unit,
+        body,
+        points: pending,
+        certified: true,
+      };
+      regions.push(region);
+      pending.forEach((point) =>
+        regionByStatement.set(point.statement, region),
+      );
+      pending = [];
+    };
+
+    body.forEach((statement, index) => {
+      if (isCertifiedLinearStatement(statement)) {
+        const point: ProgramPoint = { unit, body, index, statement };
+        pending.push(point);
+        pointByStatement.set(statement, point);
+      } else {
+        flush();
+      }
+
+      const nestedFunctions: Parser.FunctionDeclaration[] = [];
+      walkStatement(statement, {
+        onFunction: (fn) => {
+          nestedFunctions.push(fn);
+        },
+      });
+      nestedFunctions.forEach((fn) => {
+        analyzeUnit(fn.body, "function", unit, fn);
+      });
+      if (statement.type !== "FunctionDeclaration") {
+        childBodiesOfStatement(statement).forEach((child) => {
+          analyzeBody(child, unit);
+        });
+      }
+    });
+    flush();
+  };
+
+  const analyzeUnit = (
+    body: Parser.Statement[],
+    kind: ExecutionUnit["kind"],
+    parent?: ExecutionUnit,
+    owner?: Parser.FunctionDeclaration,
+  ) => {
+    const unit: ExecutionUnit = {
+      id: nextUnitId++,
+      kind,
+      body,
+      ...(parent ? { parent } : {}),
+      ...(owner ? { owner } : {}),
+    };
+    units.push(unit);
+    analyzeBody(body, unit);
+  };
+
+  analyzeUnit(chunk.body, "chunk");
+  return {
+    version,
+    complete: false,
+    units,
+    regions,
+    pointOf: (statement) => pointByStatement.get(statement),
+    regionOf: (statement) => regionByStatement.get(statement),
+    pointsBetween: (first, last) => {
+      const firstRegion = regionByStatement.get(first);
+      if (!firstRegion || firstRegion !== regionByStatement.get(last)) {
+        return undefined;
+      }
+      const from = firstRegion.points.findIndex(
+        (point) => point.statement === first,
+      );
+      const to = firstRegion.points.findIndex(
+        (point) => point.statement === last,
+      );
+      return from >= 0 && to >= from
+        ? firstRegion.points.slice(from, to + 1)
+        : undefined;
+    },
+  };
+}
+
+export function childStatementBodies(
+  body: readonly Parser.Statement[],
+): Parser.Statement[][] {
+  return body.flatMap(childBodiesOfStatement);
+}
+
+function isCertifiedLinearStatement(statement: Parser.Statement): boolean {
+  return (
+    statement.type === "LocalStatement" ||
+    statement.type === "AssignmentStatement" ||
+    statement.type === "CallStatement"
+  );
+}
+
+function childBodiesOfStatement(
+  statement: Parser.Statement,
+): Parser.Statement[][] {
+  switch (statement.type) {
+    case "DoStatement":
+    case "WhileStatement":
+    case "RepeatStatement":
+    case "ForNumericStatement":
+    case "ForGenericStatement":
+      return [statement.body];
+    case "IfStatement":
+      return statement.clauses.map((clause) => clause.body);
+    case "FunctionDeclaration":
+    case "LocalStatement":
+    case "AssignmentStatement":
+    case "CallStatement":
+    case "ReturnStatement":
+    case "BreakStatement":
+    case "LabelStatement":
+    case "GotoStatement":
+      return [];
+    default: {
+      const exhaustive: never = statement;
+      throw new TypeError(
+        `Unknown statement type: ${JSON.stringify(exhaustive)}`,
+      );
+    }
+  }
+}

--- a/src/effectAnalysis.ts
+++ b/src/effectAnalysis.ts
@@ -1,0 +1,197 @@
+import Parser from "luaparse";
+import { walkExpression } from "./astWalk";
+import { GlobalBinding, ResolveResult, Symbol } from "./resolver";
+
+export type BindingReference =
+  | { readonly kind: "symbol"; readonly symbol: Symbol }
+  | { readonly kind: "global"; readonly binding: GlobalBinding };
+
+export interface BindingEffect {
+  readonly kind: "binding";
+  readonly access: "declare" | "read" | "write";
+  readonly binding: BindingReference;
+  readonly identifier: Parser.Identifier;
+  // owner内のfactsは全順序を表さない。Luaが評価順を規定しない部分を、
+  // plannerが配列順だけで並べ替え可能と判断しないための境界である。
+  readonly owner: Parser.Node;
+}
+
+export interface EffectAnalysis {
+  readonly effects: readonly BindingEffect[];
+  effectsOf(owner: Parser.Node): readonly BindingEffect[];
+  accessesOf(symbol: Symbol): readonly BindingEffect[];
+}
+
+/**
+ * 名前解決済みASTから、bindingに対する構文上の一次事実だけを収集する。
+ * escape/dirty等の推論は、変換ごとに必要な保守性が異なるため後段で行う。
+ */
+export function analyzeBindingEffects(
+  chunk: Parser.Chunk,
+  resolved: ResolveResult,
+): EffectAnalysis {
+  const effects: BindingEffect[] = [];
+  const byOwner = new WeakMap<Parser.Node, BindingEffect[]>();
+  const bySymbol = new Map<Symbol, BindingEffect[]>();
+
+  function bindingOf(identifier: Parser.Identifier): BindingReference {
+    const symbol = resolved.symbolOf(identifier);
+    if (symbol) return { kind: "symbol", symbol };
+    if (resolved.isGlobalReference(identifier)) {
+      const binding = resolved.globals.get(identifier.name);
+      if (binding) return { kind: "global", binding };
+    }
+    throw new TypeError(
+      "Identifier is neither a binding nor a global reference",
+    );
+  }
+
+  function record(
+    access: BindingEffect["access"],
+    identifier: Parser.Identifier,
+    owner: Parser.Node,
+  ): void {
+    const binding = bindingOf(identifier);
+    const effect: BindingEffect = {
+      kind: "binding",
+      access,
+      binding,
+      identifier,
+      owner,
+    };
+    effects.push(effect);
+    const ownerEffects = byOwner.get(owner) ?? [];
+    ownerEffects.push(effect);
+    byOwner.set(owner, ownerEffects);
+    if (binding.kind === "symbol") {
+      const symbolEffects = bySymbol.get(binding.symbol) ?? [];
+      symbolEffects.push(effect);
+      bySymbol.set(binding.symbol, symbolEffects);
+    }
+  }
+
+  function analyzeFunction(fn: Parser.FunctionDeclaration): void {
+    fn.parameters.forEach((parameter) => {
+      if (parameter.type === "Identifier") {
+        record("declare", parameter, fn);
+      }
+    });
+    analyzeBlock(fn.body);
+  }
+
+  function recordReads(
+    expression: Parser.Expression,
+    owner: Parser.Node,
+  ): void {
+    walkExpression(expression, {
+      onIdentifierReference: (identifier) => {
+        record("read", identifier, owner);
+      },
+      onFunction: analyzeFunction,
+    });
+  }
+
+  function analyzeStatement(statement: Parser.Statement): void {
+    switch (statement.type) {
+      case "LocalStatement":
+        statement.init.forEach((expression) => {
+          recordReads(expression, statement);
+        });
+        statement.variables.forEach((variable) => {
+          record("declare", variable, statement);
+        });
+        return;
+      case "AssignmentStatement":
+        statement.init.forEach((expression) => {
+          recordReads(expression, statement);
+        });
+        statement.variables.forEach((variable) => {
+          if (variable.type === "Identifier") {
+            record("write", variable, statement);
+          } else {
+            // base/indexの評価はheap writeとは別のbinding readである。
+            recordReads(variable, statement);
+          }
+        });
+        return;
+      case "CallStatement":
+        recordReads(statement.expression, statement);
+        return;
+      case "DoStatement":
+        analyzeBlock(statement.body);
+        return;
+      case "WhileStatement":
+        recordReads(statement.condition, statement);
+        analyzeBlock(statement.body);
+        return;
+      case "RepeatStatement":
+        analyzeBlock(statement.body);
+        recordReads(statement.condition, statement);
+        return;
+      case "IfStatement":
+        statement.clauses.forEach((clause) => {
+          if (clause.type !== "ElseClause") {
+            recordReads(clause.condition, statement);
+          }
+          analyzeBlock(clause.body);
+        });
+        return;
+      case "ForNumericStatement":
+        recordReads(statement.start, statement);
+        recordReads(statement.end, statement);
+        if (statement.step) recordReads(statement.step, statement);
+        record("declare", statement.variable, statement);
+        analyzeBlock(statement.body);
+        return;
+      case "ForGenericStatement":
+        statement.iterators.forEach((iterator) => {
+          recordReads(iterator, statement);
+        });
+        statement.variables.forEach((variable) => {
+          record("declare", variable, statement);
+        });
+        analyzeBlock(statement.body);
+        return;
+      case "FunctionDeclaration":
+        if (statement.identifier) {
+          if (statement.identifier.type === "Identifier") {
+            record(
+              statement.isLocal ? "declare" : "write",
+              statement.identifier,
+              statement,
+            );
+          } else {
+            recordReads(statement.identifier, statement);
+          }
+        }
+        analyzeFunction(statement);
+        return;
+      case "ReturnStatement":
+        statement.arguments.forEach((argument) => {
+          recordReads(argument, statement);
+        });
+        return;
+      case "BreakStatement":
+      case "LabelStatement":
+      case "GotoStatement":
+        return;
+      default: {
+        const exhaustive: never = statement;
+        throw new TypeError(
+          "Unknown statement type: `" + JSON.stringify(exhaustive) + "`",
+        );
+      }
+    }
+  }
+
+  function analyzeBlock(body: Parser.Statement[]): void {
+    body.forEach(analyzeStatement);
+  }
+
+  analyzeBlock(chunk.body);
+  return {
+    effects,
+    effectsOf: (owner) => byOwner.get(owner) ?? [],
+    accessesOf: (symbol) => bySymbol.get(symbol) ?? [],
+  };
+}

--- a/src/generatedNode.ts
+++ b/src/generatedNode.ts
@@ -1,0 +1,25 @@
+import Parser from "luaparse";
+
+function rangeOf(node: object): [number, number] | undefined {
+  return (node as { range?: [number, number] }).range;
+}
+
+/** 合成・複製したAST nodeへSource Map上の由来位置を引き継ぐ。 */
+export function copyNodeOrigin(node: Parser.Node, origin: Parser.Node): void {
+  node.loc = origin.loc;
+  const range = rangeOf(origin);
+  if (range) {
+    (node as { range?: [number, number] }).range = range;
+  }
+}
+
+export function identifierWithOrigin(
+  origin: Parser.Identifier,
+): Parser.Identifier {
+  const identifier: Parser.Identifier = {
+    type: "Identifier",
+    name: origin.name,
+  };
+  copyNodeOrigin(identifier, origin);
+  return identifier;
+}

--- a/src/luaString.ts
+++ b/src/luaString.ts
@@ -123,6 +123,51 @@ export function luaByteStringKey(value: LuaByteString): string {
   ).join("");
 }
 
+export function compareLuaByteStrings(
+  left: LuaByteString,
+  right: LuaByteString,
+): number {
+  const length = Math.min(left.bytes.length, right.bytes.length);
+  for (let index = 0; index < length; index++) {
+    if (left.bytes[index] !== right.bytes[index]) {
+      return left.bytes[index] - right.bytes[index];
+    }
+  }
+  return left.bytes.length - right.bytes.length;
+}
+
+export function concatLuaByteStrings(
+  left: LuaByteString,
+  right: LuaByteString,
+): LuaByteString {
+  const bytes = new Uint8Array(left.bytes.length + right.bytes.length);
+  bytes.set(left.bytes);
+  bytes.set(right.bytes, left.bytes.length);
+  return { bytes };
+}
+
+/** 任意のLua byte列を、再decode可能な決定論的quoted literalへ戻す。 */
+export function encodeLuaByteString(value: LuaByteString): string {
+  const encodeWith = (quote: number): string => {
+    let raw = String.fromCharCode(quote);
+    value.bytes.forEach((byte) => {
+      if (byte === quote || byte === 0x5c) {
+        raw += `\\${String.fromCharCode(byte)}`;
+      } else if (byte >= 0x20 && byte <= 0x7e) {
+        raw += String.fromCharCode(byte);
+      } else {
+        raw += `\\x${byte.toString(16).padStart(2, "0")}`;
+      }
+    });
+    return raw + String.fromCharCode(quote);
+  };
+  const doubleQuoted = encodeWith(0x22);
+  const singleQuoted = encodeWith(0x27);
+  return singleQuoted.length < doubleQuoted.length
+    ? singleQuoted
+    : doubleQuoted;
+}
+
 const SIMPLE_ESCAPES: Readonly<Partial<Record<string, number>>> = {
   a: 0x07,
   b: 0x08,

--- a/src/luaString.ts
+++ b/src/luaString.ts
@@ -1,0 +1,137 @@
+import Parser from "luaparse";
+
+export interface LuaByteString {
+  readonly bytes: Uint8Array;
+}
+
+export type LuaStringDecodeResult =
+  | { readonly ok: true; readonly value: LuaByteString }
+  | {
+      readonly ok: false;
+      readonly reason:
+        | "invalid-delimiter"
+        | "invalid-escape"
+        | "out-of-range-byte"
+        | "invalid-code-point";
+    };
+
+const encoder = new TextEncoder();
+
+export function luaByteStringOfText(text: string): LuaByteString {
+  return { bytes: encoder.encode(text) };
+}
+
+export function decodeLuaStringLiteral(
+  node: Parser.StringLiteral,
+): LuaStringDecodeResult {
+  const raw = node.raw;
+  const long = /^\[(=*)\[/.exec(raw);
+  if (long) {
+    const close = `]${long[1]}]`;
+    if (!raw.endsWith(close)) {
+      return { ok: false, reason: "invalid-delimiter" };
+    }
+    let value = raw.slice(long[0].length, -close.length);
+    value = value.replace(/\r\n|\r/g, "\n");
+    if (value.startsWith("\n")) value = value.slice(1);
+    return { ok: true, value: luaByteStringOfText(value) };
+  }
+
+  const quote = raw[0];
+  if (
+    raw.length < 2 ||
+    (quote !== '"' && quote !== "'") ||
+    raw[raw.length - 1] !== quote
+  ) {
+    return { ok: false, reason: "invalid-delimiter" };
+  }
+
+  const bytes: number[] = [];
+  const appendText = (text: string) => bytes.push(...encoder.encode(text));
+  for (let index = 1; index < raw.length - 1; index++) {
+    const current = raw[index];
+    if (current !== "\\") {
+      const codePoint = raw.codePointAt(index);
+      if (codePoint === undefined) {
+        return { ok: false, reason: "invalid-code-point" };
+      }
+      appendText(String.fromCodePoint(codePoint));
+      if (codePoint > 0xffff) index++;
+      continue;
+    }
+
+    index++;
+    if (index >= raw.length - 1) {
+      return { ok: false, reason: "invalid-escape" };
+    }
+    const escaped = raw[index];
+    const simple = SIMPLE_ESCAPES[escaped];
+    if (simple !== undefined) {
+      bytes.push(simple);
+      continue;
+    }
+    if (escaped === "\n" || escaped === "\r") {
+      if (escaped === "\r" && raw[index + 1] === "\n") index++;
+      bytes.push(0x0a);
+      continue;
+    }
+    if (escaped === "z") {
+      while (/\s/.test(raw[index + 1] ?? "")) index++;
+      continue;
+    }
+    if (escaped === "x") {
+      const hex = raw.slice(index + 1, index + 3);
+      if (!/^[0-9a-fA-F]{2}$/.test(hex)) {
+        return { ok: false, reason: "invalid-escape" };
+      }
+      bytes.push(Number.parseInt(hex, 16));
+      index += 2;
+      continue;
+    }
+    if (escaped === "u") {
+      const match = /^\{([0-9a-fA-F]+)\}/.exec(raw.slice(index + 1));
+      if (!match) return { ok: false, reason: "invalid-escape" };
+      const codePoint = Number.parseInt(match[1], 16);
+      if (
+        codePoint > 0x10ffff ||
+        (codePoint >= 0xd800 && codePoint <= 0xdfff)
+      ) {
+        return { ok: false, reason: "invalid-code-point" };
+      }
+      appendText(String.fromCodePoint(codePoint));
+      index += match[0].length;
+      continue;
+    }
+    if (/\d/.test(escaped)) {
+      let digits = escaped;
+      while (digits.length < 3 && /\d/.test(raw[index + 1] ?? "")) {
+        digits += raw[++index];
+      }
+      const byte = Number.parseInt(digits, 10);
+      if (byte > 255) return { ok: false, reason: "out-of-range-byte" };
+      bytes.push(byte);
+      continue;
+    }
+    return { ok: false, reason: "invalid-escape" };
+  }
+  return { ok: true, value: { bytes: Uint8Array.from(bytes) } };
+}
+
+export function luaByteStringKey(value: LuaByteString): string {
+  return Array.from(value.bytes, (byte) =>
+    byte.toString(16).padStart(2, "0"),
+  ).join("");
+}
+
+const SIMPLE_ESCAPES: Readonly<Partial<Record<string, number>>> = {
+  a: 0x07,
+  b: 0x08,
+  f: 0x0c,
+  n: 0x0a,
+  r: 0x0d,
+  t: 0x09,
+  v: 0x0b,
+  "\\": 0x5c,
+  '"': 0x22,
+  "'": 0x27,
+};

--- a/src/minifier.ts
+++ b/src/minifier.ts
@@ -12,9 +12,24 @@ import { SourceMetadata } from "./sourceMetadata";
 import { removeUnusedLocals } from "./removeUnused";
 import { foldConstants } from "./constantFold";
 import { buildRequireWrapperAst, GeneratedStatement } from "./generatedAst";
+import {
+  applyNonAdjacentLocalPlan,
+  planNonAdjacentLocals,
+} from "./nonAdjacentLocals";
+
+export type RuntimeProfile = "lua53" | "stormworks";
 
 export interface MinifierMode {
   moduleLikeLua: boolean;
+  // 実行環境の意味論。moduleLikeLua（require出力方式）とは独立。
+  // 省略時は後方互換のためlua53として扱う。
+  runtimeProfile?: RuntimeProfile;
+  // 選択環境で意味を保存する効果解析Transformのmaster opt-out。
+  // Stormworks profileでは省略時に有効。
+  effectAwareTransforms?: boolean;
+  // 純Luaでdebug APIから観測できるlocal lifetimeの変更を許可するopt-in。
+  // Stormworksではdebug introspectionを前提にしないため指定不要。
+  allowLocalLifetimeChanges?: boolean;
   // 字句の結合を防ぐために必要な1バイトの空白。省略時は、出力サイズを
   // 増やさずStormworksの行単位診断を改善できるLFを使う。
   requiredWhitespace?: " " | "\n";
@@ -230,6 +245,9 @@ export class Minifier {
       ...(this.mode.neverRenameGlobals ?? []),
       ...this.annotationProtectedGlobals(),
     ]);
+    // renameAllと同じmodule順・予約名更新で仮Renameを行い、plannerのbyte costを
+    // 実際の出力名長に対する保守的な見積りにする。
+    const plannedIdentifiersInUse = new Set(this.identifiersInUse);
     this.linkOrder.forEach((moduleName) => {
       const ast = this.moduleAST.get(moduleName);
       let resolved = this.moduleResolve.get(moduleName);
@@ -244,6 +262,43 @@ export class Minifier {
         resolved = resolveScopes(ast);
       }
 
+      const keepNames = new Set(
+        resolved.symbols.filter(
+          (symbol) =>
+            this.getSourceMetadata(moduleName).annotationsOfIdentifier(
+              symbol.declaration,
+            ).keepName,
+        ),
+      );
+      const effectAwareLocalsEnabled =
+        this.mode.effectAwareTransforms !== false &&
+        (this.mode.runtimeProfile === "stormworks" ||
+          this.mode.allowLocalLifetimeChanges === true);
+      if (effectAwareLocalsEnabled) {
+        const provisionalRenames =
+          this.mode.rename === false
+            ? NO_RENAME
+            : assignRenames(
+                resolved,
+                plannedIdentifiersInUse,
+                this.globalRenames,
+                keepNames,
+              );
+        const plan = planNonAdjacentLocals(ast, resolved, {
+          outputNameLengthOf: (symbol) =>
+            (provisionalRenames.nameOf(symbol.declaration) ?? symbol.name)
+              .length,
+          preserveRequireSplice: !this.mode.moduleLikeLua,
+        });
+        const transformed = applyNonAdjacentLocalPlan(
+          plan,
+          this.getSourceMetadata(moduleName),
+        );
+        if (transformed.invalidatesResolve) {
+          resolved = resolveScopes(ast);
+        }
+      }
+
       if (this.mode.mergeLocals !== false) {
         mergeLocalDeclarations(
           ast,
@@ -256,6 +311,22 @@ export class Minifier {
       }
 
       this.moduleResolve.set(moduleName, resolved);
+      if (this.mode.rename !== false) {
+        const finalKeepNames = new Set(
+          resolved.symbols.filter(
+            (symbol) =>
+              this.getSourceMetadata(moduleName).annotationsOfIdentifier(
+                symbol.declaration,
+              ).keepName,
+          ),
+        );
+        assignRenames(
+          resolved,
+          plannedIdentifiersInUse,
+          this.globalRenames,
+          finalKeepNames,
+        ).usedNames.forEach((name) => plannedIdentifiersInUse.add(name));
+      }
     });
   }
 

--- a/src/minifier.ts
+++ b/src/minifier.ts
@@ -20,6 +20,10 @@ import { analyzeTableEffects } from "./tableEffects";
 import { applyTableReadMergePlan, planTableReadMerges } from "./tableReadMerge";
 import { PassOrchestrator } from "./optimizerPass";
 import { RuntimeProfile, runtimeEnvironmentOf } from "./runtimeEnvironment";
+import {
+  OptimizationDiagnostic,
+  OptimizationDiagnosticCollector,
+} from "./optimizerDiagnostics";
 
 export type { RuntimeProfile } from "./runtimeEnvironment";
 
@@ -63,6 +67,8 @@ export interface MinifierMode {
   removeUnusedGlobals?: boolean;
   // 定数式の事前計算と、定数ローカル変数の伝搬。省略時はfalse扱い（明示的に有効化する）。
   foldConstants?: boolean;
+  // 最適化候補の採否理由を収集する。既定offで、生成結果には影響しない。
+  collectOptimizationDiagnostics?: boolean;
 }
 
 const NO_RENAME: RenameResult = {
@@ -89,6 +95,7 @@ export class Minifier {
   // #8a: プログラム全体を横断して決定された「内部グローバル名 -> 短縮名」の対応
   private globalRenames = new Map<string, string>();
   private readonly moduleMetadata = new Map<string, SourceMetadata>();
+  private readonly diagnosticCollector?: OptimizationDiagnosticCollector;
 
   constructor(
     entryFilePath: string,
@@ -108,9 +115,16 @@ export class Minifier {
       ranges: true,
     };
     this.mode = mode;
+    if (mode.collectOptimizationDiagnostics) {
+      this.diagnosticCollector = new OptimizationDiagnosticCollector();
+    }
     const pn = path.parse(entryFilePath);
     this.dir = pn.dir;
     this.entryModule = pn.name;
+  }
+
+  get optimizationDiagnostics(): readonly OptimizationDiagnostic[] {
+    return this.diagnosticCollector?.diagnostics ?? [];
   }
 
   parse(): SourceNode {
@@ -305,6 +319,8 @@ export class Minifier {
               maxMergeArity: runtimeEnvironmentOf(
                 this.mode.runtimeProfile ?? "lua53",
               ).resources.conservativeParallelValueLimit,
+              diagnostics: this.diagnosticCollector,
+              moduleName,
             },
           );
           return applyTableReadMergePlan(
@@ -342,6 +358,8 @@ export class Minifier {
               (provisionalRenames.nameOf(symbol.declaration) ?? symbol.name)
                 .length,
             preserveRequireSplice: !this.mode.moduleLikeLua,
+            diagnostics: this.diagnosticCollector,
+            moduleName,
           });
           return applyNonAdjacentLocalPlan(
             plan,

--- a/src/minifier.ts
+++ b/src/minifier.ts
@@ -16,6 +16,9 @@ import {
   applyNonAdjacentLocalPlan,
   planNonAdjacentLocals,
 } from "./nonAdjacentLocals";
+import { analyzeBindingEffects } from "./effectAnalysis";
+import { analyzeTableEffects } from "./tableEffects";
+import { applyTableReadMergePlan, planTableReadMerges } from "./tableReadMerge";
 
 export type RuntimeProfile = "lua53" | "stormworks";
 
@@ -27,6 +30,12 @@ export interface MinifierMode {
   // 選択環境で意味を保存する効果解析Transformのmaster opt-out。
   // Stormworks profileでは省略時に有効。
   effectAwareTransforms?: boolean;
+  // RHSを元位置に残す非連続local宣言hoistの個別opt-out。
+  effectAwareLocalHoist?: boolean;
+  // fresh・nonescape tableの安定したreadを含むlocal mergeの個別opt-out。
+  effectAwareTableReads?: boolean;
+  // table全体ではなくstatic key単位でdirtyを追跡する精密化の個別opt-out。
+  fieldSensitiveTableEffects?: boolean;
   // 純Luaでdebug APIから観測できるlocal lifetimeの変更を許可するopt-in。
   // Stormworksではdebug introspectionを前提にしないため指定不要。
   allowLocalLifetimeChanges?: boolean;
@@ -262,6 +271,34 @@ export class Minifier {
         resolved = resolveScopes(ast);
       }
 
+      const effectAwareLocalsEnabled =
+        this.mode.effectAwareTransforms !== false &&
+        (this.mode.runtimeProfile === "stormworks" ||
+          this.mode.allowLocalLifetimeChanges === true);
+      if (
+        effectAwareLocalsEnabled &&
+        this.mode.effectAwareTableReads !== false
+      ) {
+        const tablePlan = planTableReadMerges(
+          ast,
+          analyzeBindingEffects(ast, resolved),
+          analyzeTableEffects(ast, resolved),
+          {
+            dirtyGranularity:
+              this.mode.fieldSensitiveTableEffects === false
+                ? "table"
+                : "static-key",
+          },
+        );
+        const transformed = applyTableReadMergePlan(
+          tablePlan,
+          this.getSourceMetadata(moduleName),
+        );
+        if (transformed.invalidatesResolve) {
+          resolved = resolveScopes(ast);
+        }
+      }
+
       const keepNames = new Set(
         resolved.symbols.filter(
           (symbol) =>
@@ -270,11 +307,10 @@ export class Minifier {
             ).keepName,
         ),
       );
-      const effectAwareLocalsEnabled =
-        this.mode.effectAwareTransforms !== false &&
-        (this.mode.runtimeProfile === "stormworks" ||
-          this.mode.allowLocalLifetimeChanges === true);
-      if (effectAwareLocalsEnabled) {
+      if (
+        effectAwareLocalsEnabled &&
+        this.mode.effectAwareLocalHoist !== false
+      ) {
         const provisionalRenames =
           this.mode.rename === false
             ? NO_RENAME

--- a/src/minifier.ts
+++ b/src/minifier.ts
@@ -288,6 +288,17 @@ export class Minifier {
               this.mode.fieldSensitiveTableEffects === false
                 ? "table"
                 : "static-key",
+            canMoveStatement: (statement) => {
+              const metadata = this.getSourceMetadata(moduleName);
+              const annotations = metadata.annotationsOf(statement);
+              return (
+                metadata.beforeOf(statement).length === 0 &&
+                metadata.trailingOf(statement).length === 0 &&
+                !annotations.keep &&
+                !annotations.keepName &&
+                !annotations.exported
+              );
+            },
           },
         );
         const transformed = applyTableReadMergePlan(

--- a/src/minifier.ts
+++ b/src/minifier.ts
@@ -20,8 +20,9 @@ import { analyzeBindingEffects } from "./effectAnalysis";
 import { analyzeTableEffects } from "./tableEffects";
 import { applyTableReadMergePlan, planTableReadMerges } from "./tableReadMerge";
 import { PassOrchestrator } from "./optimizerPass";
+import { RuntimeProfile, runtimeEnvironmentOf } from "./runtimeEnvironment";
 
-export type RuntimeProfile = "lua53" | "stormworks";
+export type { RuntimeProfile } from "./runtimeEnvironment";
 
 export interface MinifierMode {
   moduleLikeLua: boolean;
@@ -303,6 +304,9 @@ export class Minifier {
                   !annotations.exported
                 );
               },
+              maxMergeArity: runtimeEnvironmentOf(
+                this.mode.runtimeProfile ?? "lua53",
+              ).resources.conservativeParallelValueLimit,
             },
           );
           return applyTableReadMergePlan(

--- a/src/minifier.ts
+++ b/src/minifier.ts
@@ -16,7 +16,6 @@ import {
   applyNonAdjacentLocalPlan,
   planNonAdjacentLocals,
 } from "./nonAdjacentLocals";
-import { analyzeBindingEffects } from "./effectAnalysis";
 import { analyzeTableEffects } from "./tableEffects";
 import { applyTableReadMergePlan, planTableReadMerges } from "./tableReadMerge";
 import { PassOrchestrator } from "./optimizerPass";
@@ -286,7 +285,6 @@ export class Minifier {
         passes.run("effect-aware-table-reads", (currentResolve) => {
           const tablePlan = planTableReadMerges(
             ast,
-            analyzeBindingEffects(ast, currentResolve),
             analyzeTableEffects(ast, currentResolve),
             {
               dirtyGranularity:

--- a/src/minifier.ts
+++ b/src/minifier.ts
@@ -19,7 +19,12 @@ import {
 import { analyzeTableEffects } from "./tableEffects";
 import { applyTableReadMergePlan, planTableReadMerges } from "./tableReadMerge";
 import { PassOrchestrator } from "./optimizerPass";
-import { RuntimeProfile, runtimeEnvironmentOf } from "./runtimeEnvironment";
+import {
+  analyzeLocalResourceUsage,
+  checkParallelEvaluation,
+  RuntimeProfile,
+  runtimeEnvironmentOf,
+} from "./runtimeEnvironment";
 import {
   OptimizationDiagnostic,
   OptimizationDiagnosticCollector,
@@ -279,18 +284,22 @@ export class Minifier {
         throw new Error(moduleName + " is not found");
       }
 
-      if (this.mode.rename !== false && this.mode.globalAlias !== false) {
-        insertGlobalAliases(ast, resolved, {
-          excludeNames: excludeGlobalNames,
-        });
-        resolved = resolveScopes(ast);
-      }
-
       const passes = new PassOrchestrator(ast, resolved);
+      if (this.mode.rename !== false && this.mode.globalAlias !== false) {
+        passes.run("global-alias", (currentResolve) => {
+          const changed = insertGlobalAliases(ast, currentResolve, {
+            excludeNames: excludeGlobalNames,
+          });
+          return { changed, invalidatesResolve: changed };
+        });
+      }
+      resolved = passes.resolved;
+      const runtime = runtimeEnvironmentOf(this.mode.runtimeProfile ?? "lua53");
+      const localResources = analyzeLocalResourceUsage(ast);
 
       const effectAwareLocalsEnabled =
         this.mode.effectAwareTransforms !== false &&
-        (this.mode.runtimeProfile === "stormworks" ||
+        (!runtime.semantics.debugLocalIntrospection ||
           this.mode.allowLocalLifetimeChanges === true);
       if (
         effectAwareLocalsEnabled &&
@@ -316,11 +325,18 @@ export class Minifier {
                   !annotations.exported
                 );
               },
-              maxMergeArity: runtimeEnvironmentOf(
-                this.mode.runtimeProfile ?? "lua53",
-              ).resources.conservativeParallelValueLimit,
+              maxMergeArity: runtime.resources.conservativeParallelValueLimit,
+              maxMergeArityAt: (statement) =>
+                checkParallelEvaluation(runtime, {
+                  activeLocalsBefore:
+                    localResources.activeLocalsBefore(statement) ??
+                    runtime.resources.maxActiveLocalsPerFunction,
+                  parallelValueCount:
+                    runtime.resources.conservativeParallelValueLimit,
+                }).limit,
               diagnostics: this.diagnosticCollector,
               moduleName,
+              runtimeProfile: runtime.profile,
             },
           );
           return applyTableReadMergePlan(
@@ -360,6 +376,7 @@ export class Minifier {
             preserveRequireSplice: !this.mode.moduleLikeLua,
             diagnostics: this.diagnosticCollector,
             moduleName,
+            runtimeProfile: runtime.profile,
           });
           return applyNonAdjacentLocalPlan(
             plan,
@@ -370,16 +387,20 @@ export class Minifier {
 
       resolved = passes.resolved;
       if (this.mode.mergeLocals !== false) {
-        mergeLocalDeclarations(
-          ast,
-          resolved,
-          {
-            preserveRequireSplice: !this.mode.moduleLikeLua,
-          },
-          this.getSourceMetadata(moduleName),
-        );
+        passes.run("merge-local-declarations", (currentResolve) => ({
+          changed: mergeLocalDeclarations(
+            ast,
+            currentResolve,
+            {
+              preserveRequireSplice: !this.mode.moduleLikeLua,
+            },
+            this.getSourceMetadata(moduleName),
+          ),
+          invalidatesResolve: false,
+        }));
       }
 
+      resolved = passes.resolved;
       this.moduleResolve.set(moduleName, resolved);
       if (this.mode.rename !== false) {
         const finalKeepNames = new Set(
@@ -466,12 +487,18 @@ export class Minifier {
     if (this.mode.foldConstants !== true) return;
     this.linkOrder.forEach((moduleName) => {
       const ast = this.moduleAST.get(moduleName);
-      let resolved = this.moduleResolve.get(moduleName);
+      const resolved = this.moduleResolve.get(moduleName);
       if (!ast || !resolved) throw new Error(moduleName + " is not found");
-      while (foldConstants(ast, resolved, this.getSourceMetadata(moduleName))) {
-        resolved = resolveScopes(ast);
-      }
-      this.moduleResolve.set(moduleName, resolved);
+      const passes = new PassOrchestrator(ast, resolved);
+      passes.runUntilStable("fold-constants", (currentResolve) => {
+        const changed = foldConstants(
+          ast,
+          currentResolve,
+          this.getSourceMetadata(moduleName),
+        );
+        return { changed, invalidatesResolve: changed };
+      });
+      this.moduleResolve.set(moduleName, passes.resolved);
     });
   }
 
@@ -480,12 +507,14 @@ export class Minifier {
     this.linkOrder.forEach((moduleName) => {
       const ast = this.moduleAST.get(moduleName);
       const metadata = this.getSourceMetadata(moduleName);
-      let resolved = this.moduleResolve.get(moduleName);
+      const resolved = this.moduleResolve.get(moduleName);
       if (!ast || !resolved) throw new Error(moduleName + " is not found");
-      while (removeUnusedLocals(ast, resolved, metadata)) {
-        resolved = resolveScopes(ast);
-      }
-      this.moduleResolve.set(moduleName, resolved);
+      const passes = new PassOrchestrator(ast, resolved);
+      passes.runUntilStable("remove-unused", (currentResolve) => {
+        const changed = removeUnusedLocals(ast, currentResolve, metadata);
+        return { changed, invalidatesResolve: changed };
+      });
+      this.moduleResolve.set(moduleName, passes.resolved);
     });
   }
 

--- a/src/minifier.ts
+++ b/src/minifier.ts
@@ -19,6 +19,7 @@ import {
 import { analyzeBindingEffects } from "./effectAnalysis";
 import { analyzeTableEffects } from "./tableEffects";
 import { applyTableReadMergePlan, planTableReadMerges } from "./tableReadMerge";
+import { PassOrchestrator } from "./optimizerPass";
 
 export type RuntimeProfile = "lua53" | "stormworks";
 
@@ -271,6 +272,8 @@ export class Minifier {
         resolved = resolveScopes(ast);
       }
 
+      const passes = new PassOrchestrator(ast, resolved);
+
       const effectAwareLocalsEnabled =
         this.mode.effectAwareTransforms !== false &&
         (this.mode.runtimeProfile === "stormworks" ||
@@ -279,37 +282,37 @@ export class Minifier {
         effectAwareLocalsEnabled &&
         this.mode.effectAwareTableReads !== false
       ) {
-        const tablePlan = planTableReadMerges(
-          ast,
-          analyzeBindingEffects(ast, resolved),
-          analyzeTableEffects(ast, resolved),
-          {
-            dirtyGranularity:
-              this.mode.fieldSensitiveTableEffects === false
-                ? "table"
-                : "static-key",
-            canMoveStatement: (statement) => {
-              const metadata = this.getSourceMetadata(moduleName);
-              const annotations = metadata.annotationsOf(statement);
-              return (
-                metadata.beforeOf(statement).length === 0 &&
-                metadata.trailingOf(statement).length === 0 &&
-                !annotations.keep &&
-                !annotations.keepName &&
-                !annotations.exported
-              );
+        passes.run("effect-aware-table-reads", (currentResolve) => {
+          const tablePlan = planTableReadMerges(
+            ast,
+            analyzeBindingEffects(ast, currentResolve),
+            analyzeTableEffects(ast, currentResolve),
+            {
+              dirtyGranularity:
+                this.mode.fieldSensitiveTableEffects === false
+                  ? "table"
+                  : "static-key",
+              canMoveStatement: (statement) => {
+                const metadata = this.getSourceMetadata(moduleName);
+                const annotations = metadata.annotationsOf(statement);
+                return (
+                  metadata.beforeOf(statement).length === 0 &&
+                  metadata.trailingOf(statement).length === 0 &&
+                  !annotations.keep &&
+                  !annotations.keepName &&
+                  !annotations.exported
+                );
+              },
             },
-          },
-        );
-        const transformed = applyTableReadMergePlan(
-          tablePlan,
-          this.getSourceMetadata(moduleName),
-        );
-        if (transformed.invalidatesResolve) {
-          resolved = resolveScopes(ast);
-        }
+          );
+          return applyTableReadMergePlan(
+            tablePlan,
+            this.getSourceMetadata(moduleName),
+          );
+        });
       }
 
+      resolved = passes.resolved;
       const keepNames = new Set(
         resolved.symbols.filter(
           (symbol) =>
@@ -331,21 +334,21 @@ export class Minifier {
                 this.globalRenames,
                 keepNames,
               );
-        const plan = planNonAdjacentLocals(ast, resolved, {
-          outputNameLengthOf: (symbol) =>
-            (provisionalRenames.nameOf(symbol.declaration) ?? symbol.name)
-              .length,
-          preserveRequireSplice: !this.mode.moduleLikeLua,
+        passes.run("effect-aware-local-hoist", (currentResolve) => {
+          const plan = planNonAdjacentLocals(ast, currentResolve, {
+            outputNameLengthOf: (symbol) =>
+              (provisionalRenames.nameOf(symbol.declaration) ?? symbol.name)
+                .length,
+            preserveRequireSplice: !this.mode.moduleLikeLua,
+          });
+          return applyNonAdjacentLocalPlan(
+            plan,
+            this.getSourceMetadata(moduleName),
+          );
         });
-        const transformed = applyNonAdjacentLocalPlan(
-          plan,
-          this.getSourceMetadata(moduleName),
-        );
-        if (transformed.invalidatesResolve) {
-          resolved = resolveScopes(ast);
-        }
       }
 
+      resolved = passes.resolved;
       if (this.mode.mergeLocals !== false) {
         mergeLocalDeclarations(
           ast,

--- a/src/nonAdjacentLocals.ts
+++ b/src/nonAdjacentLocals.ts
@@ -3,6 +3,7 @@ import { AstWalkVisitor, walkStatement } from "./astWalk";
 import { ResolveResult, Symbol } from "./resolver";
 import { copyNodeOrigin, identifierWithOrigin } from "./generatedNode";
 import { SourceMetadata } from "./sourceMetadata";
+import { TransformResult } from "./optimizerPass";
 
 export interface NonAdjacentLocalGroup {
   readonly body: Parser.Statement[];
@@ -14,11 +15,6 @@ export interface NonAdjacentLocalGroup {
 
 export interface NonAdjacentLocalPlan {
   readonly groups: readonly NonAdjacentLocalGroup[];
-}
-
-export interface TransformResult {
-  readonly changed: boolean;
-  readonly invalidatesResolve: boolean;
 }
 
 export interface NonAdjacentLocalPlannerOptions {

--- a/src/nonAdjacentLocals.ts
+++ b/src/nonAdjacentLocals.ts
@@ -9,6 +9,7 @@ import {
   OptimizationDiagnosticReason,
   OptimizationDiagnosticSink,
 } from "./optimizerDiagnostics";
+import { RuntimeProfile } from "./runtimeEnvironment";
 
 export interface NonAdjacentLocalGroup {
   readonly body: Parser.Statement[];
@@ -28,6 +29,7 @@ export interface NonAdjacentLocalPlannerOptions {
   readonly preserveRequireSplice: boolean;
   readonly diagnostics?: OptimizationDiagnosticSink;
   readonly moduleName?: string;
+  readonly runtimeProfile?: RuntimeProfile;
 }
 
 interface Candidate {
@@ -35,6 +37,10 @@ interface Candidate {
   readonly index: number;
   readonly symbol: Symbol;
 }
+
+type CandidateDecision =
+  | { readonly candidate: Candidate }
+  | { readonly reason: OptimizationDiagnosticReason };
 
 /**
  * 非連続localの宣言hoist候補を選ぶ。ASTは変更しない。
@@ -58,14 +64,19 @@ export function planNonAdjacentLocals(
       reason: OptimizationDiagnosticReason,
       candidateSize: number,
       estimatedByteSavings?: number,
+      estimatedOpportunityBytes?: number,
+      sourceRange?: readonly [number, number],
     ) =>
       options.diagnostics?.record({
         pass: "effect-aware-local-hoist",
         moduleName: options.moduleName,
+        runtimeProfile: options.runtimeProfile,
         decision,
         reason,
         candidateSize,
         estimatedByteSavings,
+        estimatedOpportunityBytes,
+        sourceRange,
       });
     const flush = (
       rejectionReason: OptimizationDiagnosticReason = "insufficient-group",
@@ -89,16 +100,44 @@ export function planNonAdjacentLocals(
               symbols: run.map((candidate) => candidate.symbol),
               estimatedByteSavings: savings,
             });
-            record("accepted", "profitable-group", run.length, savings);
+            record(
+              "accepted",
+              "profitable-group",
+              run.length,
+              savings,
+              undefined,
+              rangeOf(run[0].statement),
+            );
             run = [];
             return;
           }
-          record("rejected", "nonpositive-cost", run.length);
+          record(
+            "rejected",
+            "nonpositive-cost",
+            run.length,
+            undefined,
+            Math.max(0, 4 * run.length - 6),
+            rangeOf(run[0].statement),
+          );
         } else {
-          record("rejected", "output-name-unknown", run.length);
+          record(
+            "rejected",
+            "output-name-unknown",
+            run.length,
+            undefined,
+            Math.max(0, 4 * run.length - 6),
+            rangeOf(run[0].statement),
+          );
         }
       } else if (run.length > 0) {
-        record("rejected", rejectionReason, run.length);
+        record(
+          "rejected",
+          rejectionReason,
+          run.length,
+          undefined,
+          0,
+          rangeOf(run[0].statement),
+        );
       }
       run = [];
     };
@@ -115,17 +154,46 @@ export function planNonAdjacentLocals(
           body[index + 1]?.type === "LocalStatement")
       ) {
         flush("adjacent-local-owned-by-merge");
+        record(
+          "rejected",
+          "adjacent-local-owned-by-merge",
+          1,
+          undefined,
+          0,
+          rangeOf(statement),
+        );
         return;
       }
 
-      const candidate = candidateOf(statement, index, resolved, options);
-      if (!candidate) {
-        flush("noncandidate-boundary");
+      if (statement.type !== "LocalStatement") {
+        flush("control-flow-barrier");
         return;
       }
+      const decision = candidateOf(statement, index, resolved, options);
+      if ("reason" in decision) {
+        flush("control-flow-barrier");
+        record(
+          "rejected",
+          decision.reason,
+          1,
+          undefined,
+          0,
+          rangeOf(statement),
+        );
+        return;
+      }
+      const candidate = decision.candidate;
 
       if (wouldChangeBinding(body, index, candidate)) {
         flush("binding-shadow-hazard");
+        record(
+          "rejected",
+          "binding-shadow-hazard",
+          1,
+          undefined,
+          0,
+          rangeOf(statement),
+        );
         return;
       }
 
@@ -187,22 +255,22 @@ export function applyNonAdjacentLocalPlan(
 }
 
 function candidateOf(
-  statement: Parser.Statement,
+  statement: Parser.LocalStatement,
   index: number,
   resolved: ResolveResult,
   options: NonAdjacentLocalPlannerOptions,
-): Candidate | undefined {
-  if (
-    statement.type !== "LocalStatement" ||
-    statement.variables.length !== 1 ||
-    statement.init.length !== 1 ||
-    (options.preserveRequireSplice && isRequireCall(statement.init[0]))
-  ) {
-    return undefined;
+): CandidateDecision {
+  if (statement.variables.length !== 1 || statement.init.length !== 1) {
+    return { reason: "unsupported-shape" };
+  }
+  if (options.preserveRequireSplice && isRequireCall(statement.init[0])) {
+    return { reason: "require-splice" };
   }
   const symbol = resolved.symbolOf(statement.variables[0]);
-  if (!symbol || symbol.kind !== "local") return undefined;
-  return { statement, index, symbol };
+  if (!symbol || symbol.kind !== "local") {
+    return { reason: "unsupported-shape" };
+  }
+  return { candidate: { statement, index, symbol } };
 }
 
 function isLinearInterveningStatement(statement: Parser.Statement): boolean {
@@ -246,4 +314,10 @@ function isRequireCall(expression: Parser.Expression): boolean {
     expression.base.type === "Identifier" &&
     expression.base.name === "require"
   );
+}
+
+function rangeOf(
+  statement: Parser.Statement,
+): readonly [number, number] | undefined {
+  return (statement as { range?: [number, number] }).range;
 }

--- a/src/nonAdjacentLocals.ts
+++ b/src/nonAdjacentLocals.ts
@@ -5,6 +5,10 @@ import { copyNodeOrigin, identifierWithOrigin } from "./generatedNode";
 import { SourceMetadata } from "./sourceMetadata";
 import { TransformResult } from "./optimizerPass";
 import { childStatementBodies } from "./controlFlow";
+import {
+  OptimizationDiagnosticReason,
+  OptimizationDiagnosticSink,
+} from "./optimizerDiagnostics";
 
 export interface NonAdjacentLocalGroup {
   readonly body: Parser.Statement[];
@@ -22,6 +26,8 @@ export interface NonAdjacentLocalPlannerOptions {
   // Rename後の印字名長。未確定のsymbolをundefinedにすると、その候補は拒否する。
   readonly outputNameLengthOf: (symbol: Symbol) => number | undefined;
   readonly preserveRequireSplice: boolean;
+  readonly diagnostics?: OptimizationDiagnosticSink;
+  readonly moduleName?: string;
 }
 
 interface Candidate {
@@ -47,7 +53,23 @@ export function planNonAdjacentLocals(
     childBlocksOf(body).forEach(processBlock);
 
     let run: Candidate[] = [];
-    const flush = () => {
+    const record = (
+      decision: "accepted" | "rejected",
+      reason: OptimizationDiagnosticReason,
+      candidateSize: number,
+      estimatedByteSavings?: number,
+    ) =>
+      options.diagnostics?.record({
+        pass: "effect-aware-local-hoist",
+        moduleName: options.moduleName,
+        decision,
+        reason,
+        candidateSize,
+        estimatedByteSavings,
+      });
+    const flush = (
+      rejectionReason: OptimizationDiagnosticReason = "insufficient-group",
+    ) => {
       if (run.length >= 2) {
         const lengths = run.map((candidate) =>
           options.outputNameLengthOf(candidate.symbol),
@@ -67,8 +89,16 @@ export function planNonAdjacentLocals(
               symbols: run.map((candidate) => candidate.symbol),
               estimatedByteSavings: savings,
             });
+            record("accepted", "profitable-group", run.length, savings);
+            run = [];
+            return;
           }
+          record("rejected", "nonpositive-cost", run.length);
+        } else {
+          record("rejected", "output-name-unknown", run.length);
         }
+      } else if (run.length > 0) {
+        record("rejected", rejectionReason, run.length);
       }
       run = [];
     };
@@ -84,18 +114,18 @@ export function planNonAdjacentLocals(
         (body[index - 1]?.type === "LocalStatement" ||
           body[index + 1]?.type === "LocalStatement")
       ) {
-        flush();
+        flush("adjacent-local-owned-by-merge");
         return;
       }
 
       const candidate = candidateOf(statement, index, resolved, options);
       if (!candidate) {
-        flush();
+        flush("noncandidate-boundary");
         return;
       }
 
       if (wouldChangeBinding(body, index, candidate)) {
-        flush();
+        flush("binding-shadow-hazard");
         return;
       }
 
@@ -103,7 +133,7 @@ export function planNonAdjacentLocals(
         run.some((prior) => prior.symbol.name === candidate.symbol.name) ||
         wouldChangeBinding(body, run[0]?.index ?? candidate.index, candidate)
       ) {
-        flush();
+        flush("binding-shadow-hazard");
       }
       run.push(candidate);
     });

--- a/src/nonAdjacentLocals.ts
+++ b/src/nonAdjacentLocals.ts
@@ -1,6 +1,8 @@
 import Parser from "luaparse";
 import { AstWalkVisitor, walkStatement } from "./astWalk";
 import { ResolveResult, Symbol } from "./resolver";
+import { copyNodeOrigin, identifierWithOrigin } from "./generatedNode";
+import { SourceMetadata } from "./sourceMetadata";
 
 export interface NonAdjacentLocalGroup {
   readonly body: Parser.Statement[];
@@ -12,6 +14,11 @@ export interface NonAdjacentLocalGroup {
 
 export interface NonAdjacentLocalPlan {
   readonly groups: readonly NonAdjacentLocalGroup[];
+}
+
+export interface TransformResult {
+  readonly changed: boolean;
+  readonly invalidatesResolve: boolean;
 }
 
 export interface NonAdjacentLocalPlannerOptions {
@@ -96,6 +103,48 @@ export function planNonAdjacentLocals(
 
   processBlock(chunk.body);
   return { groups };
+}
+
+/** plannerが安全性と費用を確認したgroupだけをASTへ適用する。 */
+export function applyNonAdjacentLocalPlan(
+  plan: NonAdjacentLocalPlan,
+  metadata?: SourceMetadata,
+): TransformResult {
+  // nested blockを含む各bodyは別配列である。同じbody内では後ろから置換し、
+  // plannerが記録したindexを先行groupの挿入でずらさない。
+  [...plan.groups].reverse().forEach((group) => {
+    const declaration: Parser.LocalStatement = {
+      type: "LocalStatement",
+      variables: group.statements.map((statement) => statement.variables[0]),
+      init: [],
+    };
+    copyNodeOrigin(declaration, group.statements[0]);
+
+    const assignments = group.statements.map((statement) => {
+      const assignment: Parser.AssignmentStatement = {
+        type: "AssignmentStatement",
+        variables: [identifierWithOrigin(statement.variables[0])],
+        init: [statement.init[0]],
+      };
+      copyNodeOrigin(assignment, statement);
+      return assignment;
+    });
+
+    for (let offset = group.indexes.length - 1; offset >= 0; offset--) {
+      const index = group.indexes[offset];
+      const source = group.statements[offset];
+      const replacements =
+        offset === 0
+          ? [declaration, assignments[offset]]
+          : [assignments[offset]];
+      metadata?.replaceStatement(source, replacements);
+      group.body.splice(index, 1, ...replacements);
+    }
+  });
+  return {
+    changed: plan.groups.length > 0,
+    invalidatesResolve: plan.groups.length > 0,
+  };
 }
 
 function candidateOf(

--- a/src/nonAdjacentLocals.ts
+++ b/src/nonAdjacentLocals.ts
@@ -79,6 +79,18 @@ export function planNonAdjacentLocals(
     body.forEach((statement, index) => {
       if (isLinearInterveningStatement(statement)) return;
 
+      // 後続の既存local merge (#9) と候補選択を競合させない。隣接localを
+      // hoistすると、#47単体では短くても#9適用後を基準に出力が長くなり得る。
+      // #42で両案を同じplannerへ統合するまでは、孤立したlocalだけを扱う。
+      if (
+        statement.type === "LocalStatement" &&
+        (body[index - 1]?.type === "LocalStatement" ||
+          body[index + 1]?.type === "LocalStatement")
+      ) {
+        flush();
+        return;
+      }
+
       const candidate = candidateOf(statement, index, resolved, options);
       if (!candidate) {
         flush();

--- a/src/nonAdjacentLocals.ts
+++ b/src/nonAdjacentLocals.ts
@@ -1,0 +1,167 @@
+import Parser from "luaparse";
+import { AstWalkVisitor, walkStatement } from "./astWalk";
+import { ResolveResult, Symbol } from "./resolver";
+
+export interface NonAdjacentLocalGroup {
+  readonly body: Parser.Statement[];
+  readonly statements: readonly Parser.LocalStatement[];
+  readonly indexes: readonly number[];
+  readonly symbols: readonly Symbol[];
+  readonly estimatedByteSavings: number;
+}
+
+export interface NonAdjacentLocalPlan {
+  readonly groups: readonly NonAdjacentLocalGroup[];
+}
+
+export interface NonAdjacentLocalPlannerOptions {
+  // Rename後の印字名長。未確定のsymbolをundefinedにすると、その候補は拒否する。
+  readonly outputNameLengthOf: (symbol: Symbol) => number | undefined;
+  readonly preserveRequireSplice: boolean;
+}
+
+interface Candidate {
+  readonly statement: Parser.LocalStatement;
+  readonly index: number;
+  readonly symbol: Symbol;
+}
+
+/**
+ * 非連続localの宣言hoist候補を選ぶ。ASTは変更しない。
+ *
+ * 初期段階では単純な1変数/1初期化だけを扱い、制御文や複数戻り値を境界にする。
+ * これにより評価式は元位置へ代入として残せ、後続transformの安全性判断を小さく保つ。
+ */
+export function planNonAdjacentLocals(
+  chunk: Parser.Chunk,
+  resolved: ResolveResult,
+  options: NonAdjacentLocalPlannerOptions,
+): NonAdjacentLocalPlan {
+  const groups: NonAdjacentLocalGroup[] = [];
+
+  function processBlock(body: Parser.Statement[]): void {
+    childBlocksOf(body).forEach(processBlock);
+
+    let run: Candidate[] = [];
+    const flush = () => {
+      if (run.length >= 2) {
+        const lengths = run.map((candidate) =>
+          options.outputNameLengthOf(candidate.symbol),
+        );
+        if (lengths.every((length): length is number => length !== undefined)) {
+          // N個の`local v=e`を`local v,...` + N個の`v=e`へ変える。
+          // token差に加え、新しい宣言と最初の代入間に必要な1 byte separatorも引く。
+          const savings =
+            4 * run.length -
+            6 -
+            lengths.reduce((sum, length) => sum + length, 0);
+          if (savings > 0) {
+            groups.push({
+              body,
+              statements: run.map((candidate) => candidate.statement),
+              indexes: run.map((candidate) => candidate.index),
+              symbols: run.map((candidate) => candidate.symbol),
+              estimatedByteSavings: savings,
+            });
+          }
+        }
+      }
+      run = [];
+    };
+
+    body.forEach((statement, index) => {
+      if (isLinearInterveningStatement(statement)) return;
+
+      const candidate = candidateOf(statement, index, resolved, options);
+      if (!candidate) {
+        flush();
+        return;
+      }
+
+      if (wouldChangeBinding(body, index, candidate)) {
+        flush();
+        return;
+      }
+
+      if (
+        run.some((prior) => prior.symbol.name === candidate.symbol.name) ||
+        wouldChangeBinding(body, run[0]?.index ?? candidate.index, candidate)
+      ) {
+        flush();
+      }
+      run.push(candidate);
+    });
+    flush();
+  }
+
+  processBlock(chunk.body);
+  return { groups };
+}
+
+function candidateOf(
+  statement: Parser.Statement,
+  index: number,
+  resolved: ResolveResult,
+  options: NonAdjacentLocalPlannerOptions,
+): Candidate | undefined {
+  if (
+    statement.type !== "LocalStatement" ||
+    statement.variables.length !== 1 ||
+    statement.init.length !== 1 ||
+    (options.preserveRequireSplice && isRequireCall(statement.init[0]))
+  ) {
+    return undefined;
+  }
+  const symbol = resolved.symbolOf(statement.variables[0]);
+  if (!symbol || symbol.kind !== "local") return undefined;
+  return { statement, index, symbol };
+}
+
+function isLinearInterveningStatement(statement: Parser.Statement): boolean {
+  return (
+    statement.type === "AssignmentStatement" ||
+    statement.type === "CallStatement"
+  );
+}
+
+function wouldChangeBinding(
+  body: Parser.Statement[],
+  groupStart: number,
+  candidate: Candidate,
+): boolean {
+  for (let index = groupStart; index <= candidate.index; index++) {
+    const referencedNames: string[] = [];
+    const visitor: AstWalkVisitor = {
+      onIdentifierReference: (identifier) => {
+        referencedNames.push(identifier.name);
+      },
+      onBlock: (nested) => {
+        nested.forEach((statement) => {
+          walkStatement(statement, visitor);
+        });
+      },
+    };
+    walkStatement(body[index], visitor);
+    if (referencedNames.includes(candidate.symbol.name)) return true;
+  }
+  return false;
+}
+
+function childBlocksOf(body: Parser.Statement[]): Parser.Statement[][] {
+  const children: Parser.Statement[][] = [];
+  body.forEach((statement) => {
+    walkStatement(statement, {
+      onBlock: (nested) => children.push(nested),
+    });
+  });
+  return children;
+}
+
+function isRequireCall(expression: Parser.Expression): boolean {
+  return (
+    (expression.type === "CallExpression" ||
+      expression.type === "StringCallExpression") &&
+    expression.base.type === "Identifier" &&
+    expression.base.name === "require"
+  );
+}

--- a/src/nonAdjacentLocals.ts
+++ b/src/nonAdjacentLocals.ts
@@ -4,6 +4,7 @@ import { ResolveResult, Symbol } from "./resolver";
 import { copyNodeOrigin, identifierWithOrigin } from "./generatedNode";
 import { SourceMetadata } from "./sourceMetadata";
 import { TransformResult } from "./optimizerPass";
+import { childStatementBodies } from "./controlFlow";
 
 export interface NonAdjacentLocalGroup {
   readonly body: Parser.Statement[];
@@ -205,13 +206,7 @@ function wouldChangeBinding(
 }
 
 function childBlocksOf(body: Parser.Statement[]): Parser.Statement[][] {
-  const children: Parser.Statement[][] = [];
-  body.forEach((statement) => {
-    walkStatement(statement, {
-      onBlock: (nested) => children.push(nested),
-    });
-  });
-  return children;
+  return childStatementBodies(body);
 }
 
 function isRequireCall(expression: Parser.Expression): boolean {

--- a/src/optimizerDiagnostics.ts
+++ b/src/optimizerDiagnostics.ts
@@ -1,0 +1,77 @@
+export type OptimizationDecision = "accepted" | "rejected";
+export type OptimizationDiagnosticReason =
+  | "profitable-group"
+  | "insufficient-group"
+  | "noncandidate-boundary"
+  | "effect-or-binding-barrier"
+  | "adjacent-local-owned-by-merge"
+  | "binding-shadow-hazard"
+  | "output-name-unknown"
+  | "nonpositive-cost";
+
+export interface OptimizationDiagnostic {
+  readonly pass: string;
+  readonly moduleName?: string;
+  readonly decision: OptimizationDecision;
+  readonly reason: OptimizationDiagnosticReason;
+  readonly candidateSize?: number;
+  readonly estimatedByteSavings?: number;
+}
+
+/**
+ * 最適化の観測は変換結果へ影響してはならない。sinkは候補判定後に同期的に
+ * 呼ばれ、plannerの入力やASTを受け取らないため、診断から変換を書き換えられない。
+ */
+export interface OptimizationDiagnosticSink {
+  record(diagnostic: OptimizationDiagnostic): void;
+}
+
+export class OptimizationDiagnosticCollector implements OptimizationDiagnosticSink {
+  private readonly diagnosticsValue: OptimizationDiagnostic[] = [];
+
+  get diagnostics(): readonly OptimizationDiagnostic[] {
+    return this.diagnosticsValue;
+  }
+
+  record(diagnostic: OptimizationDiagnostic): void {
+    this.diagnosticsValue.push({ ...diagnostic });
+  }
+}
+
+export interface OptimizationDiagnosticSummary {
+  readonly acceptedCandidates: number;
+  readonly rejectedCandidates: number;
+  readonly estimatedByteSavings: number;
+  readonly byReason: readonly {
+    readonly key: string;
+    readonly candidateCount: number;
+  }[];
+}
+
+export function summarizeOptimizationDiagnostics(
+  diagnostics: readonly OptimizationDiagnostic[],
+): OptimizationDiagnosticSummary {
+  const byReason = new Map<string, number>();
+  let acceptedCandidates = 0;
+  let rejectedCandidates = 0;
+  let estimatedByteSavings = 0;
+  diagnostics.forEach((diagnostic) => {
+    const count = diagnostic.candidateSize ?? 1;
+    if (diagnostic.decision === "accepted") {
+      acceptedCandidates += count;
+      estimatedByteSavings += diagnostic.estimatedByteSavings ?? 0;
+    } else {
+      rejectedCandidates += count;
+    }
+    const key = `${diagnostic.pass}:${diagnostic.reason}`;
+    byReason.set(key, (byReason.get(key) ?? 0) + count);
+  });
+  return {
+    acceptedCandidates,
+    rejectedCandidates,
+    estimatedByteSavings,
+    byReason: [...byReason]
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, candidateCount]) => ({ key, candidateCount })),
+  };
+}

--- a/src/optimizerDiagnostics.ts
+++ b/src/optimizerDiagnostics.ts
@@ -2,20 +2,38 @@ export type OptimizationDecision = "accepted" | "rejected";
 export type OptimizationDiagnosticReason =
   | "profitable-group"
   | "insufficient-group"
-  | "noncandidate-boundary"
-  | "effect-or-binding-barrier"
+  | "unsupported-shape"
+  | "require-splice"
+  | "control-flow-barrier"
+  | "metadata-preserved"
+  | "dynamic-key"
+  | "unsupported-string-key"
+  | "allocation-unknown"
+  | "unstable-reaching-definition"
+  | "dirty-static-key"
+  | "dirty-table"
+  | "alias-escape"
+  | "call-escape"
+  | "return-escape"
+  | "store-escape"
+  | "capture-escape"
+  | "value-use-escape"
   | "adjacent-local-owned-by-merge"
   | "binding-shadow-hazard"
   | "output-name-unknown"
-  | "nonpositive-cost";
+  | "nonpositive-cost"
+  | "resource-budget";
 
 export interface OptimizationDiagnostic {
   readonly pass: string;
   readonly moduleName?: string;
+  readonly runtimeProfile?: "lua53" | "stormworks";
   readonly decision: OptimizationDecision;
   readonly reason: OptimizationDiagnosticReason;
   readonly candidateSize?: number;
   readonly estimatedByteSavings?: number;
+  readonly estimatedOpportunityBytes?: number;
+  readonly sourceRange?: readonly [number, number];
 }
 
 /**
@@ -42,19 +60,39 @@ export interface OptimizationDiagnosticSummary {
   readonly acceptedCandidates: number;
   readonly rejectedCandidates: number;
   readonly estimatedByteSavings: number;
-  readonly byReason: readonly {
-    readonly key: string;
+  readonly estimatedOpportunityBytes: number;
+  readonly buckets: readonly {
+    readonly runtimeProfile: string;
+    readonly moduleName: string;
+    readonly pass: string;
+    readonly decision: OptimizationDecision;
+    readonly reason: OptimizationDiagnosticReason;
     readonly candidateCount: number;
+    readonly estimatedByteSavings: number;
+    readonly estimatedOpportunityBytes: number;
   }[];
 }
 
 export function summarizeOptimizationDiagnostics(
   diagnostics: readonly OptimizationDiagnostic[],
 ): OptimizationDiagnosticSummary {
-  const byReason = new Map<string, number>();
+  const buckets = new Map<
+    string,
+    {
+      runtimeProfile: string;
+      moduleName: string;
+      pass: string;
+      decision: OptimizationDecision;
+      reason: OptimizationDiagnosticReason;
+      candidateCount: number;
+      estimatedByteSavings: number;
+      estimatedOpportunityBytes: number;
+    }
+  >();
   let acceptedCandidates = 0;
   let rejectedCandidates = 0;
   let estimatedByteSavings = 0;
+  let estimatedOpportunityBytes = 0;
   diagnostics.forEach((diagnostic) => {
     const count = diagnostic.candidateSize ?? 1;
     if (diagnostic.decision === "accepted") {
@@ -62,16 +100,40 @@ export function summarizeOptimizationDiagnostics(
       estimatedByteSavings += diagnostic.estimatedByteSavings ?? 0;
     } else {
       rejectedCandidates += count;
+      estimatedOpportunityBytes += diagnostic.estimatedOpportunityBytes ?? 0;
     }
-    const key = `${diagnostic.pass}:${diagnostic.reason}`;
-    byReason.set(key, (byReason.get(key) ?? 0) + count);
+    const runtimeProfile = diagnostic.runtimeProfile ?? "unknown";
+    const moduleName = diagnostic.moduleName ?? "unknown";
+    const key = [
+      runtimeProfile,
+      moduleName,
+      diagnostic.pass,
+      diagnostic.decision,
+      diagnostic.reason,
+    ].join("\u0000");
+    const current = buckets.get(key) ?? {
+      runtimeProfile,
+      moduleName,
+      pass: diagnostic.pass,
+      decision: diagnostic.decision,
+      reason: diagnostic.reason,
+      candidateCount: 0,
+      estimatedByteSavings: 0,
+      estimatedOpportunityBytes: 0,
+    };
+    current.candidateCount += count;
+    current.estimatedByteSavings += diagnostic.estimatedByteSavings ?? 0;
+    current.estimatedOpportunityBytes +=
+      diagnostic.estimatedOpportunityBytes ?? 0;
+    buckets.set(key, current);
   });
   return {
     acceptedCandidates,
     rejectedCandidates,
     estimatedByteSavings,
-    byReason: [...byReason]
+    estimatedOpportunityBytes,
+    buckets: [...buckets]
       .sort(([left], [right]) => left.localeCompare(right))
-      .map(([key, candidateCount]) => ({ key, candidateCount })),
+      .map(([, bucket]) => ({ ...bucket })),
   };
 }

--- a/src/optimizerPass.ts
+++ b/src/optimizerPass.ts
@@ -66,6 +66,20 @@ export class PassOrchestrator {
     });
     return result;
   }
+
+  runUntilStable(
+    name: string,
+    transform: (resolved: ResolveResult, iteration: number) => TransformResult,
+  ): readonly TransformResult[] {
+    const results: TransformResult[] = [];
+    for (let iteration = 0; ; iteration++) {
+      const result = this.run(`${name}:${String(iteration)}`, (resolved) =>
+        transform(resolved, iteration),
+      );
+      results.push(result);
+      if (!result.changed) return results;
+    }
+  }
 }
 
 export const UNCHANGED: TransformResult = {

--- a/src/optimizerPass.ts
+++ b/src/optimizerPass.ts
@@ -1,0 +1,74 @@
+import Parser from "luaparse";
+import { resolveScopes, ResolveResult } from "./resolver";
+
+export interface TransformResult {
+  readonly changed: boolean;
+  readonly invalidatesResolve: boolean;
+}
+
+export interface PassRecord extends TransformResult {
+  readonly name: string;
+  readonly resolveGenerationBefore: number;
+  readonly resolveGenerationAfter: number;
+}
+
+/**
+ * AST変換と解析世代を結び付ける最小のpass orchestrator。
+ *
+ * 構造変更後の古いResolveResultを後続passへ渡さないことが第一の不変条件である。
+ * CFG/effect/cost等の解析cacheは、この世代番号とpass履歴を共通の失効根拠として
+ * 後から追加できる。現在はResolveだけを所有し、未使用の抽象化は持ち込まない。
+ */
+export class PassOrchestrator {
+  private resolvedValue: ResolveResult;
+  private generationValue = 0;
+  private readonly recordsValue: PassRecord[] = [];
+
+  constructor(
+    private readonly chunk: Parser.Chunk,
+    initialResolve: ResolveResult,
+  ) {
+    this.resolvedValue = initialResolve;
+  }
+
+  get resolved(): ResolveResult {
+    return this.resolvedValue;
+  }
+
+  get resolveGeneration(): number {
+    return this.generationValue;
+  }
+
+  get records(): readonly PassRecord[] {
+    return this.recordsValue;
+  }
+
+  run(
+    name: string,
+    transform: (resolved: ResolveResult) => TransformResult,
+  ): TransformResult {
+    const before = this.generationValue;
+    const result = transform(this.resolvedValue);
+    if (!result.changed && result.invalidatesResolve) {
+      throw new Error(
+        `Pass ${name} cannot invalidate Resolve without changing the AST`,
+      );
+    }
+    if (result.invalidatesResolve) {
+      this.resolvedValue = resolveScopes(this.chunk);
+      this.generationValue++;
+    }
+    this.recordsValue.push({
+      name,
+      ...result,
+      resolveGenerationBefore: before,
+      resolveGenerationAfter: this.generationValue,
+    });
+    return result;
+  }
+}
+
+export const UNCHANGED: TransformResult = {
+  changed: false,
+  invalidatesResolve: false,
+};

--- a/src/optimizerTransaction.ts
+++ b/src/optimizerTransaction.ts
@@ -1,0 +1,96 @@
+import { Options } from "luaparse";
+import { Minifier, MinifierMode } from "./minifier";
+
+export interface MinifiedArtifact {
+  readonly code: string;
+  readonly sourceMap: string;
+  readonly byteLength: number;
+}
+
+export type TransactionalVariantResult =
+  | {
+      readonly accepted: true;
+      readonly selected: MinifiedArtifact;
+      readonly baseline: MinifiedArtifact;
+      readonly trial: MinifiedArtifact;
+      readonly byteSavings: number;
+    }
+  | {
+      readonly accepted: false;
+      readonly reason: "not-shorter" | "trial-failed";
+      readonly selected: MinifiedArtifact;
+      readonly baseline: MinifiedArtifact;
+      readonly trial?: MinifiedArtifact;
+      readonly trialError?: unknown;
+      readonly byteSavings: 0;
+    };
+
+export interface TransactionalMinifierRequest {
+  readonly entryFilePath: string;
+  readonly luaParseSettings: Partial<Options>;
+  readonly baselineMode: MinifierMode;
+  readonly trialMode: MinifierMode;
+  readonly outputFile?: string;
+}
+
+function renderVariant(
+  request: TransactionalMinifierRequest,
+  mode: MinifierMode,
+): MinifiedArtifact {
+  // Minifier instanceを共有しないことがrollbackの不変条件。ASTだけでなく
+  // Resolve、SourceMetadata、annotation、rename cache、module予約名も分離する。
+  const output = new Minifier(
+    request.entryFilePath,
+    request.luaParseSettings,
+    mode,
+  )
+    .parse()
+    .toStringWithSourceMap({
+      file: request.outputFile ?? "main.min.lua",
+    });
+  return {
+    code: output.code,
+    sourceMap: output.map.toString(),
+    byteLength: new TextEncoder().encode(output.code).length,
+  };
+}
+
+/**
+ * baselineとtrialを最終Rename/Printまで同条件で評価し、厳密に短いtrialだけを選ぶ。
+ * trialは隔離されたMinifier上で動くため、失敗・同長・増加時に復元操作は不要。
+ */
+export function selectTransactionalMinifierVariant(
+  request: TransactionalMinifierRequest,
+): TransactionalVariantResult {
+  const baseline = renderVariant(request, request.baselineMode);
+  let trial: MinifiedArtifact;
+  try {
+    trial = renderVariant(request, request.trialMode);
+  } catch (trialError) {
+    return {
+      accepted: false,
+      reason: "trial-failed",
+      selected: baseline,
+      baseline,
+      trialError,
+      byteSavings: 0,
+    };
+  }
+  if (trial.byteLength >= baseline.byteLength) {
+    return {
+      accepted: false,
+      reason: "not-shorter",
+      selected: baseline,
+      baseline,
+      trial,
+      byteSavings: 0,
+    };
+  }
+  return {
+    accepted: true,
+    selected: trial,
+    baseline,
+    trial,
+    byteSavings: baseline.byteLength - trial.byteLength,
+  };
+}

--- a/src/runtimeEnvironment.ts
+++ b/src/runtimeEnvironment.ts
@@ -1,0 +1,70 @@
+export type RuntimeProfile = "lua53" | "stormworks";
+
+export interface RuntimeSemantics {
+  readonly mutableMetatables: boolean;
+  readonly debugLocalIntrospection: boolean;
+}
+
+export interface RuntimeResourceBudget {
+  readonly maxActiveLocalsPerFunction: number;
+  readonly maxRegistersPerFunction: number;
+  readonly conservativeParallelValueLimit: number;
+}
+
+export interface RuntimeEnvironment {
+  readonly profile: RuntimeProfile;
+  readonly semantics: RuntimeSemantics;
+  readonly resources: RuntimeResourceBudget;
+}
+
+export type ResourceDecision =
+  | {
+      readonly allowed: true;
+      readonly confidence: "conservative-policy";
+      readonly limit: number;
+    }
+  | {
+      readonly allowed: false;
+      readonly reason: "parallel-value-limit";
+      readonly limit: number;
+    };
+
+const COMMON_RESOURCES: RuntimeResourceBudget = {
+  maxActiveLocalsPerFunction: 200,
+  maxRegistersPerFunction: 255,
+  // compilerの一時register推定が未完成でも、local/register上限間に余裕を残す。
+  conservativeParallelValueLimit: 50,
+};
+
+export function runtimeEnvironmentOf(
+  profile: RuntimeProfile,
+): RuntimeEnvironment {
+  if (profile === "stormworks") {
+    return {
+      profile,
+      semantics: {
+        mutableMetatables: false,
+        debugLocalIntrospection: false,
+      },
+      resources: COMMON_RESOURCES,
+    };
+  }
+  return {
+    profile,
+    semantics: {
+      mutableMetatables: true,
+      debugLocalIntrospection: true,
+    },
+    resources: COMMON_RESOURCES,
+  };
+}
+
+export function checkParallelValueCount(
+  environment: RuntimeEnvironment,
+  count: number,
+): ResourceDecision {
+  const limit = environment.resources.conservativeParallelValueLimit;
+  return count <= limit
+    ? { allowed: true, confidence: "conservative-policy", limit }
+    : { allowed: false, reason: "parallel-value-limit", limit };
+}

--- a/src/runtimeEnvironment.ts
+++ b/src/runtimeEnvironment.ts
@@ -22,12 +22,24 @@ export type ResourceDecision =
       readonly allowed: true;
       readonly confidence: "conservative-policy";
       readonly limit: number;
+      readonly estimatedPeakRegisters: number;
     }
   | {
       readonly allowed: false;
-      readonly reason: "parallel-value-limit";
+      readonly reason:
+        "parallel-value-limit" | "local-limit" | "register-limit";
       readonly limit: number;
+      readonly estimatedPeakRegisters: number;
     };
+
+export interface ParallelEvaluationRequest {
+  readonly activeLocalsBefore: number;
+  readonly parallelValueCount: number;
+}
+
+export interface LocalResourceUsage {
+  activeLocalsBefore(statement: Parser.Statement): number | undefined;
+}
 
 const COMMON_RESOURCES: RuntimeResourceBudget = {
   maxActiveLocalsPerFunction: 200,
@@ -63,8 +75,91 @@ export function checkParallelValueCount(
   environment: RuntimeEnvironment,
   count: number,
 ): ResourceDecision {
-  const limit = environment.resources.conservativeParallelValueLimit;
-  return count <= limit
-    ? { allowed: true, confidence: "conservative-policy", limit }
-    : { allowed: false, reason: "parallel-value-limit", limit };
+  return checkParallelEvaluation(environment, {
+    activeLocalsBefore: 0,
+    parallelValueCount: count,
+  });
 }
+
+export function checkParallelEvaluation(
+  environment: RuntimeEnvironment,
+  request: ParallelEvaluationRequest,
+): ResourceDecision {
+  const limit = environment.resources.conservativeParallelValueLimit;
+  const localHeadroom = Math.max(
+    0,
+    environment.resources.maxActiveLocalsPerFunction -
+      request.activeLocalsBefore,
+  );
+  const registerHeadroom = Math.max(
+    0,
+    environment.resources.maxRegistersPerFunction - request.activeLocalsBefore,
+  );
+  const allowedCount = Math.min(limit, localHeadroom, registerHeadroom);
+  const estimatedPeakRegisters =
+    request.activeLocalsBefore + request.parallelValueCount;
+  if (request.parallelValueCount <= allowedCount) {
+    return {
+      allowed: true,
+      confidence: "conservative-policy",
+      limit: allowedCount,
+      estimatedPeakRegisters,
+    };
+  }
+  const reason =
+    localHeadroom < request.parallelValueCount
+      ? "local-limit"
+      : registerHeadroom < request.parallelValueCount
+        ? "register-limit"
+        : "parallel-value-limit";
+  return {
+    allowed: false,
+    reason,
+    limit: allowedCount,
+    estimatedPeakRegisters,
+  };
+}
+
+/** 各function/blockの字句的local生存数を、文の直前位置で数える。 */
+export function analyzeLocalResourceUsage(
+  chunk: Parser.Chunk,
+): LocalResourceUsage {
+  const activeBefore = new WeakMap<Parser.Statement, number>();
+
+  const visitBlock = (body: Parser.Statement[], entryActive: number): void => {
+    let active = entryActive;
+    body.forEach((statement) => {
+      activeBefore.set(statement, active);
+      switch (statement.type) {
+        case "LocalStatement":
+          active += statement.variables.length;
+          break;
+        case "FunctionDeclaration":
+          visitBlock(statement.body, statement.parameters.length);
+          if (statement.isLocal) active++;
+          break;
+        case "DoStatement":
+        case "WhileStatement":
+          visitBlock(statement.body, active);
+          break;
+        case "RepeatStatement":
+          visitBlock(statement.body, active);
+          break;
+        case "IfStatement":
+          statement.clauses.forEach((clause) =>
+            visitBlock(clause.body, active),
+          );
+          break;
+        case "ForNumericStatement":
+          visitBlock(statement.body, active + 1);
+          break;
+        case "ForGenericStatement":
+          visitBlock(statement.body, active + statement.variables.length);
+          break;
+      }
+    });
+  };
+  visitBlock(chunk.body, 0);
+  return { activeLocalsBefore: (statement) => activeBefore.get(statement) };
+}
+import Parser from "luaparse";

--- a/src/runtimeEnvironment.ts
+++ b/src/runtimeEnvironment.ts
@@ -146,9 +146,9 @@ export function analyzeLocalResourceUsage(
           visitBlock(statement.body, active);
           break;
         case "IfStatement":
-          statement.clauses.forEach((clause) =>
-            visitBlock(clause.body, active),
-          );
+          statement.clauses.forEach((clause) => {
+            visitBlock(clause.body, active);
+          });
           break;
         case "ForNumericStatement":
           visitBlock(statement.body, active + 1);

--- a/src/tableEffects.ts
+++ b/src/tableEffects.ts
@@ -438,7 +438,22 @@ export function analyzeTableEffects(
     const target = owner.variables[index];
     if (target.type !== "Identifier") return undefined;
     const symbol = resolved.symbolOf(target);
-    return symbol ? { symbol, declaration: owner } : undefined;
+    if (
+      !symbol ||
+      (owner.type === "AssignmentStatement" &&
+        !valueFlow.controlFlow.regions.some(
+          (region) =>
+            region.unit === allocation.unit &&
+            region.points.some(
+              (point) =>
+                point.statement.type === "LocalStatement" &&
+                point.statement.variables.includes(symbol.declaration),
+            ),
+        ))
+    ) {
+      return undefined;
+    }
+    return { symbol, declaration: owner };
   }
 
   function depthOf(unit: Allocation["unit"]): number {

--- a/src/tableEffects.ts
+++ b/src/tableEffects.ts
@@ -436,7 +436,7 @@ export function analyzeTableEffects(
     const index = owner.init.indexOf(allocation.origin);
     if (index < 0) return undefined;
     const target = owner.variables[index];
-    if (target?.type !== "Identifier") return undefined;
+    if (target.type !== "Identifier") return undefined;
     const symbol = resolved.symbolOf(target);
     return symbol ? { symbol, declaration: owner } : undefined;
   }

--- a/src/tableEffects.ts
+++ b/src/tableEffects.ts
@@ -5,10 +5,12 @@ import {
   luaByteStringKey,
   luaByteStringOfText,
 } from "./luaString";
+import { Allocation, analyzeValueFlow } from "./valueFlow";
 
 export interface FreshTable {
+  readonly allocation: Allocation;
   readonly symbol: Symbol;
-  readonly declaration: Parser.LocalStatement;
+  readonly declaration: Parser.LocalStatement | Parser.AssignmentStatement;
   readonly constructor: Parser.TableConstructorExpression;
   readonly functionDepth: number;
 }
@@ -20,6 +22,7 @@ export interface TableEffect {
   readonly staticKey: string | undefined;
   readonly expression: Parser.MemberExpression | Parser.IndexExpression;
   readonly owner: Parser.Statement;
+  readonly baseSymbol: Symbol;
 }
 
 export type TableEscapeReason =
@@ -38,6 +41,12 @@ export interface TableEffectAnalysis {
   readonly escapes: readonly TableEscape[];
   isNonescaping(table: FreshTable): boolean;
   effectsOf(table: FreshTable): readonly TableEffect[];
+  stableBetween(
+    table: FreshTable,
+    baseSymbol: Symbol,
+    first: Parser.Statement,
+    last: Parser.Statement,
+  ): boolean;
 }
 
 type ValueUse = "value-use" | "alias" | "call" | "return" | "store";
@@ -48,9 +57,41 @@ export function analyzeTableEffects(
   resolved: ResolveResult,
 ): TableEffectAnalysis {
   const freshTables: FreshTable[] = [];
-  const freshBySymbol = new Map<Symbol, FreshTable>();
+  const freshByAllocation = new Map<Allocation, FreshTable>();
+  const allocationByStableSymbol = new Map<Symbol, Allocation | null>();
   const effects: TableEffect[] = [];
   const escapes: TableEscape[] = [];
+  const valueFlow = analyzeValueFlow(chunk, resolved);
+
+  valueFlow.allocations.forEach((allocation) => {
+    const binding = bindingOfAllocation(allocation);
+    if (!binding) return;
+    const table: FreshTable = {
+      allocation,
+      symbol: binding.symbol,
+      declaration: binding.declaration,
+      constructor: allocation.origin,
+      functionDepth: depthOf(allocation.unit),
+    };
+    freshTables.push(table);
+    freshByAllocation.set(allocation, table);
+  });
+  valueFlow.definitions.forEach((definition) => {
+    if (
+      definition.value.kind !== "allocations" ||
+      definition.value.allocations.size !== 1
+    ) {
+      allocationByStableSymbol.set(definition.symbol, null);
+      return;
+    }
+    const allocation = definition.value.allocations.values().next().value;
+    if (!allocation) return;
+    const existing = allocationByStableSymbol.get(definition.symbol);
+    allocationByStableSymbol.set(
+      definition.symbol,
+      existing === undefined || existing === allocation ? allocation : null,
+    );
+  });
 
   analyzeBlock(chunk.body, 0);
 
@@ -61,7 +102,16 @@ export function analyzeTableEffects(
     functionDepth: number,
   ): void {
     const symbol = resolved.symbolOf(identifier);
-    const table = symbol ? freshBySymbol.get(symbol) : undefined;
+    const point = valueFlow.controlFlow.pointOf(owner);
+    const allocation =
+      symbol && point
+        ? valueFlow.allocationOfBase(identifier, point)
+        : undefined;
+    const fallback = symbol ? allocationByStableSymbol.get(symbol) : undefined;
+    const resolvedAllocation = allocation ?? fallback ?? undefined;
+    const table = resolvedAllocation
+      ? freshByAllocation.get(resolvedAllocation)
+      : undefined;
     if (!table) return;
     escapes.push({
       table,
@@ -159,7 +209,7 @@ export function analyzeTableEffects(
       analyzeExpression(argument, owner, "call", functionDepth);
     });
     if (base.type === "MemberExpression" && base.indexer === ":") {
-      const table = tableOfBase(base.base);
+      const table = tableOfBase(base.base, owner);
       if (table && base.base.type === "Identifier") {
         escapeIdentifier(base.base, "call", owner, functionDepth);
       }
@@ -172,14 +222,19 @@ export function analyzeTableEffects(
     owner: Parser.Statement,
     functionDepth: number,
   ): void {
-    const table = tableOfBase(expression.base);
-    if (table) {
+    const baseSymbol =
+      expression.base.type === "Identifier"
+        ? resolved.symbolOf(expression.base)
+        : undefined;
+    const table = tableOfBase(expression.base, owner);
+    if (table && baseSymbol) {
       effects.push({
         access,
         table,
         staticKey: staticKeyOf(expression),
         expression,
         owner,
+        baseSymbol,
       });
       if (
         functionDepth > table.functionDepth &&
@@ -195,10 +250,14 @@ export function analyzeTableEffects(
     }
   }
 
-  function tableOfBase(base: Parser.Expression): FreshTable | undefined {
-    if (base.type !== "Identifier") return undefined;
-    const symbol = resolved.symbolOf(base);
-    return symbol ? freshBySymbol.get(symbol) : undefined;
+  function tableOfBase(
+    base: Parser.Expression,
+    owner: Parser.Statement,
+  ): FreshTable | undefined {
+    const point = valueFlow.controlFlow.pointOf(owner);
+    if (!point) return undefined;
+    const allocation = valueFlow.allocationOfBase(base, point);
+    return allocation ? freshByAllocation.get(allocation) : undefined;
   }
 
   function analyzeStatement(
@@ -207,30 +266,24 @@ export function analyzeTableEffects(
   ): void {
     switch (statement.type) {
       case "LocalStatement":
-        if (
-          statement.variables.length === 1 &&
-          statement.init.length === 1 &&
-          statement.init[0].type === "TableConstructorExpression"
-        ) {
-          const symbol = resolved.symbolOf(statement.variables[0]);
-          if (symbol?.kind === "local") {
-            const table: FreshTable = {
-              symbol,
-              declaration: statement,
-              constructor: statement.init[0],
-              functionDepth,
-            };
-            freshTables.push(table);
-            freshBySymbol.set(symbol, table);
-          }
-        }
         statement.init.forEach((expression) => {
-          analyzeExpression(expression, statement, "alias", functionDepth);
+          if (expression.type !== "Identifier") {
+            analyzeExpression(expression, statement, "alias", functionDepth);
+          }
         });
         return;
       case "AssignmentStatement":
-        statement.init.forEach((expression) => {
-          analyzeExpression(expression, statement, "store", functionDepth);
+        statement.init.forEach((expression, index) => {
+          const target = statement.variables[index];
+          const targetSymbol =
+            target?.type === "Identifier"
+              ? resolved.symbolOf(target)
+              : undefined;
+          const aliasAssignment =
+            expression.type === "Identifier" && targetSymbol?.kind === "local";
+          if (!aliasAssignment) {
+            analyzeExpression(expression, statement, "store", functionDepth);
+          }
         });
         statement.variables.forEach((variable) => {
           if (
@@ -351,7 +404,42 @@ export function analyzeTableEffects(
     escapes,
     isNonescaping: (table) => !escapes.some((escape) => escape.table === table),
     effectsOf: (table) => effects.filter((effect) => effect.table === table),
+    stableBetween: (table, baseSymbol, first, last) =>
+      valueFlow.stableAllocationBetween(
+        first,
+        last,
+        baseSymbol,
+        table.allocation,
+      ),
   };
+
+  function bindingOfAllocation(allocation: Allocation):
+    | {
+        readonly symbol: Symbol;
+        readonly declaration:
+          Parser.LocalStatement | Parser.AssignmentStatement;
+      }
+    | undefined {
+    const owner = allocation.owner;
+    if (
+      owner.type !== "LocalStatement" &&
+      owner.type !== "AssignmentStatement"
+    ) {
+      return undefined;
+    }
+    const index = owner.init.indexOf(allocation.origin);
+    if (index < 0) return undefined;
+    const target = owner.variables[index];
+    if (target?.type !== "Identifier") return undefined;
+    const symbol = resolved.symbolOf(target);
+    return symbol ? { symbol, declaration: owner } : undefined;
+  }
+
+  function depthOf(unit: Allocation["unit"]): number {
+    let depth = 0;
+    for (let current = unit.parent; current; current = current.parent) depth++;
+    return depth;
+  }
 }
 
 export function staticKeyOf(

--- a/src/tableEffects.ts
+++ b/src/tableEffects.ts
@@ -260,6 +260,19 @@ export function analyzeTableEffects(
     return allocation ? freshByAllocation.get(allocation) : undefined;
   }
 
+  function isTrackedLocalAlias(
+    expression: Parser.Expression,
+    owner: Parser.Statement,
+    functionDepth: number,
+  ): boolean {
+    if (expression.type !== "Identifier") return false;
+    const point = valueFlow.controlFlow.pointOf(owner);
+    if (!point) return false;
+    const allocation = valueFlow.allocationOfBase(expression, point);
+    const table = allocation ? freshByAllocation.get(allocation) : undefined;
+    return table?.functionDepth === functionDepth;
+  }
+
   function analyzeStatement(
     statement: Parser.Statement,
     functionDepth: number,
@@ -267,23 +280,16 @@ export function analyzeTableEffects(
     switch (statement.type) {
       case "LocalStatement":
         statement.init.forEach((expression) => {
-          if (expression.type !== "Identifier") {
+          if (!isTrackedLocalAlias(expression, statement, functionDepth)) {
             analyzeExpression(expression, statement, "alias", functionDepth);
           }
         });
         return;
       case "AssignmentStatement":
-        statement.init.forEach((expression, index) => {
-          const target = statement.variables[index];
-          const targetSymbol =
-            target?.type === "Identifier"
-              ? resolved.symbolOf(target)
-              : undefined;
-          const aliasAssignment =
-            expression.type === "Identifier" && targetSymbol?.kind === "local";
-          if (!aliasAssignment) {
-            analyzeExpression(expression, statement, "store", functionDepth);
-          }
+        statement.init.forEach((expression) => {
+          // 既存bindingへの代入はupvalueへの公開になり得る。代入先localの
+          // execution unitを証明する解析が入るまでは、単純aliasでもescape扱い。
+          analyzeExpression(expression, statement, "store", functionDepth);
         });
         statement.variables.forEach((variable) => {
           if (

--- a/src/tableEffects.ts
+++ b/src/tableEffects.ts
@@ -1,0 +1,364 @@
+import Parser from "luaparse";
+import { ResolveResult, Symbol } from "./resolver";
+
+export interface FreshTable {
+  readonly symbol: Symbol;
+  readonly declaration: Parser.LocalStatement;
+  readonly constructor: Parser.TableConstructorExpression;
+  readonly functionDepth: number;
+}
+
+export interface TableEffect {
+  readonly access: "read" | "write";
+  readonly table: FreshTable;
+  // undefinedは動的keyまたは安全にdecodeできない文字列literal。
+  readonly staticKey: string | undefined;
+  readonly expression: Parser.MemberExpression | Parser.IndexExpression;
+  readonly owner: Parser.Statement;
+}
+
+export type TableEscapeReason =
+  "alias" | "call" | "return" | "store" | "capture" | "value-use";
+
+export interface TableEscape {
+  readonly table: FreshTable;
+  readonly reason: TableEscapeReason;
+  readonly identifier: Parser.Identifier;
+  readonly owner: Parser.Statement;
+}
+
+export interface TableEffectAnalysis {
+  readonly freshTables: readonly FreshTable[];
+  readonly effects: readonly TableEffect[];
+  readonly escapes: readonly TableEscape[];
+  isNonescaping(table: FreshTable): boolean;
+  effectsOf(table: FreshTable): readonly TableEffect[];
+}
+
+type ValueUse = "value-use" | "alias" | "call" | "return" | "store";
+
+/** fresh local tableに対する構文事実を収集する。ASTは変更しない。 */
+export function analyzeTableEffects(
+  chunk: Parser.Chunk,
+  resolved: ResolveResult,
+): TableEffectAnalysis {
+  const freshTables: FreshTable[] = [];
+  const freshBySymbol = new Map<Symbol, FreshTable>();
+  const effects: TableEffect[] = [];
+  const escapes: TableEscape[] = [];
+
+  analyzeBlock(chunk.body, 0);
+
+  function escapeIdentifier(
+    identifier: Parser.Identifier,
+    use: ValueUse,
+    owner: Parser.Statement,
+    functionDepth: number,
+  ): void {
+    const symbol = resolved.symbolOf(identifier);
+    const table = symbol ? freshBySymbol.get(symbol) : undefined;
+    if (!table) return;
+    escapes.push({
+      table,
+      reason: functionDepth > table.functionDepth ? "capture" : use,
+      identifier,
+      owner,
+    });
+  }
+
+  function analyzeExpression(
+    expression: Parser.Expression,
+    owner: Parser.Statement,
+    use: ValueUse,
+    functionDepth: number,
+  ): void {
+    switch (expression.type) {
+      case "Identifier":
+        escapeIdentifier(expression, use, owner, functionDepth);
+        return;
+      case "StringLiteral":
+      case "NumericLiteral":
+      case "BooleanLiteral":
+      case "NilLiteral":
+      case "VarargLiteral":
+        return;
+      case "LogicalExpression":
+      case "BinaryExpression":
+        analyzeExpression(expression.left, owner, "value-use", functionDepth);
+        analyzeExpression(expression.right, owner, "value-use", functionDepth);
+        return;
+      case "UnaryExpression":
+        analyzeExpression(
+          expression.argument,
+          owner,
+          "value-use",
+          functionDepth,
+        );
+        return;
+      case "MemberExpression":
+      case "IndexExpression":
+        analyzeTableAccess(expression, "read", owner, functionDepth);
+        return;
+      case "CallExpression":
+        analyzeCallParts(
+          expression.base,
+          expression.arguments,
+          owner,
+          functionDepth,
+        );
+        return;
+      case "TableCallExpression":
+        analyzeCallParts(
+          expression.base,
+          [expression.arguments],
+          owner,
+          functionDepth,
+        );
+        return;
+      case "StringCallExpression":
+        analyzeCallParts(
+          expression.base,
+          [expression.argument],
+          owner,
+          functionDepth,
+        );
+        return;
+      case "FunctionDeclaration":
+        analyzeBlock(expression.body, functionDepth + 1);
+        return;
+      case "TableConstructorExpression":
+        expression.fields.forEach((field) => {
+          if (field.type === "TableKey") {
+            analyzeExpression(field.key, owner, "value-use", functionDepth);
+          }
+          analyzeExpression(field.value, owner, "store", functionDepth);
+        });
+        return;
+      default: {
+        const exhaustive: never = expression;
+        throw new TypeError(
+          "Unknown expression type: `" + JSON.stringify(exhaustive) + "`",
+        );
+      }
+    }
+  }
+
+  function analyzeCallParts(
+    base: Parser.Expression,
+    args: Parser.Expression[],
+    owner: Parser.Statement,
+    functionDepth: number,
+  ): void {
+    analyzeExpression(base, owner, "call", functionDepth);
+    args.forEach((argument) => {
+      analyzeExpression(argument, owner, "call", functionDepth);
+    });
+    if (base.type === "MemberExpression" && base.indexer === ":") {
+      const table = tableOfBase(base.base);
+      if (table && base.base.type === "Identifier") {
+        escapeIdentifier(base.base, "call", owner, functionDepth);
+      }
+    }
+  }
+
+  function analyzeTableAccess(
+    expression: Parser.MemberExpression | Parser.IndexExpression,
+    access: TableEffect["access"],
+    owner: Parser.Statement,
+    functionDepth: number,
+  ): void {
+    const table = tableOfBase(expression.base);
+    if (table) {
+      effects.push({
+        access,
+        table,
+        staticKey: staticKeyOf(expression),
+        expression,
+        owner,
+      });
+      if (
+        functionDepth > table.functionDepth &&
+        expression.base.type === "Identifier"
+      ) {
+        escapeIdentifier(expression.base, "value-use", owner, functionDepth);
+      }
+    } else {
+      analyzeExpression(expression.base, owner, "value-use", functionDepth);
+    }
+    if (expression.type === "IndexExpression") {
+      analyzeExpression(expression.index, owner, "value-use", functionDepth);
+    }
+  }
+
+  function tableOfBase(base: Parser.Expression): FreshTable | undefined {
+    if (base.type !== "Identifier") return undefined;
+    const symbol = resolved.symbolOf(base);
+    return symbol ? freshBySymbol.get(symbol) : undefined;
+  }
+
+  function analyzeStatement(
+    statement: Parser.Statement,
+    functionDepth: number,
+  ): void {
+    switch (statement.type) {
+      case "LocalStatement":
+        if (
+          statement.variables.length === 1 &&
+          statement.init.length === 1 &&
+          statement.init[0].type === "TableConstructorExpression"
+        ) {
+          const symbol = resolved.symbolOf(statement.variables[0]);
+          if (symbol?.kind === "local") {
+            const table: FreshTable = {
+              symbol,
+              declaration: statement,
+              constructor: statement.init[0],
+              functionDepth,
+            };
+            freshTables.push(table);
+            freshBySymbol.set(symbol, table);
+          }
+        }
+        statement.init.forEach((expression) => {
+          analyzeExpression(expression, statement, "alias", functionDepth);
+        });
+        return;
+      case "AssignmentStatement":
+        statement.init.forEach((expression) => {
+          analyzeExpression(expression, statement, "store", functionDepth);
+        });
+        statement.variables.forEach((variable) => {
+          if (
+            variable.type === "MemberExpression" ||
+            variable.type === "IndexExpression"
+          ) {
+            analyzeTableAccess(variable, "write", statement, functionDepth);
+          }
+        });
+        return;
+      case "CallStatement":
+        analyzeExpression(
+          statement.expression,
+          statement,
+          "call",
+          functionDepth,
+        );
+        return;
+      case "DoStatement":
+        analyzeBlock(statement.body, functionDepth);
+        return;
+      case "WhileStatement":
+        analyzeExpression(
+          statement.condition,
+          statement,
+          "value-use",
+          functionDepth,
+        );
+        analyzeBlock(statement.body, functionDepth);
+        return;
+      case "RepeatStatement":
+        analyzeBlock(statement.body, functionDepth);
+        analyzeExpression(
+          statement.condition,
+          statement,
+          "value-use",
+          functionDepth,
+        );
+        return;
+      case "IfStatement":
+        statement.clauses.forEach((clause) => {
+          if (clause.type !== "ElseClause") {
+            analyzeExpression(
+              clause.condition,
+              statement,
+              "value-use",
+              functionDepth,
+            );
+          }
+          analyzeBlock(clause.body, functionDepth);
+        });
+        return;
+      case "ForNumericStatement":
+        analyzeExpression(
+          statement.start,
+          statement,
+          "value-use",
+          functionDepth,
+        );
+        analyzeExpression(statement.end, statement, "value-use", functionDepth);
+        if (statement.step) {
+          analyzeExpression(
+            statement.step,
+            statement,
+            "value-use",
+            functionDepth,
+          );
+        }
+        analyzeBlock(statement.body, functionDepth);
+        return;
+      case "ForGenericStatement":
+        statement.iterators.forEach((iterator) => {
+          analyzeExpression(iterator, statement, "value-use", functionDepth);
+        });
+        analyzeBlock(statement.body, functionDepth);
+        return;
+      case "FunctionDeclaration":
+        if (
+          statement.identifier &&
+          statement.identifier.type !== "Identifier"
+        ) {
+          analyzeTableAccess(
+            statement.identifier,
+            "write",
+            statement,
+            functionDepth,
+          );
+        }
+        analyzeBlock(statement.body, functionDepth + 1);
+        return;
+      case "ReturnStatement":
+        statement.arguments.forEach((argument) => {
+          analyzeExpression(argument, statement, "return", functionDepth);
+        });
+        return;
+      case "BreakStatement":
+      case "LabelStatement":
+      case "GotoStatement":
+        return;
+      default: {
+        const exhaustive: never = statement;
+        throw new TypeError(
+          "Unknown statement type: `" + JSON.stringify(exhaustive) + "`",
+        );
+      }
+    }
+  }
+
+  function analyzeBlock(body: Parser.Statement[], functionDepth: number): void {
+    body.forEach((statement) => {
+      analyzeStatement(statement, functionDepth);
+    });
+  }
+
+  return {
+    freshTables,
+    effects,
+    escapes,
+    isNonescaping: (table) => !escapes.some((escape) => escape.table === table),
+    effectsOf: (table) => effects.filter((effect) => effect.table === table),
+  };
+}
+
+export function staticKeyOf(
+  expression: Parser.MemberExpression | Parser.IndexExpression,
+): string | undefined {
+  if (expression.type === "MemberExpression") return expression.identifier.name;
+  if (expression.index.type !== "StringLiteral") return undefined;
+  const raw = expression.index.raw;
+  if (raw.length < 2 || raw.includes("\\")) return undefined;
+  const quote = raw[0];
+  if ((quote !== '"' && quote !== "'") || raw[raw.length - 1] !== quote) {
+    return undefined;
+  }
+  return raw.slice(1, -1);
+}

--- a/src/tableEffects.ts
+++ b/src/tableEffects.ts
@@ -1,5 +1,10 @@
 import Parser from "luaparse";
 import { ResolveResult, Symbol } from "./resolver";
+import {
+  decodeLuaStringLiteral,
+  luaByteStringKey,
+  luaByteStringOfText,
+} from "./luaString";
 
 export interface FreshTable {
   readonly symbol: Symbol;
@@ -352,13 +357,10 @@ export function analyzeTableEffects(
 export function staticKeyOf(
   expression: Parser.MemberExpression | Parser.IndexExpression,
 ): string | undefined {
-  if (expression.type === "MemberExpression") return expression.identifier.name;
-  if (expression.index.type !== "StringLiteral") return undefined;
-  const raw = expression.index.raw;
-  if (raw.length < 2 || raw.includes("\\")) return undefined;
-  const quote = raw[0];
-  if ((quote !== '"' && quote !== "'") || raw[raw.length - 1] !== quote) {
-    return undefined;
+  if (expression.type === "MemberExpression") {
+    return luaByteStringKey(luaByteStringOfText(expression.identifier.name));
   }
-  return raw.slice(1, -1);
+  if (expression.index.type !== "StringLiteral") return undefined;
+  const decoded = decodeLuaStringLiteral(expression.index);
+  return decoded.ok ? luaByteStringKey(decoded.value) : undefined;
 }

--- a/src/tableEffects.ts
+++ b/src/tableEffects.ts
@@ -41,12 +41,19 @@ export interface TableEffectAnalysis {
   readonly escapes: readonly TableEscape[];
   isNonescaping(table: FreshTable): boolean;
   effectsOf(table: FreshTable): readonly TableEffect[];
-  stableBetween(
+  escapeReasonsOf(table: FreshTable): readonly TableEscapeReason[];
+  stabilityBetween(
     table: FreshTable,
     baseSymbol: Symbol,
     first: Parser.Statement,
     last: Parser.Statement,
-  ): boolean;
+  ):
+    | { readonly stable: true }
+    | {
+        readonly stable: false;
+        readonly reason:
+          "control-flow-barrier" | "unstable-reaching-definition";
+      };
 }
 
 type ValueUse = "value-use" | "alias" | "call" | "return" | "store";
@@ -410,13 +417,23 @@ export function analyzeTableEffects(
     escapes,
     isNonescaping: (table) => !escapes.some((escape) => escape.table === table),
     effectsOf: (table) => effects.filter((effect) => effect.table === table),
-    stableBetween: (table, baseSymbol, first, last) =>
-      valueFlow.stableAllocationBetween(
+    escapeReasonsOf: (table) =>
+      escapes
+        .filter((escape) => escape.table === table)
+        .map((escape) => escape.reason),
+    stabilityBetween: (table, baseSymbol, first, last) => {
+      if (!valueFlow.controlFlow.pointsBetween(first, last)) {
+        return { stable: false, reason: "control-flow-barrier" };
+      }
+      return valueFlow.stableAllocationBetween(
         first,
         last,
         baseSymbol,
         table.allocation,
-      ),
+      )
+        ? { stable: true }
+        : { stable: false, reason: "unstable-reaching-definition" };
+    },
   };
 
   function bindingOfAllocation(allocation: Allocation):

--- a/src/tableReadMerge.ts
+++ b/src/tableReadMerge.ts
@@ -5,6 +5,10 @@ import { SourceMetadata } from "./sourceMetadata";
 import { TransformResult } from "./optimizerPass";
 import { childStatementBodies } from "./controlFlow";
 import { TableEffect, TableEffectAnalysis } from "./tableEffects";
+import {
+  OptimizationDiagnosticReason,
+  OptimizationDiagnosticSink,
+} from "./optimizerDiagnostics";
 
 export interface TableReadMergeGroup {
   readonly body: Parser.Statement[];
@@ -22,6 +26,8 @@ export interface TableReadMergeOptions {
   readonly dirtyGranularity: "table" | "static-key";
   readonly canMoveStatement?: (statement: Parser.LocalStatement) => boolean;
   readonly maxMergeArity?: number;
+  readonly diagnostics?: OptimizationDiagnosticSink;
+  readonly moduleName?: string;
 }
 
 interface Candidate {
@@ -47,7 +53,24 @@ export function planTableReadMerges(
     body.forEach((statement, index) => indexOf.set(statement, index));
     let run: Candidate[] = [];
 
-    const flush = () => {
+    const record = (
+      decision: "accepted" | "rejected",
+      reason: OptimizationDiagnosticReason,
+      candidateSize: number,
+      estimatedByteSavings?: number,
+    ) =>
+      options.diagnostics?.record({
+        pass: "effect-aware-table-reads",
+        moduleName: options.moduleName,
+        decision,
+        reason,
+        candidateSize,
+        estimatedByteSavings,
+      });
+    const flush = (
+      rejectionReason: OptimizationDiagnosticReason = "insufficient-group",
+    ) => {
+      let accepted = 0;
       const maxMergeArity = options.maxMergeArity ?? DEFAULT_MAX_MERGE_ARITY;
       for (let start = 0; start < run.length; start += maxMergeArity) {
         const part = run.slice(start, start + maxMergeArity);
@@ -60,6 +83,7 @@ export function planTableReadMerges(
         ) {
           continue;
         }
+        const estimatedByteSavings = 5 * (part.length - 1);
         groups.push({
           body,
           statements: part.map((candidate) => candidate.statement),
@@ -67,8 +91,18 @@ export function planTableReadMerges(
           reads: part.map((candidate) => candidate.read),
           // N文を1文へまとめると、2文目以降ごとに`local `と`=`の重複から
           // 変数/init間のcommaを差し引いて5 bytesずつ減る。
-          estimatedByteSavings: 5 * (part.length - 1),
+          estimatedByteSavings,
         });
+        accepted += part.length;
+        record(
+          "accepted",
+          "profitable-group",
+          part.length,
+          estimatedByteSavings,
+        );
+      }
+      if (run.length > accepted) {
+        record("rejected", rejectionReason, run.length - accepted);
       }
       run = [];
     };
@@ -77,7 +111,7 @@ export function planTableReadMerges(
       if (isIntervening(statement)) return;
       const candidate = candidateOf(statement, index, tableEffects, options);
       if (!candidate) {
-        flush();
+        flush("noncandidate-boundary");
         return;
       }
 
@@ -98,7 +132,7 @@ export function planTableReadMerges(
           options.dirtyGranularity,
         )
       ) {
-        flush();
+        flush("effect-or-binding-barrier");
       }
       run.push(candidate);
     });

--- a/src/tableReadMerge.ts
+++ b/src/tableReadMerge.ts
@@ -1,0 +1,212 @@
+import Parser from "luaparse";
+import { AstWalkVisitor, walkStatement } from "./astWalk";
+import { EffectAnalysis } from "./effectAnalysis";
+import { copyNodeOrigin } from "./generatedNode";
+import { SourceMetadata } from "./sourceMetadata";
+import { TableEffect, TableEffectAnalysis } from "./tableEffects";
+
+export interface TableReadMergeGroup {
+  readonly body: Parser.Statement[];
+  readonly statements: readonly Parser.LocalStatement[];
+  readonly indexes: readonly number[];
+  readonly reads: readonly TableEffect[];
+  readonly estimatedByteSavings: number;
+}
+
+export interface TableReadMergePlan {
+  readonly groups: readonly TableReadMergeGroup[];
+}
+
+export interface TableReadMergeOptions {
+  // falseはtable全体dirty、trueは(table,key)単位のdirty判定。
+  readonly fieldSensitive: boolean;
+}
+
+interface Candidate {
+  readonly statement: Parser.LocalStatement;
+  readonly index: number;
+  readonly read: TableEffect;
+}
+
+export function planTableReadMerges(
+  chunk: Parser.Chunk,
+  bindingEffects: EffectAnalysis,
+  tableEffects: TableEffectAnalysis,
+  options: TableReadMergeOptions,
+): TableReadMergePlan {
+  const groups: TableReadMergeGroup[] = [];
+
+  function processBlock(body: Parser.Statement[]): void {
+    childBlocksOf(body).forEach(processBlock);
+    const indexOf = new Map<Parser.Statement, number>();
+    body.forEach((statement, index) => indexOf.set(statement, index));
+    let run: Candidate[] = [];
+
+    const flush = () => {
+      if (run.length >= 2) {
+        groups.push({
+          body,
+          statements: run.map((candidate) => candidate.statement),
+          indexes: run.map((candidate) => candidate.index),
+          reads: run.map((candidate) => candidate.read),
+          // N文を1文へまとめると、2文目以降ごとに`local `と`=`の重複から
+          // 変数/init間のcommaを差し引いて5 bytesずつ減る。
+          estimatedByteSavings: 5 * (run.length - 1),
+        });
+      }
+      run = [];
+    };
+
+    body.forEach((statement, index) => {
+      if (isIntervening(statement)) return;
+      const candidate = candidateOf(statement, index, tableEffects);
+      if (!candidate) {
+        flush();
+        return;
+      }
+
+      if (
+        shadowsInterveningReference(body, run[0]?.index ?? index, candidate) ||
+        tableIsDirtyBetween(
+          candidate.read,
+          run[0]?.index ?? index,
+          index,
+          indexOf,
+          bindingEffects,
+          tableEffects,
+          options.fieldSensitive,
+        )
+      ) {
+        flush();
+      }
+      run.push(candidate);
+    });
+    flush();
+  }
+
+  processBlock(chunk.body);
+  return { groups };
+}
+
+export function applyTableReadMergePlan(
+  plan: TableReadMergePlan,
+  metadata?: SourceMetadata,
+): { readonly changed: boolean; readonly invalidatesResolve: boolean } {
+  [...plan.groups].reverse().forEach((group) => {
+    const combined: Parser.LocalStatement = {
+      type: "LocalStatement",
+      variables: group.statements.map((statement) => statement.variables[0]),
+      init: group.statements.map((statement) => statement.init[0]),
+    };
+    copyNodeOrigin(combined, group.statements[0]);
+    metadata?.transferStatements(group.statements, combined);
+
+    for (let offset = group.indexes.length - 1; offset >= 0; offset--) {
+      const index = group.indexes[offset];
+      if (offset === 0) {
+        group.body.splice(index, 1, combined);
+      } else {
+        group.body.splice(index, 1);
+      }
+    }
+  });
+  return {
+    changed: plan.groups.length > 0,
+    invalidatesResolve: plan.groups.length > 0,
+  };
+}
+
+function candidateOf(
+  statement: Parser.Statement,
+  index: number,
+  analysis: TableEffectAnalysis,
+): Candidate | undefined {
+  if (
+    statement.type !== "LocalStatement" ||
+    statement.variables.length !== 1 ||
+    statement.init.length !== 1 ||
+    (statement.init[0].type !== "MemberExpression" &&
+      statement.init[0].type !== "IndexExpression")
+  ) {
+    return undefined;
+  }
+  const read = analysis.effects.find(
+    (effect) =>
+      effect.access === "read" &&
+      effect.expression === statement.init[0] &&
+      effect.staticKey !== undefined &&
+      analysis.isNonescaping(effect.table),
+  );
+  return read ? { statement, index, read } : undefined;
+}
+
+function isIntervening(statement: Parser.Statement): boolean {
+  return (
+    statement.type === "AssignmentStatement" ||
+    statement.type === "CallStatement"
+  );
+}
+
+function tableIsDirtyBetween(
+  read: TableEffect,
+  start: number,
+  end: number,
+  indexOf: ReadonlyMap<Parser.Statement, number>,
+  bindingEffects: EffectAnalysis,
+  tableEffects: TableEffectAnalysis,
+  fieldSensitive: boolean,
+): boolean {
+  const inOpenInterval = (owner: Parser.Node): boolean => {
+    const index = indexOf.get(owner as Parser.Statement);
+    return index !== undefined && start < index && index < end;
+  };
+  const bindingWrite = bindingEffects
+    .accessesOf(read.table.symbol)
+    .some(
+      (effect) => effect.access === "write" && inOpenInterval(effect.owner),
+    );
+  if (bindingWrite) return true;
+
+  return tableEffects.effectsOf(read.table).some((effect) => {
+    if (effect.access !== "write" || !inOpenInterval(effect.owner))
+      return false;
+    if (!fieldSensitive) return true;
+    return (
+      effect.staticKey === undefined || effect.staticKey === read.staticKey
+    );
+  });
+}
+
+function shadowsInterveningReference(
+  body: Parser.Statement[],
+  start: number,
+  candidate: Candidate,
+): boolean {
+  const name = candidate.statement.variables[0].name;
+  for (let index = start; index <= candidate.index; index++) {
+    const names: string[] = [];
+    const visitor: AstWalkVisitor = {
+      onIdentifierReference: (identifier) => {
+        names.push(identifier.name);
+      },
+      onBlock: (nested) => {
+        nested.forEach((statement) => {
+          walkStatement(statement, visitor);
+        });
+      },
+    };
+    walkStatement(body[index], visitor);
+    if (names.includes(name)) return true;
+  }
+  return false;
+}
+
+function childBlocksOf(body: Parser.Statement[]): Parser.Statement[][] {
+  const children: Parser.Statement[][] = [];
+  body.forEach((statement) => {
+    walkStatement(statement, {
+      onBlock: (nested) => children.push(nested),
+    });
+  });
+  return children;
+}

--- a/src/tableReadMerge.ts
+++ b/src/tableReadMerge.ts
@@ -4,6 +4,7 @@ import { EffectAnalysis } from "./effectAnalysis";
 import { copyNodeOrigin } from "./generatedNode";
 import { SourceMetadata } from "./sourceMetadata";
 import { TransformResult } from "./optimizerPass";
+import { childStatementBodies } from "./controlFlow";
 import { TableEffect, TableEffectAnalysis } from "./tableEffects";
 
 export interface TableReadMergeGroup {
@@ -231,11 +232,5 @@ function shadowsInterveningReference(
 }
 
 function childBlocksOf(body: Parser.Statement[]): Parser.Statement[][] {
-  const children: Parser.Statement[][] = [];
-  body.forEach((statement) => {
-    walkStatement(statement, {
-      onBlock: (nested) => children.push(nested),
-    });
-  });
-  return children;
+  return childStatementBodies(body);
 }

--- a/src/tableReadMerge.ts
+++ b/src/tableReadMerge.ts
@@ -3,6 +3,7 @@ import { AstWalkVisitor, walkStatement } from "./astWalk";
 import { EffectAnalysis } from "./effectAnalysis";
 import { copyNodeOrigin } from "./generatedNode";
 import { SourceMetadata } from "./sourceMetadata";
+import { TransformResult } from "./optimizerPass";
 import { TableEffect, TableEffectAnalysis } from "./tableEffects";
 
 export interface TableReadMergeGroup {
@@ -111,7 +112,7 @@ export function planTableReadMerges(
 export function applyTableReadMergePlan(
   plan: TableReadMergePlan,
   metadata?: SourceMetadata,
-): { readonly changed: boolean; readonly invalidatesResolve: boolean } {
+): TransformResult {
   [...plan.groups].reverse().forEach((group) => {
     const combined: Parser.LocalStatement = {
       type: "LocalStatement",

--- a/src/tableReadMerge.ts
+++ b/src/tableReadMerge.ts
@@ -22,6 +22,7 @@ export interface TableReadMergePlan {
 export interface TableReadMergeOptions {
   readonly dirtyGranularity: "table" | "static-key";
   readonly canMoveStatement?: (statement: Parser.LocalStatement) => boolean;
+  readonly maxMergeArity?: number;
 }
 
 interface Candidate {
@@ -32,7 +33,7 @@ interface Candidate {
 
 // Lua 5.3のlocal上限200とregister上限255の差より小さく保つ。
 // static table readは単純でも、全RHSを同時評価する巨大local文を生成しない。
-const MAX_MERGE_ARITY = 50;
+const DEFAULT_MAX_MERGE_ARITY = 50;
 
 export function planTableReadMerges(
   chunk: Parser.Chunk,
@@ -49,8 +50,9 @@ export function planTableReadMerges(
     let run: Candidate[] = [];
 
     const flush = () => {
-      for (let start = 0; start < run.length; start += MAX_MERGE_ARITY) {
-        const part = run.slice(start, start + MAX_MERGE_ARITY);
+      const maxMergeArity = options.maxMergeArity ?? DEFAULT_MAX_MERGE_ARITY;
+      for (let start = 0; start < run.length; start += maxMergeArity) {
+        const part = run.slice(start, start + maxMergeArity);
         if (part.length < 2) continue;
         if (
           !part.some(

--- a/src/tableReadMerge.ts
+++ b/src/tableReadMerge.ts
@@ -27,6 +27,10 @@ interface Candidate {
   readonly read: TableEffect;
 }
 
+// Lua 5.3のlocal上限200とregister上限255の差より小さく保つ。
+// static table readは単純でも、全RHSを同時評価する巨大local文を生成しない。
+const MAX_MERGE_ARITY = 50;
+
 export function planTableReadMerges(
   chunk: Parser.Chunk,
   bindingEffects: EffectAnalysis,
@@ -42,15 +46,17 @@ export function planTableReadMerges(
     let run: Candidate[] = [];
 
     const flush = () => {
-      if (run.length >= 2) {
+      for (let start = 0; start < run.length; start += MAX_MERGE_ARITY) {
+        const part = run.slice(start, start + MAX_MERGE_ARITY);
+        if (part.length < 2) continue;
         groups.push({
           body,
-          statements: run.map((candidate) => candidate.statement),
-          indexes: run.map((candidate) => candidate.index),
-          reads: run.map((candidate) => candidate.read),
+          statements: part.map((candidate) => candidate.statement),
+          indexes: part.map((candidate) => candidate.index),
+          reads: part.map((candidate) => candidate.read),
           // N文を1文へまとめると、2文目以降ごとに`local `と`=`の重複から
           // 変数/init間のcommaを差し引いて5 bytesずつ減る。
-          estimatedByteSavings: 5 * (run.length - 1),
+          estimatedByteSavings: 5 * (part.length - 1),
         });
       }
       run = [];
@@ -58,7 +64,12 @@ export function planTableReadMerges(
 
     body.forEach((statement, index) => {
       if (isIntervening(statement)) return;
-      const candidate = candidateOf(statement, index, tableEffects);
+      const candidate = candidateOf(
+        statement,
+        index,
+        bindingEffects,
+        tableEffects,
+      );
       if (!candidate) {
         flush();
         return;
@@ -118,6 +129,7 @@ export function applyTableReadMergePlan(
 function candidateOf(
   statement: Parser.Statement,
   index: number,
+  bindingEffects: EffectAnalysis,
   analysis: TableEffectAnalysis,
 ): Candidate | undefined {
   if (
@@ -134,7 +146,12 @@ function candidateOf(
       effect.access === "read" &&
       effect.expression === statement.init[0] &&
       effect.staticKey !== undefined &&
-      analysis.isNonescaping(effect.table),
+      analysis.isNonescaping(effect.table) &&
+      // Symbolの現在値をallocationへ結び付けるpoints-to/CFGはまだ無い。
+      // 一度でも再代入されれば、以後のaccessを元fresh tableとはみなさない。
+      !bindingEffects
+        .accessesOf(effect.table.symbol)
+        .some((binding) => binding.access === "write"),
   );
   return read ? { statement, index, read } : undefined;
 }

--- a/src/tableReadMerge.ts
+++ b/src/tableReadMerge.ts
@@ -236,7 +236,7 @@ function candidateOf(
 ): CandidateDecision {
   if (statement.type !== "LocalStatement") return undefined;
   const init = statement.init[0];
-  if (init?.type !== "MemberExpression" && init?.type !== "IndexExpression") {
+  if (init.type !== "MemberExpression" && init.type !== "IndexExpression") {
     return undefined;
   }
   if (statement.variables.length !== 1 || statement.init.length !== 1) {
@@ -259,8 +259,10 @@ function candidateOf(
     }
     return { reason: "dynamic-key" };
   }
-  const escape = analysis.escapeReasonsOf(read.table)[0];
-  if (escape) return { reason: escapeReasonOf(escape) };
+  const escapeReasons = analysis.escapeReasonsOf(read.table);
+  if (escapeReasons.length > 0) {
+    return { reason: escapeReasonOf(escapeReasons[0]) };
+  }
   return { candidate: { statement, index, read } };
 }
 

--- a/src/tableReadMerge.ts
+++ b/src/tableReadMerge.ts
@@ -9,6 +9,8 @@ import {
   OptimizationDiagnosticReason,
   OptimizationDiagnosticSink,
 } from "./optimizerDiagnostics";
+import { decodeLuaStringLiteral } from "./luaString";
+import { RuntimeProfile } from "./runtimeEnvironment";
 
 export interface TableReadMergeGroup {
   readonly body: Parser.Statement[];
@@ -26,8 +28,10 @@ export interface TableReadMergeOptions {
   readonly dirtyGranularity: "table" | "static-key";
   readonly canMoveStatement?: (statement: Parser.LocalStatement) => boolean;
   readonly maxMergeArity?: number;
+  readonly maxMergeArityAt?: (statement: Parser.LocalStatement) => number;
   readonly diagnostics?: OptimizationDiagnosticSink;
   readonly moduleName?: string;
+  readonly runtimeProfile?: RuntimeProfile;
 }
 
 interface Candidate {
@@ -35,6 +39,11 @@ interface Candidate {
   readonly index: number;
   readonly read: TableEffect;
 }
+
+type CandidateDecision =
+  | { readonly candidate: Candidate }
+  | { readonly reason: OptimizationDiagnosticReason }
+  | undefined;
 
 // Lua 5.3のlocal上限200とregister上限255の差より小さく保つ。
 // static table readは単純でも、全RHSを同時評価する巨大local文を生成しない。
@@ -58,22 +67,36 @@ export function planTableReadMerges(
       reason: OptimizationDiagnosticReason,
       candidateSize: number,
       estimatedByteSavings?: number,
+      estimatedOpportunityBytes?: number,
+      sourceRange?: readonly [number, number],
     ) =>
       options.diagnostics?.record({
         pass: "effect-aware-table-reads",
         moduleName: options.moduleName,
+        runtimeProfile: options.runtimeProfile,
         decision,
         reason,
         candidateSize,
         estimatedByteSavings,
+        estimatedOpportunityBytes,
+        sourceRange,
       });
     const flush = (
       rejectionReason: OptimizationDiagnosticReason = "insufficient-group",
     ) => {
       let accepted = 0;
-      const maxMergeArity = options.maxMergeArity ?? DEFAULT_MAX_MERGE_ARITY;
-      for (let start = 0; start < run.length; start += maxMergeArity) {
+      const policyLimit = options.maxMergeArity ?? DEFAULT_MAX_MERGE_ARITY;
+      for (let start = 0; start < run.length;) {
+        const maxMergeArity = Math.min(
+          policyLimit,
+          options.maxMergeArityAt?.(run[start].statement) ?? policyLimit,
+        );
+        if (maxMergeArity < 2) {
+          start++;
+          continue;
+        }
         const part = run.slice(start, start + maxMergeArity);
+        start += part.length;
         if (part.length < 2) continue;
         if (
           !part.some(
@@ -99,40 +122,74 @@ export function planTableReadMerges(
           "profitable-group",
           part.length,
           estimatedByteSavings,
+          undefined,
+          rangeOf(part[0].statement),
         );
       }
       if (run.length > accepted) {
-        record("rejected", rejectionReason, run.length - accepted);
+        const rejected = run.length - accepted;
+        record(
+          "rejected",
+          run.length > policyLimit && rejected === 1
+            ? "resource-budget"
+            : rejectionReason,
+          rejected,
+          undefined,
+          Math.max(0, 5 * (rejected - 1)),
+          rangeOf(run[accepted]?.statement),
+        );
       }
       run = [];
     };
 
     body.forEach((statement, index) => {
       if (isIntervening(statement)) return;
-      const candidate = candidateOf(statement, index, tableEffects, options);
-      if (!candidate) {
-        flush("noncandidate-boundary");
+      const decision = candidateOf(statement, index, tableEffects, options);
+      if (!decision) {
+        flush("control-flow-barrier");
         return;
       }
+      if ("reason" in decision) {
+        flush("control-flow-barrier");
+        record(
+          "rejected",
+          decision.reason,
+          1,
+          undefined,
+          0,
+          rangeOf(statement),
+        );
+        return;
+      }
+      const candidate = decision.candidate;
 
-      if (
-        shadowsInterveningReference(body, run[0]?.index ?? index, candidate) ||
-        !tableEffects.stableBetween(
-          candidate.read.table,
-          candidate.read.baseSymbol,
-          run[0]?.statement ?? statement,
-          statement,
-        ) ||
-        tableIsDirtyBetween(
-          candidate.read,
-          run[0]?.index ?? index,
-          index,
-          indexOf,
-          tableEffects,
-          options.dirtyGranularity,
-        )
-      ) {
-        flush("effect-or-binding-barrier");
+      const shadowed = shadowsInterveningReference(
+        body,
+        run[0]?.index ?? index,
+        candidate,
+      );
+      const stability = tableEffects.stabilityBetween(
+        candidate.read.table,
+        candidate.read.baseSymbol,
+        run[0]?.statement ?? statement,
+        statement,
+      );
+      const dirtyReason = tableDirtyReasonBetween(
+        candidate.read,
+        run[0]?.index ?? index,
+        index,
+        indexOf,
+        tableEffects,
+        options.dirtyGranularity,
+      );
+      if (shadowed || !stability.stable || dirtyReason) {
+        flush(
+          shadowed
+            ? "binding-shadow-hazard"
+            : !stability.stable
+              ? stability.reason
+              : dirtyReason,
+        );
       }
       run.push(candidate);
     });
@@ -176,25 +233,35 @@ function candidateOf(
   index: number,
   analysis: TableEffectAnalysis,
   options: TableReadMergeOptions,
-): Candidate | undefined {
-  if (
-    statement.type !== "LocalStatement" ||
-    statement.variables.length !== 1 ||
-    statement.init.length !== 1 ||
-    (statement.init[0].type !== "MemberExpression" &&
-      statement.init[0].type !== "IndexExpression")
-  ) {
+): CandidateDecision {
+  if (statement.type !== "LocalStatement") return undefined;
+  const init = statement.init[0];
+  if (init?.type !== "MemberExpression" && init?.type !== "IndexExpression") {
     return undefined;
   }
-  if (options.canMoveStatement?.(statement) === false) return undefined;
+  if (statement.variables.length !== 1 || statement.init.length !== 1) {
+    return { reason: "unsupported-shape" };
+  }
+  if (options.canMoveStatement?.(statement) === false) {
+    return { reason: "metadata-preserved" };
+  }
   const read = analysis.effects.find(
-    (effect) =>
-      effect.access === "read" &&
-      effect.expression === statement.init[0] &&
-      effect.staticKey !== undefined &&
-      analysis.isNonescaping(effect.table),
+    (effect) => effect.access === "read" && effect.expression === init,
   );
-  return read ? { statement, index, read } : undefined;
+  if (!read) return { reason: "allocation-unknown" };
+  if (read.staticKey === undefined) {
+    if (
+      init.type === "IndexExpression" &&
+      init.index.type === "StringLiteral" &&
+      !decodeLuaStringLiteral(init.index).ok
+    ) {
+      return { reason: "unsupported-string-key" };
+    }
+    return { reason: "dynamic-key" };
+  }
+  const escape = analysis.escapeReasonsOf(read.table)[0];
+  if (escape) return { reason: escapeReasonOf(escape) };
+  return { candidate: { statement, index, read } };
 }
 
 function isIntervening(statement: Parser.Statement): boolean {
@@ -204,19 +271,19 @@ function isIntervening(statement: Parser.Statement): boolean {
   );
 }
 
-function tableIsDirtyBetween(
+function tableDirtyReasonBetween(
   read: TableEffect,
   start: number,
   end: number,
   indexOf: ReadonlyMap<Parser.Statement, number>,
   tableEffects: TableEffectAnalysis,
   dirtyGranularity: TableReadMergeOptions["dirtyGranularity"],
-): boolean {
+): OptimizationDiagnosticReason | undefined {
   const inOpenInterval = (owner: Parser.Node): boolean => {
     const index = indexOf.get(owner as Parser.Statement);
     return index !== undefined && start < index && index < end;
   };
-  return tableEffects.effectsOf(read.table).some((effect) => {
+  const dirty = tableEffects.effectsOf(read.table).find((effect) => {
     if (effect.access !== "write" || !inOpenInterval(effect.owner))
       return false;
     if (dirtyGranularity === "table") return true;
@@ -224,6 +291,35 @@ function tableIsDirtyBetween(
       effect.staticKey === undefined || effect.staticKey === read.staticKey
     );
   });
+  if (!dirty) return undefined;
+  return dirtyGranularity === "static-key" && dirty.staticKey !== undefined
+    ? "dirty-static-key"
+    : "dirty-table";
+}
+
+function escapeReasonOf(
+  reason: ReturnType<TableEffectAnalysis["escapeReasonsOf"]>[number],
+): OptimizationDiagnosticReason {
+  switch (reason) {
+    case "alias":
+      return "alias-escape";
+    case "call":
+      return "call-escape";
+    case "return":
+      return "return-escape";
+    case "store":
+      return "store-escape";
+    case "capture":
+      return "capture-escape";
+    case "value-use":
+      return "value-use-escape";
+  }
+}
+
+function rangeOf(
+  statement: Parser.Statement,
+): readonly [number, number] | undefined {
+  return (statement as { range?: [number, number] }).range;
 }
 
 function shadowsInterveningReference(

--- a/src/tableReadMerge.ts
+++ b/src/tableReadMerge.ts
@@ -18,8 +18,7 @@ export interface TableReadMergePlan {
 }
 
 export interface TableReadMergeOptions {
-  // falseはtable全体dirty、trueは(table,key)単位のdirty判定。
-  readonly fieldSensitive: boolean;
+  readonly dirtyGranularity: "table" | "static-key";
 }
 
 interface Candidate {
@@ -74,7 +73,7 @@ export function planTableReadMerges(
           indexOf,
           bindingEffects,
           tableEffects,
-          options.fieldSensitive,
+          options.dirtyGranularity,
         )
       ) {
         flush();
@@ -154,7 +153,7 @@ function tableIsDirtyBetween(
   indexOf: ReadonlyMap<Parser.Statement, number>,
   bindingEffects: EffectAnalysis,
   tableEffects: TableEffectAnalysis,
-  fieldSensitive: boolean,
+  dirtyGranularity: TableReadMergeOptions["dirtyGranularity"],
 ): boolean {
   const inOpenInterval = (owner: Parser.Node): boolean => {
     const index = indexOf.get(owner as Parser.Statement);
@@ -170,7 +169,7 @@ function tableIsDirtyBetween(
   return tableEffects.effectsOf(read.table).some((effect) => {
     if (effect.access !== "write" || !inOpenInterval(effect.owner))
       return false;
-    if (!fieldSensitive) return true;
+    if (dirtyGranularity === "table") return true;
     return (
       effect.staticKey === undefined || effect.staticKey === read.staticKey
     );

--- a/src/tableReadMerge.ts
+++ b/src/tableReadMerge.ts
@@ -235,12 +235,12 @@ function candidateOf(
   options: TableReadMergeOptions,
 ): CandidateDecision {
   if (statement.type !== "LocalStatement") return undefined;
+  if (statement.variables.length !== 1 || statement.init.length !== 1) {
+    return { reason: "unsupported-shape" };
+  }
   const init = statement.init[0];
   if (init.type !== "MemberExpression" && init.type !== "IndexExpression") {
     return undefined;
-  }
-  if (statement.variables.length !== 1 || statement.init.length !== 1) {
-    return { reason: "unsupported-shape" };
   }
   if (options.canMoveStatement?.(statement) === false) {
     return { reason: "metadata-preserved" };

--- a/src/tableReadMerge.ts
+++ b/src/tableReadMerge.ts
@@ -19,6 +19,7 @@ export interface TableReadMergePlan {
 
 export interface TableReadMergeOptions {
   readonly dirtyGranularity: "table" | "static-key";
+  readonly canMoveStatement?: (statement: Parser.LocalStatement) => boolean;
 }
 
 interface Candidate {
@@ -49,6 +50,14 @@ export function planTableReadMerges(
       for (let start = 0; start < run.length; start += MAX_MERGE_ARITY) {
         const part = run.slice(start, start + MAX_MERGE_ARITY);
         if (part.length < 2) continue;
+        if (
+          !part.some(
+            (candidate, offset) =>
+              offset > 0 && candidate.index > part[offset - 1].index + 1,
+          )
+        ) {
+          continue;
+        }
         groups.push({
           body,
           statements: part.map((candidate) => candidate.statement),
@@ -69,6 +78,7 @@ export function planTableReadMerges(
         index,
         bindingEffects,
         tableEffects,
+        options,
       );
       if (!candidate) {
         flush();
@@ -131,6 +141,7 @@ function candidateOf(
   index: number,
   bindingEffects: EffectAnalysis,
   analysis: TableEffectAnalysis,
+  options: TableReadMergeOptions,
 ): Candidate | undefined {
   if (
     statement.type !== "LocalStatement" ||
@@ -141,6 +152,7 @@ function candidateOf(
   ) {
     return undefined;
   }
+  if (options.canMoveStatement?.(statement) === false) return undefined;
   const read = analysis.effects.find(
     (effect) =>
       effect.access === "read" &&

--- a/src/tableReadMerge.ts
+++ b/src/tableReadMerge.ts
@@ -1,6 +1,5 @@
 import Parser from "luaparse";
 import { AstWalkVisitor, walkStatement } from "./astWalk";
-import { EffectAnalysis } from "./effectAnalysis";
 import { copyNodeOrigin } from "./generatedNode";
 import { SourceMetadata } from "./sourceMetadata";
 import { TransformResult } from "./optimizerPass";
@@ -37,7 +36,6 @@ const DEFAULT_MAX_MERGE_ARITY = 50;
 
 export function planTableReadMerges(
   chunk: Parser.Chunk,
-  bindingEffects: EffectAnalysis,
   tableEffects: TableEffectAnalysis,
   options: TableReadMergeOptions,
 ): TableReadMergePlan {
@@ -77,13 +75,7 @@ export function planTableReadMerges(
 
     body.forEach((statement, index) => {
       if (isIntervening(statement)) return;
-      const candidate = candidateOf(
-        statement,
-        index,
-        bindingEffects,
-        tableEffects,
-        options,
-      );
+      const candidate = candidateOf(statement, index, tableEffects, options);
       if (!candidate) {
         flush();
         return;
@@ -91,12 +83,17 @@ export function planTableReadMerges(
 
       if (
         shadowsInterveningReference(body, run[0]?.index ?? index, candidate) ||
+        !tableEffects.stableBetween(
+          candidate.read.table,
+          candidate.read.baseSymbol,
+          run[0]?.statement ?? statement,
+          statement,
+        ) ||
         tableIsDirtyBetween(
           candidate.read,
           run[0]?.index ?? index,
           index,
           indexOf,
-          bindingEffects,
           tableEffects,
           options.dirtyGranularity,
         )
@@ -143,7 +140,6 @@ export function applyTableReadMergePlan(
 function candidateOf(
   statement: Parser.Statement,
   index: number,
-  bindingEffects: EffectAnalysis,
   analysis: TableEffectAnalysis,
   options: TableReadMergeOptions,
 ): Candidate | undefined {
@@ -162,12 +158,7 @@ function candidateOf(
       effect.access === "read" &&
       effect.expression === statement.init[0] &&
       effect.staticKey !== undefined &&
-      analysis.isNonescaping(effect.table) &&
-      // Symbolの現在値をallocationへ結び付けるpoints-to/CFGはまだ無い。
-      // 一度でも再代入されれば、以後のaccessを元fresh tableとはみなさない。
-      !bindingEffects
-        .accessesOf(effect.table.symbol)
-        .some((binding) => binding.access === "write"),
+      analysis.isNonescaping(effect.table),
   );
   return read ? { statement, index, read } : undefined;
 }
@@ -184,7 +175,6 @@ function tableIsDirtyBetween(
   start: number,
   end: number,
   indexOf: ReadonlyMap<Parser.Statement, number>,
-  bindingEffects: EffectAnalysis,
   tableEffects: TableEffectAnalysis,
   dirtyGranularity: TableReadMergeOptions["dirtyGranularity"],
 ): boolean {
@@ -192,13 +182,6 @@ function tableIsDirtyBetween(
     const index = indexOf.get(owner as Parser.Statement);
     return index !== undefined && start < index && index < end;
   };
-  const bindingWrite = bindingEffects
-    .accessesOf(read.table.symbol)
-    .some(
-      (effect) => effect.access === "write" && inOpenInterval(effect.owner),
-    );
-  if (bindingWrite) return true;
-
   return tableEffects.effectsOf(read.table).some((effect) => {
     if (effect.access !== "write" || !inOpenInterval(effect.owner))
       return false;

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -30,8 +30,8 @@ export function mergeLocalDeclarations(
   resolveResult: ResolveResult,
   options: MergeLocalsOptions,
   metadata?: SourceMetadata,
-): void {
-  processBlock(chunk.body, resolveResult, options, metadata);
+): boolean {
+  return processBlock(chunk.body, resolveResult, options, metadata);
 }
 
 // #8b: リネームできない外部グローバル識別子（screen等）をチャンク先頭で
@@ -79,7 +79,7 @@ export function insertGlobalAliases(
   chunk: Parser.Chunk,
   resolveResult: ResolveResult,
   options: InsertGlobalAliasesOptions,
-): void {
+): boolean {
   const newLocals: Parser.LocalStatement[] = [];
   let aliasCounter = 0;
 
@@ -116,6 +116,7 @@ export function insertGlobalAliases(
   if (newLocals.length > 0) {
     chunk.body.unshift(...newLocals);
   }
+  return newLocals.length > 0;
 }
 
 // ============================================================
@@ -127,17 +128,19 @@ function processBlock(
   resolveResult: ResolveResult,
   options: MergeLocalsOptions,
   metadata?: SourceMetadata,
-): void {
+): boolean {
   // 先に子ブロック（ネストしたスコープ）を処理する。子ブロックは別配列なので
   // このレベルでのまとめ上げには影響しない。
+  let changed = false;
   body.forEach((statement) => {
     walkStatement(statement, {
       onBlock: (nested) => {
-        processBlock(nested, resolveResult, options, metadata);
+        changed =
+          processBlock(nested, resolveResult, options, metadata) || changed;
       },
     });
   });
-  mergeRunsInPlace(body, resolveResult, options, metadata);
+  return mergeRunsInPlace(body, resolveResult, options, metadata) || changed;
 }
 
 // あるexpr（候補文のinit式）の中に現れる識別子参照をすべて収集する。
@@ -357,7 +360,7 @@ function mergeRunsInPlace(
   resolveResult: ResolveResult,
   options: MergeLocalsOptions,
   metadata?: SourceMetadata,
-): void {
+): boolean {
   const result: Parser.Statement[] = [];
   let i = 0;
   while (i < body.length) {
@@ -376,5 +379,9 @@ function mergeRunsInPlace(
     result.push(...mergeRun(run, resolveResult, options, metadata));
     i = j;
   }
-  body.splice(0, body.length, ...result);
+  const changed =
+    result.length !== body.length ||
+    result.some((statement, index) => statement !== body[index]);
+  if (changed) body.splice(0, body.length, ...result);
+  return changed;
 }

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -14,6 +14,7 @@ import Parser from "luaparse";
 import { ResolveResult, Symbol } from "./resolver";
 import { staticStringArgument, RESERVED_MODULE_FUNCTION_NAMES } from "./linker";
 import { SourceMetadata } from "./sourceMetadata";
+import { AstWalkVisitor, walkExpression, walkStatement } from "./astWalk";
 
 export interface MergeLocalsOptions {
   // SLモード（moduleLikeLua:false）では`local x = require("m")`形式の文を
@@ -121,169 +122,6 @@ export function insertGlobalAliases(
 // ブロックの再帰走査
 // ============================================================
 
-interface WalkVisitor {
-  onIdentifierReference?: (id: Parser.Identifier) => void;
-  onBlock?: (body: Parser.Statement[]) => void;
-}
-
-// resolver.tsのresolveStatement/resolveExpressionの分岐を鏡写しにした
-// 汎用ウォーカー。「参照として現れる識別子」と「ネストしたブロック本体」を
-// どちらも一度の走査で収集できるようにし、resolver.tsの走査ロジックの
-// 重複を避ける。
-function walkStatement(
-  statement: Parser.Statement,
-  visitor: WalkVisitor,
-): void {
-  switch (statement.type) {
-    case "LocalStatement":
-      // 宣言される変数自体は参照ではないため辿らない
-      statement.init.forEach((expr) => {
-        walkExpression(expr, visitor);
-      });
-      return;
-    case "AssignmentStatement":
-      statement.variables.forEach((v) => {
-        if (v.type === "Identifier") {
-          visitor.onIdentifierReference?.(v);
-        } else {
-          walkExpression(v, visitor);
-        }
-      });
-      statement.init.forEach((expr) => {
-        walkExpression(expr, visitor);
-      });
-      return;
-    case "CallStatement":
-      walkExpression(statement.expression, visitor);
-      return;
-    case "DoStatement":
-      visitor.onBlock?.(statement.body);
-      return;
-    case "WhileStatement":
-      walkExpression(statement.condition, visitor);
-      visitor.onBlock?.(statement.body);
-      return;
-    case "RepeatStatement":
-      visitor.onBlock?.(statement.body);
-      walkExpression(statement.condition, visitor);
-      return;
-    case "IfStatement":
-      statement.clauses.forEach((clause) => {
-        if (clause.type !== "ElseClause") {
-          walkExpression(clause.condition, visitor);
-        }
-        visitor.onBlock?.(clause.body);
-      });
-      return;
-    case "ForNumericStatement":
-      walkExpression(statement.start, visitor);
-      walkExpression(statement.end, visitor);
-      if (statement.step) {
-        walkExpression(statement.step, visitor);
-      }
-      visitor.onBlock?.(statement.body);
-      return;
-    case "ForGenericStatement":
-      statement.iterators.forEach((iterator) => {
-        walkExpression(iterator, visitor);
-      });
-      visitor.onBlock?.(statement.body);
-      return;
-    case "FunctionDeclaration":
-      if (statement.identifier) {
-        if (statement.identifier.type === "Identifier") {
-          if (!statement.isLocal) {
-            // 非local: 既存のローカル/グローバルへの代入（参照扱い）
-            visitor.onIdentifierReference?.(statement.identifier);
-          }
-          // isLocalの場合は宣言自体であり参照ではないため辿らない
-        } else {
-          walkExpression(statement.identifier, visitor);
-        }
-      }
-      visitor.onBlock?.(statement.body);
-      return;
-    case "ReturnStatement":
-      statement.arguments.forEach((argument) => {
-        walkExpression(argument, visitor);
-      });
-      return;
-    case "BreakStatement":
-    case "LabelStatement":
-    case "GotoStatement":
-      return;
-    default: {
-      const exhaustive: never = statement;
-      throw new TypeError(
-        "Unknown statement type: `" + JSON.stringify(exhaustive) + "`",
-      );
-    }
-  }
-}
-
-function walkExpression(expr: Parser.Expression, visitor: WalkVisitor): void {
-  switch (expr.type) {
-    case "Identifier":
-      visitor.onIdentifierReference?.(expr);
-      return;
-    case "StringLiteral":
-    case "NumericLiteral":
-    case "BooleanLiteral":
-    case "NilLiteral":
-    case "VarargLiteral":
-      return;
-    case "LogicalExpression":
-    case "BinaryExpression":
-      walkExpression(expr.left, visitor);
-      walkExpression(expr.right, visitor);
-      return;
-    case "UnaryExpression":
-      walkExpression(expr.argument, visitor);
-      return;
-    case "CallExpression":
-      walkExpression(expr.base, visitor);
-      expr.arguments.forEach((argument) => {
-        walkExpression(argument, visitor);
-      });
-      return;
-    case "TableCallExpression":
-      walkExpression(expr.base, visitor);
-      walkExpression(expr.arguments, visitor);
-      return;
-    case "StringCallExpression":
-      walkExpression(expr.base, visitor);
-      walkExpression(expr.argument, visitor);
-      return;
-    case "IndexExpression":
-      walkExpression(expr.base, visitor);
-      walkExpression(expr.index, visitor);
-      return;
-    case "MemberExpression":
-      walkExpression(expr.base, visitor);
-      // フィールド名（`.identifier`）は変数参照ではないため辿らない
-      return;
-    case "FunctionDeclaration":
-      visitor.onBlock?.(expr.body);
-      return;
-    case "TableConstructorExpression":
-      expr.fields.forEach((field) => {
-        if (field.type === "TableKey") {
-          walkExpression(field.key, visitor);
-          walkExpression(field.value, visitor);
-        } else {
-          walkExpression(field.value, visitor);
-        }
-      });
-      return;
-    default: {
-      const exhaustive: never = expr;
-      throw new TypeError(
-        "Unknown expression type: `" + JSON.stringify(exhaustive) + "`",
-      );
-    }
-  }
-}
-
 function processBlock(
   body: Parser.Statement[],
   resolveResult: ResolveResult,
@@ -309,7 +147,7 @@ function collectIdentifierReferences(
   expr: Parser.Expression,
 ): Parser.Identifier[] {
   const found: Parser.Identifier[] = [];
-  const visitor: WalkVisitor = {
+  const visitor: AstWalkVisitor = {
     onIdentifierReference: (id) => found.push(id),
     onBlock: (body) => {
       body.forEach((s) => {

--- a/src/valueFlow.ts
+++ b/src/valueFlow.ts
@@ -1,0 +1,212 @@
+import Parser from "luaparse";
+import {
+  analyzeControlFlow,
+  ControlFlowAnalysis,
+  ExecutionUnit,
+  ProgramPoint,
+} from "./controlFlow";
+import { ResolveResult, Symbol } from "./resolver";
+
+export interface Allocation {
+  readonly id: number;
+  readonly kind: "table";
+  readonly origin: Parser.TableConstructorExpression;
+  readonly owner: Parser.Statement;
+  readonly unit: ExecutionUnit;
+}
+
+export type AbstractValue =
+  | {
+      readonly kind: "allocations";
+      readonly allocations: ReadonlySet<Allocation>;
+    }
+  | { readonly kind: "nil" }
+  | { readonly kind: "unknown"; readonly reason: string };
+
+export interface Definition {
+  readonly id: number;
+  readonly symbol: Symbol;
+  readonly owner: Parser.Statement;
+  readonly value: AbstractValue;
+}
+
+export interface ValueFlowAnalysis {
+  readonly version: number;
+  readonly controlFlow: ControlFlowAnalysis;
+  readonly allocations: readonly Allocation[];
+  readonly definitions: readonly Definition[];
+  valueBefore(point: ProgramPoint, symbol: Symbol): AbstractValue;
+  valueAfter(point: ProgramPoint, symbol: Symbol): AbstractValue;
+  reachingDefinitionBefore(
+    point: ProgramPoint,
+    symbol: Symbol,
+  ): Definition | undefined;
+  aliasesBefore(
+    point: ProgramPoint,
+    allocation: Allocation,
+  ): ReadonlySet<Symbol>;
+  allocationOfBase(
+    expression: Parser.Expression,
+    point: ProgramPoint,
+  ): Allocation | undefined;
+}
+
+const UNKNOWN_ENTRY: AbstractValue = {
+  kind: "unknown",
+  reason: "region-entry",
+};
+
+/** 直線regionだけを対象にしたallocation/reaching-definition解析。 */
+export function analyzeValueFlow(
+  chunk: Parser.Chunk,
+  resolved: ResolveResult,
+  version = 0,
+): ValueFlowAnalysis {
+  const controlFlow = analyzeControlFlow(chunk, version);
+  const allocations: Allocation[] = [];
+  const definitions: Definition[] = [];
+  const allocationByOrigin = new WeakMap<
+    Parser.TableConstructorExpression,
+    Allocation
+  >();
+  const beforeByPoint = new WeakMap<
+    ProgramPoint,
+    ReadonlyMap<Symbol, AbstractValue>
+  >();
+  const afterByPoint = new WeakMap<
+    ProgramPoint,
+    ReadonlyMap<Symbol, AbstractValue>
+  >();
+  const definitionBeforeByPoint = new WeakMap<
+    ProgramPoint,
+    ReadonlyMap<Symbol, Definition>
+  >();
+  let nextAllocationId = 0;
+  let nextDefinitionId = 0;
+
+  const allocationOf = (
+    expression: Parser.TableConstructorExpression,
+    point: ProgramPoint,
+  ): Allocation => {
+    const existing = allocationByOrigin.get(expression);
+    if (existing) return existing;
+    const allocation: Allocation = {
+      id: nextAllocationId++,
+      kind: "table",
+      origin: expression,
+      owner: point.statement,
+      unit: point.unit,
+    };
+    allocations.push(allocation);
+    allocationByOrigin.set(expression, allocation);
+    return allocation;
+  };
+
+  const abstractExpression = (
+    expression: Parser.Expression | undefined,
+    point: ProgramPoint,
+    values: ReadonlyMap<Symbol, AbstractValue>,
+  ): AbstractValue => {
+    if (!expression) return { kind: "nil" };
+    if (expression.type === "TableConstructorExpression") {
+      return {
+        kind: "allocations",
+        allocations: new Set([allocationOf(expression, point)]),
+      };
+    }
+    if (expression.type === "Identifier") {
+      const symbol = resolved.symbolOf(expression);
+      return symbol
+        ? (values.get(symbol) ?? UNKNOWN_ENTRY)
+        : { kind: "unknown", reason: "global-or-unresolved" };
+    }
+    if (expression.type === "NilLiteral") return { kind: "nil" };
+    return { kind: "unknown", reason: "unsupported-expression" };
+  };
+
+  controlFlow.regions.forEach((region) => {
+    const values = new Map<Symbol, AbstractValue>();
+    const reaching = new Map<Symbol, Definition>();
+    region.points.forEach((point) => {
+      beforeByPoint.set(point, new Map(values));
+      definitionBeforeByPoint.set(point, new Map(reaching));
+      const statement = point.statement;
+      const writes: { symbol: Symbol; value: AbstractValue }[] = [];
+      if (statement.type === "LocalStatement") {
+        statement.variables.forEach((identifier, index) => {
+          const symbol = resolved.symbolOf(identifier);
+          if (symbol) {
+            writes.push({
+              symbol,
+              value: abstractExpression(statement.init[index], point, values),
+            });
+          }
+        });
+      } else if (statement.type === "AssignmentStatement") {
+        statement.variables.forEach((variable, index) => {
+          if (variable.type !== "Identifier") return;
+          const symbol = resolved.symbolOf(variable);
+          if (symbol) {
+            writes.push({
+              symbol,
+              value: abstractExpression(statement.init[index], point, values),
+            });
+          }
+        });
+      }
+      writes.forEach(({ symbol, value }) => {
+        const definition: Definition = {
+          id: nextDefinitionId++,
+          symbol,
+          owner: statement,
+          value,
+        };
+        definitions.push(definition);
+        values.set(symbol, value);
+        reaching.set(symbol, definition);
+      });
+      afterByPoint.set(point, new Map(values));
+    });
+  });
+
+  const valueAt = (
+    store: WeakMap<ProgramPoint, ReadonlyMap<Symbol, AbstractValue>>,
+    point: ProgramPoint,
+    symbol: Symbol,
+  ) => store.get(point)?.get(symbol) ?? UNKNOWN_ENTRY;
+
+  return {
+    version,
+    controlFlow,
+    allocations,
+    definitions,
+    valueBefore: (point, symbol) => valueAt(beforeByPoint, point, symbol),
+    valueAfter: (point, symbol) => valueAt(afterByPoint, point, symbol),
+    reachingDefinitionBefore: (point, symbol) =>
+      definitionBeforeByPoint.get(point)?.get(symbol),
+    aliasesBefore: (point, allocation) => {
+      const aliases = new Set<Symbol>();
+      const values = beforeByPoint.get(point);
+      values?.forEach((value, symbol) => {
+        if (
+          value.kind === "allocations" &&
+          value.allocations.size === 1 &&
+          value.allocations.has(allocation)
+        ) {
+          aliases.add(symbol);
+        }
+      });
+      return aliases;
+    },
+    allocationOfBase: (expression, point) => {
+      if (expression.type !== "Identifier") return undefined;
+      const symbol = resolved.symbolOf(expression);
+      if (!symbol) return undefined;
+      const value = valueAt(beforeByPoint, point, symbol);
+      if (value.kind !== "allocations" || value.allocations.size !== 1) {
+        return undefined;
+      }
+      return value.allocations.values().next().value;
+    },
+  };
+}

--- a/src/valueFlow.ts
+++ b/src/valueFlow.ts
@@ -49,6 +49,12 @@ export interface ValueFlowAnalysis {
     expression: Parser.Expression,
     point: ProgramPoint,
   ): Allocation | undefined;
+  stableAllocationBetween(
+    first: Parser.Statement,
+    last: Parser.Statement,
+    symbol: Symbol,
+    expected: Allocation,
+  ): boolean;
 }
 
 const UNKNOWN_ENTRY: AbstractValue = {
@@ -207,6 +213,18 @@ export function analyzeValueFlow(
         return undefined;
       }
       return value.allocations.values().next().value;
+    },
+    stableAllocationBetween: (first, last, symbol, expected) => {
+      const points = controlFlow.pointsBetween(first, last);
+      if (!points) return false;
+      return points.every((point) => {
+        const value = valueAt(beforeByPoint, point, symbol);
+        return (
+          value.kind === "allocations" &&
+          value.allocations.size === 1 &&
+          value.allocations.has(expected)
+        );
+      });
     },
   };
 }

--- a/test/astWalk.test.ts
+++ b/test/astWalk.test.ts
@@ -1,0 +1,73 @@
+import Parser from "luaparse";
+import { describe, expect, test } from "vitest";
+import { walkExpression, walkStatement } from "../src/astWalk";
+
+const settings = { luaVersion: "5.3" as const };
+
+function parse(source: string): Parser.Chunk {
+  return Parser.parse(source, settings);
+}
+
+describe("AST walker", () => {
+  test("distinguishes variable references from declarations and field names", () => {
+    const chunk = parse("local x=t.x+t[k]");
+    const statement = chunk.body[0];
+    const references: string[] = [];
+
+    walkStatement(statement, {
+      onIdentifierReference: (identifier) => references.push(identifier.name),
+    });
+
+    expect(references).toEqual(["t", "t", "k"]);
+  });
+
+  test("lets the caller choose whether to enter nested blocks", () => {
+    const chunk = parse("if flag then print(value) end");
+    const shallow: string[] = [];
+    const recursive: string[] = [];
+
+    walkStatement(chunk.body[0], {
+      onIdentifierReference: (identifier) => shallow.push(identifier.name),
+    });
+
+    const visitor = {
+      onIdentifierReference: (identifier: Parser.Identifier) =>
+        recursive.push(identifier.name),
+      onBlock: (body: Parser.Statement[]) => {
+        body.forEach((statement) => {
+          walkStatement(statement, visitor);
+        });
+      },
+    };
+    walkStatement(chunk.body[0], visitor);
+
+    expect(shallow).toEqual(["flag"]);
+    expect(recursive).toEqual(["flag", "print", "value"]);
+  });
+
+  test("walks computed table keys but not named constructor keys", () => {
+    const chunk = parse("return {named=value,[key]=other}");
+    const returnStatement = chunk.body[0] as Parser.ReturnStatement;
+    const references: string[] = [];
+
+    walkExpression(returnStatement.arguments[0], {
+      onIdentifierReference: (identifier) => references.push(identifier.name),
+    });
+
+    expect(references).toEqual(["value", "key", "other"]);
+  });
+
+  test("reports assignment targets as references without entering closures", () => {
+    const chunk = parse("target=function() return captured end");
+    const references: string[] = [];
+    const blocks: Parser.Statement[][] = [];
+
+    walkStatement(chunk.body[0], {
+      onIdentifierReference: (identifier) => references.push(identifier.name),
+      onBlock: (body) => blocks.push(body),
+    });
+
+    expect(references).toEqual(["target"]);
+    expect(blocks).toHaveLength(1);
+  });
+});

--- a/test/cliOptions.test.ts
+++ b/test/cliOptions.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "vitest";
+import { createCliProgram } from "../src/cliOptions";
+
+function optionsOf(...args: string[]): Record<string, unknown> {
+  const program = createCliProgram();
+  program.exitOverride();
+  program.parse(args, { from: "user" });
+  return program.opts<Record<string, unknown>>();
+}
+
+describe("effect-aware CLI options", () => {
+  test("uses the Stormworks safe profile by default", () => {
+    expect(optionsOf()).toMatchObject({
+      runtimeProfile: "stormworks",
+      effectAwareTransforms: true,
+      effectAwareLocalHoist: true,
+      effectAwareTableReads: true,
+      fieldSensitiveTableEffects: true,
+    });
+  });
+
+  test("keeps runtime profile and pure-Lua lifetime permission separate", () => {
+    expect(
+      optionsOf("--runtime-profile", "lua53", "--allow-local-lifetime-changes"),
+    ).toMatchObject({
+      runtimeProfile: "lua53",
+      allowLocalLifetimeChanges: true,
+    });
+  });
+
+  test("supports master and individual opt-outs", () => {
+    expect(
+      optionsOf(
+        "--no-effect-aware-transforms",
+        "--no-effect-aware-local-hoist",
+        "--no-effect-aware-table-reads",
+        "--no-field-sensitive-table-effects",
+      ),
+    ).toMatchObject({
+      effectAwareTransforms: false,
+      effectAwareLocalHoist: false,
+      effectAwareTableReads: false,
+      fieldSensitiveTableEffects: false,
+    });
+  });
+
+  test("rejects an unknown runtime profile", () => {
+    const program = createCliProgram();
+    program.exitOverride();
+    program.configureOutput({ writeErr: () => undefined });
+    expect(() =>
+      program.parse(["--runtime-profile", "unknown"], { from: "user" }),
+    ).toThrow(/allowed choices/i);
+  });
+});

--- a/test/constantFold.test.ts
+++ b/test/constantFold.test.ts
@@ -14,6 +14,11 @@ import {
 } from "../src/constantFold";
 import { SourceMetadata } from "../src/sourceMetadata";
 import { Minifier } from "../src/minifier";
+import {
+  decodeLuaStringLiteral,
+  luaByteStringKey,
+  luaByteStringOfText,
+} from "../src/luaString";
 
 const PARSE_SETTINGS = {
   luaVersion: "5.3" as const,
@@ -110,7 +115,10 @@ function assertRoundTrips(expr: Parser.Expression): ConstantValue {
   } else if (original.kind === "float" && roundTripped.kind === "float") {
     assert.equal(roundTripped.value, original.value);
   } else if (original.kind === "string" && roundTripped.kind === "string") {
-    assert.equal(roundTripped.value, original.value);
+    assert.equal(
+      luaByteStringKey(roundTripped.value),
+      luaByteStringKey(original.value),
+    );
   } else if (original.kind === "boolean" && roundTripped.kind === "boolean") {
     assert.equal(roundTripped.value, original.value);
   }
@@ -136,7 +144,12 @@ function assertBoolean(expr: Parser.Expression, expected: boolean): void {
 
 function assertStringValue(expr: Parser.Expression, expected: string): void {
   assert.equal(expr.type, "StringLiteral");
-  assert.equal(expr.value, expected);
+  const decoded = decodeLuaStringLiteral(expr);
+  assert.ok(decoded.ok);
+  assert.equal(
+    luaByteStringKey(decoded.value),
+    luaByteStringKey(luaByteStringOfText(expected)),
+  );
 }
 
 // ============================================================
@@ -291,9 +304,9 @@ test('#"abc" folds to the byte length 3', () => {
   assertInt(foldExpr('#"abc"'), 3n);
 });
 
-test("the length of a long-bracket string is not folded", () => {
-  // 長括弧形式は定数として認めていないので、バイト長も求めない。
-  assert.equal(foldExpr("#[[abc]]").type, "UnaryExpression");
+test("long-bracket and Unicode string lengths use Lua bytes", () => {
+  assertInt(foldExpr("#[[abc]]"), 3n);
+  assertInt(foldExpr('#"あ"'), 3n);
 });
 
 test("the length of a table constructor is not folded", () => {
@@ -320,16 +333,17 @@ test('"abc" >= "abd" folds to false', () => {
   assertBoolean(foldExpr('"abc" >= "abd"'), false);
 });
 
-test("long-bracket string comparison is not folded", () => {
-  assert.equal(foldExpr("[[a]] < [[b]]").type, "BinaryExpression");
+test("long-bracket and escaped strings compare by Lua bytes", () => {
+  assertBoolean(foldExpr("[[a]] < [[b]]"), true);
+  assertBoolean(foldExpr('"\\x61" == "a"'), true);
 });
 
-test("long-bracket string concatenation is not folded", () => {
-  assert.equal(foldExpr("[[abc]]..[[def]]").type, "BinaryExpression");
+test("long-bracket string concatenation is folded through shared bytes", () => {
+  assertStringValue(foldExpr("[[abc]]..[[def]]"), "abcdef");
 });
 
-test("concatenation of a string containing an escape is not folded", () => {
-  assert.equal(foldExpr('"a\\nb".."c"').type, "BinaryExpression");
+test("concatenation preserves escaped byte values", () => {
+  assertStringValue(foldExpr('"a\\nb".."c"'), "a\nbc");
 });
 
 test("(1+2).x folds to a literal base, and the printer keeps the parentheses", () => {

--- a/test/controlFlow.test.ts
+++ b/test/controlFlow.test.ts
@@ -1,0 +1,48 @@
+import Parser from "luaparse";
+import { describe, expect, test } from "vitest";
+import { analyzeControlFlow } from "../src/controlFlow";
+
+describe("certified linear control-flow regions", () => {
+  test("keeps calls and assignments in a region and splits at control flow", () => {
+    const chunk = Parser.parse(
+      "local a=f() tick() a=2 if flag then local b=g() tick() end local c=h() return c",
+      { luaVersion: "5.3" },
+    );
+    const flow = analyzeControlFlow(chunk, 7);
+
+    expect(flow.complete).toBe(false);
+    expect(flow.version).toBe(7);
+    expect(flow.regions.map((region) => region.points.length)).toEqual([
+      3, 2, 1,
+    ]);
+    expect(flow.units).toHaveLength(1);
+    expect(flow.pointsBetween(chunk.body[0], chunk.body[2])).toHaveLength(3);
+    expect(flow.pointsBetween(chunk.body[0], chunk.body[4])).toBeUndefined();
+  });
+
+  test("creates a separate execution unit for each nested function", () => {
+    const chunk = Parser.parse(
+      "local outer=1 local f=function() local inner=2 tick() return inner end use(outer,f)",
+      { luaVersion: "5.3" },
+    );
+    const flow = analyzeControlFlow(chunk);
+
+    expect(flow.units.map((unit) => unit.kind)).toEqual(["chunk", "function"]);
+    expect(flow.regions.map((region) => region.unit.id)).toEqual([1, 0]);
+  });
+
+  test("does not certify label, goto, loop, or return statements", () => {
+    const chunk = Parser.parse(
+      "::again:: local a=1 while flag do a=2 end goto again",
+      { luaVersion: "5.3" },
+    );
+    const flow = analyzeControlFlow(chunk);
+
+    expect(chunk.body.map((statement) => flow.pointOf(statement))).toEqual([
+      undefined,
+      expect.any(Object),
+      undefined,
+      undefined,
+    ]);
+  });
+});

--- a/test/controlFlow.test.ts
+++ b/test/controlFlow.test.ts
@@ -45,4 +45,24 @@ describe("certified linear control-flow regions", () => {
       undefined,
     ]);
   });
+
+  test("exposes an explicit conservative graph without claiming unknown edges", () => {
+    const chunk = Parser.parse(
+      "local a=1 tick() if flag then use(a) end local b=2 return b",
+      { luaVersion: "5.3" },
+    );
+    const flow = analyzeControlFlow(chunk);
+    const ifNode = flow.nodeOf(chunk.body[2]);
+    expect(ifNode?.kind).toBe("opaque");
+    expect(ifNode?.successors[0].kind).toBe("unknown");
+    expect(flow.nodes.filter((node) => node.kind === "entry")).toHaveLength(1);
+    expect(flow.nodes.filter((node) => node.kind === "exit")).toHaveLength(1);
+    flow.nodes.forEach((node) => {
+      node.successors.forEach((edge) => {
+        expect(edge.to.predecessors).toContain(edge);
+      });
+    });
+    expect(flow.dominates(chunk.body[0], chunk.body[1])).toBe(true);
+    expect(flow.dominates(chunk.body[0], chunk.body[3])).toBe(false);
+  });
 });

--- a/test/effectAnalysis.test.ts
+++ b/test/effectAnalysis.test.ts
@@ -1,0 +1,109 @@
+import Parser from "luaparse";
+import { describe, expect, test } from "vitest";
+import { analyzeBindingEffects } from "../src/effectAnalysis";
+import { resolveScopes } from "../src/resolver";
+import { Symbol } from "../src/resolver";
+
+function analyze(source: string) {
+  const chunk = Parser.parse(source, { luaVersion: "5.3" });
+  const resolved = resolveScopes(chunk);
+  return { chunk, resolved, analysis: analyzeBindingEffects(chunk, resolved) };
+}
+
+function requiredSymbol(
+  symbols: readonly Symbol[],
+  predicate: (symbol: Symbol) => boolean,
+): Symbol {
+  const symbol = symbols.find(predicate);
+  if (!symbol) throw new Error("expected symbol was not resolved");
+  return symbol;
+}
+
+describe("binding effect analysis", () => {
+  test("separates declaration, read, and write for one symbol", () => {
+    const { resolved, analysis } = analyze("local x=1 x=x+1 return x");
+    const x = resolved.symbols[0];
+
+    expect(analysis.accessesOf(x).map((effect) => effect.access)).toEqual([
+      "declare",
+      "read",
+      "write",
+      "read",
+    ]);
+  });
+
+  test("keeps outer and shadowing locals distinct in local x=x", () => {
+    const { resolved, analysis } = analyze(
+      "local x=1 do local x=x return x end",
+    );
+    const [outer, inner] = resolved.symbols;
+
+    expect(analysis.accessesOf(outer).map((effect) => effect.access)).toEqual([
+      "declare",
+      "read",
+    ]);
+    expect(analysis.accessesOf(inner).map((effect) => effect.access)).toEqual([
+      "declare",
+      "read",
+    ]);
+  });
+
+  test("classifies global reads and writes without treating field names as globals", () => {
+    const { resolved, analysis } = analyze("target=source.field return target");
+    const globals = analysis.effects
+      .filter((effect) => effect.binding.kind === "global")
+      .map((effect) => [effect.identifier.name, effect.access]);
+
+    expect(globals).toEqual([
+      ["source", "read"],
+      ["target", "write"],
+      ["target", "read"],
+    ]);
+    expect(resolved.globals.has("field")).toBe(false);
+  });
+
+  test("does not flatten a closure body into its containing local statement", () => {
+    const { chunk, resolved, analysis } = analyze(
+      "local outer=1 local f=function(arg) return outer+arg end",
+    );
+    const localF = chunk.body[1];
+    const outer = requiredSymbol(
+      resolved.symbols,
+      (symbol) => symbol.name === "outer",
+    );
+    const f = requiredSymbol(resolved.symbols, (symbol) => symbol.name === "f");
+    const arg = requiredSymbol(
+      resolved.symbols,
+      (symbol) => symbol.kind === "param",
+    );
+
+    expect(analysis.effectsOf(localF).map((effect) => effect.access)).toEqual([
+      "declare",
+    ]);
+    expect(analysis.accessesOf(outer).map((effect) => effect.access)).toEqual([
+      "declare",
+      "read",
+    ]);
+    expect(analysis.accessesOf(f).map((effect) => effect.access)).toEqual([
+      "declare",
+    ]);
+    expect(analysis.accessesOf(arg).map((effect) => effect.access)).toEqual([
+      "declare",
+      "read",
+    ]);
+  });
+
+  test("records table assignment address identifiers as reads", () => {
+    const { resolved, analysis } = analyze("local t,k={},1 t[k]=value");
+    const [t, k] = resolved.symbols;
+
+    expect(analysis.accessesOf(t).map((effect) => effect.access)).toEqual([
+      "declare",
+      "read",
+    ]);
+    expect(analysis.accessesOf(k).map((effect) => effect.access)).toEqual([
+      "declare",
+      "read",
+    ]);
+  });
+});

--- a/test/effectAwarePipeline.integration.test.ts
+++ b/test/effectAwarePipeline.integration.test.ts
@@ -1,0 +1,115 @@
+import assert from "node:assert/strict";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import Parser from "luaparse";
+import { afterEach, describe, test } from "vitest";
+import { Minifier, MinifierMode } from "../src/minifier";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  temporaryDirectories.splice(0).forEach((directory) => {
+    fs.rmSync(directory, { recursive: true, force: true });
+  });
+});
+
+const MAIN = `
+local dependency=require("dep")
+local mainTable={left=1,right=2}
+local mainLeft=mainTable.left
+mainStep()
+local mainRight=mainTable.right
+local foldedMain=1+2
+local unusedMain=99
+screen.drawText(0,0,"a")
+screen.drawText(0,0,"b")
+screen.drawText(0,0,"c")
+screen.drawText(0,0,"d")
+screen.drawText(0,0,"e")
+useMain(mainLeft,mainRight,foldedMain,dependency)
+`;
+
+const DEPENDENCY = `
+local depTable={first=3,second=4}
+local depFirst=depTable.first
+depStep()
+local depSecond=depTable.second
+local foldedDep=2*3
+local unusedDep=88
+useDep(depFirst,depSecond,foldedDep)
+return depFirst+depSecond
+`;
+
+function minify(
+  moduleLikeLua: boolean,
+  overrides: Partial<MinifierMode> = {},
+): string {
+  const directory = fs.mkdtempSync(
+    path.join(os.tmpdir(), "storm-effect-pipeline-test-"),
+  );
+  temporaryDirectories.push(directory);
+  fs.writeFileSync(path.join(directory, "main.lua"), MAIN);
+  fs.writeFileSync(path.join(directory, "dep.lua"), DEPENDENCY);
+
+  return new Minifier(
+    path.join(directory, "main.lua"),
+    { locations: true, luaVersion: "5.3", ranges: true, scope: true },
+    {
+      moduleLikeLua,
+      runtimeProfile: "stormworks",
+      ...overrides,
+    },
+  )
+    .parse()
+    .toStringWithSourceMap({ file: "pipeline.min.lua" }).code;
+}
+
+function assertValidAndNonGrowing(
+  moduleLikeLua: boolean,
+  pairwiseMode: Partial<MinifierMode> = {},
+): void {
+  const enabled = minify(moduleLikeLua, pairwiseMode);
+  const disabled = minify(moduleLikeLua, {
+    ...pairwiseMode,
+    effectAwareTransforms: false,
+  });
+
+  assert.doesNotThrow(() => Parser.parse(enabled, { luaVersion: "5.3" }));
+  assert.doesNotThrow(() => Parser.parse(disabled, { luaVersion: "5.3" }));
+  assert.ok(
+    Buffer.byteLength(enabled) <= Buffer.byteLength(disabled),
+    `effect-aware output grew (${String(Buffer.byteLength(enabled))} > ${String(Buffer.byteLength(disabled))})`,
+  );
+  assert.match(enabled, /mainStep\(\)/);
+  assert.match(enabled, /depStep\(\)/);
+}
+
+describe.each([false, true])(
+  "effect-aware multi-module pipeline (moduleLikeLua=%s)",
+  (moduleLikeLua) => {
+    test("transforms candidates in both the entry and dependency modules", () => {
+      assertValidAndNonGrowing(moduleLikeLua);
+    });
+
+    test.each([
+      ["constant folding", { foldConstants: false }],
+      ["global alias", { globalAlias: false }],
+      ["local merge", { mergeLocals: false }],
+      ["unused removal", { removeUnused: false }],
+    ] as const)("composes pairwise with %s disabled", (_label, mode) => {
+      assertValidAndNonGrowing(moduleLikeLua, mode);
+    });
+  },
+);
+
+test("SL require statement splicing remains protected from local hoisting", () => {
+  const enabled = minify(false);
+  const disabledHoist = minify(false, { effectAwareLocalHoist: false });
+
+  assert.doesNotThrow(() => Parser.parse(enabled, { luaVersion: "5.3" }));
+  assert.doesNotThrow(() => Parser.parse(disabledHoist, { luaVersion: "5.3" }));
+  assert.doesNotMatch(enabled, /require\s*\(?["']dep["']/);
+  assert.match(enabled, /depStep\(\)/);
+  assert.match(enabled, /mainStep\(\)/);
+});

--- a/test/effectAwarePipeline.integration.test.ts
+++ b/test/effectAwarePipeline.integration.test.ts
@@ -93,7 +93,7 @@ describe.each([false, true])(
     });
 
     test.each([
-      ["constant folding", { foldConstants: false }],
+      ["constant folding", { foldConstants: true }],
       ["global alias", { globalAlias: false }],
       ["local merge", { mergeLocals: false }],
       ["unused removal", { removeUnused: false }],

--- a/test/fixtures/effect-aware-table/main.lua
+++ b/test/fixtures/effect-aware-table/main.lua
@@ -1,0 +1,5 @@
+local tableValue = { x = 1, y = 2 }
+local first = tableValue.x
+tick()
+local second = tableValue.y
+use(first, second)

--- a/test/fixtures/effect-aware/main.lua
+++ b/test/fixtures/effect-aware/main.lua
@@ -1,0 +1,6 @@
+local first = makeFirst()
+tick()
+local second = makeSecond()
+value = 1
+local third = makeThird()
+use(first, second, third)

--- a/test/luaString.test.ts
+++ b/test/luaString.test.ts
@@ -1,0 +1,45 @@
+import Parser from "luaparse";
+import { describe, expect, test } from "vitest";
+import { decodeLuaStringLiteral, luaByteStringKey } from "../src/luaString";
+
+function decode(raw: string): number[] | undefined {
+  const chunk = Parser.parse(`return ${raw}`, { luaVersion: "5.3" });
+  const statement = chunk.body[0];
+  if (
+    statement.type !== "ReturnStatement" ||
+    statement.arguments[0]?.type !== "StringLiteral"
+  ) {
+    throw new Error("expected a string literal");
+  }
+  const result = decodeLuaStringLiteral(statement.arguments[0]);
+  return result.ok ? [...result.value.bytes] : undefined;
+}
+
+describe("Lua byte string decoder", () => {
+  test.each([
+    ['"x"', [0x78]],
+    ['"\\120"', [0x78]],
+    ['"\\x78"', [0x78]],
+    ['"a\\0b"', [0x61, 0x00, 0x62]],
+    ['"\\u{3042}"', [0xe3, 0x81, 0x82]],
+    ['"a\\z  \n b"', [0x61, 0x62]],
+    ["[[\nline\r\nnext]]", [...new TextEncoder().encode("line\nnext")]],
+    ["[=[value]=]", [...new TextEncoder().encode("value")]],
+  ])("decodes %s as Lua bytes", (raw, expected) => {
+    expect(decode(raw)).toEqual(expected);
+  });
+
+  test("uses a collision-free canonical byte key", () => {
+    const literal = Parser.parse('return "\\120"', {
+      luaVersion: "5.3",
+    }).body[0];
+    if (
+      literal.type !== "ReturnStatement" ||
+      literal.arguments[0]?.type !== "StringLiteral"
+    ) {
+      throw new Error("expected a string literal");
+    }
+    const decoded = decodeLuaStringLiteral(literal.arguments[0]);
+    expect(decoded.ok && luaByteStringKey(decoded.value)).toBe("78");
+  });
+});

--- a/test/luaString.test.ts
+++ b/test/luaString.test.ts
@@ -1,6 +1,10 @@
 import Parser from "luaparse";
 import { describe, expect, test } from "vitest";
-import { decodeLuaStringLiteral, luaByteStringKey } from "../src/luaString";
+import {
+  decodeLuaStringLiteral,
+  encodeLuaByteString,
+  luaByteStringKey,
+} from "../src/luaString";
 
 function decode(raw: string): number[] | undefined {
   const chunk = Parser.parse(`return ${raw}`, { luaVersion: "5.3" });
@@ -41,5 +45,29 @@ describe("Lua byte string decoder", () => {
     }
     const decoded = decodeLuaStringLiteral(literal.arguments[0]);
     expect(decoded.ok && luaByteStringKey(decoded.value)).toBe("78");
+  });
+
+  test.each([
+    { bytes: [] },
+    { bytes: [0, 10, 13, 255] },
+    { bytes: [0x22, 0x27, 0x5c] },
+    { bytes: [0x61, 0xe3, 0x81, 0x82] },
+  ])("printer representation round-trips byte sequence $bytes", ({ bytes }) => {
+    const raw = encodeLuaByteString({ bytes: Uint8Array.from(bytes) });
+    expect(decode(raw)).toEqual(bytes);
+  });
+
+  test.each([
+    ['"\\xg0"', "invalid-escape"],
+    ['"\\256"', "out-of-range-byte"],
+    ['"\\u{110000}"', "invalid-code-point"],
+    ['"unterminated', "invalid-delimiter"],
+  ] as const)("rejects malformed literal %s", (raw, reason) => {
+    const result = decodeLuaStringLiteral({
+      type: "StringLiteral",
+      raw,
+      value: "",
+    });
+    expect(result).toEqual({ ok: false, reason });
   });
 });

--- a/test/nonAdjacentLocals.integration.test.ts
+++ b/test/nonAdjacentLocals.integration.test.ts
@@ -113,4 +113,25 @@ describe("effect-aware non-adjacent locals pipeline", () => {
       Buffer.byteLength(localDisabled),
     );
   });
+
+  test("does not grow after Rename crosses the one-character name range", () => {
+    const names = Array.from(
+      { length: 60 },
+      (_, index) => `value${String(index)}`,
+    );
+    const declarations = names
+      .map((name, index) => `local ${name}=make(${String(index)})\ntick()`)
+      .join("\n");
+    const source = `${declarations}\nuse(${names.join(",")})`;
+    const disabled = minify(source, {
+      runtimeProfile: "stormworks",
+      effectAwareTransforms: false,
+    });
+    const enabled = minify(source, { runtimeProfile: "stormworks" });
+
+    expect(Buffer.byteLength(enabled)).toBeLessThanOrEqual(
+      Buffer.byteLength(disabled),
+    );
+    expect(() => Parser.parse(enabled, { luaVersion: "5.3" })).not.toThrow();
+  });
 });

--- a/test/nonAdjacentLocals.integration.test.ts
+++ b/test/nonAdjacentLocals.integration.test.ts
@@ -82,4 +82,19 @@ describe("effect-aware non-adjacent locals pipeline", () => {
 
     expect(output).toBe(minify(SOURCE, { runtimeProfile: "lua53" }));
   });
+
+  test("does not replace a shorter adjacent-local merge", () => {
+    const source =
+      "local first=f() local second=g() local third=h() use(first,second,third)";
+    const disabled = minify(source, {
+      runtimeProfile: "stormworks",
+      effectAwareTransforms: false,
+    });
+    const enabled = minify(source, { runtimeProfile: "stormworks" });
+
+    expect(Buffer.byteLength(enabled)).toBeLessThanOrEqual(
+      Buffer.byteLength(disabled),
+    );
+    expect(enabled).toBe(disabled);
+  });
 });

--- a/test/nonAdjacentLocals.integration.test.ts
+++ b/test/nonAdjacentLocals.integration.test.ts
@@ -1,0 +1,85 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import Parser from "luaparse";
+import { afterEach, describe, expect, test } from "vitest";
+import { Minifier, MinifierMode } from "../src/minifier";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  temporaryDirectories.splice(0).forEach((directory) => {
+    fs.rmSync(directory, { recursive: true, force: true });
+  });
+});
+
+function minify(source: string, mode: Partial<MinifierMode>): string {
+  const directory = fs.mkdtempSync(
+    path.join(os.tmpdir(), "storm-effect-locals-test-"),
+  );
+  temporaryDirectories.push(directory);
+  const entry = path.join(directory, "main.lua");
+  fs.writeFileSync(entry, source);
+  return new Minifier(
+    entry,
+    { locations: true, luaVersion: "5.3", ranges: true, scope: true },
+    { moduleLikeLua: false, ...mode },
+  )
+    .parse()
+    .toStringWithSourceMap({ file: "main.min.lua" }).code;
+}
+
+const SOURCE = `
+local first = makeFirst()
+tick()
+local second = makeSecond()
+value = 1
+local third = makeThird()
+use(first, second, third)
+`;
+
+describe("effect-aware non-adjacent locals pipeline", () => {
+  test("is enabled by default for Stormworks and produces shorter valid Lua", () => {
+    const disabled = minify(SOURCE, {
+      runtimeProfile: "stormworks",
+      effectAwareTransforms: false,
+    });
+    const enabled = minify(SOURCE, { runtimeProfile: "stormworks" });
+
+    expect(Buffer.byteLength(enabled)).toBeLessThan(
+      Buffer.byteLength(disabled),
+    );
+    expect(() => Parser.parse(enabled, { luaVersion: "5.3" })).not.toThrow();
+  });
+
+  test("can be opted out in Stormworks", () => {
+    expect(
+      minify(SOURCE, {
+        runtimeProfile: "stormworks",
+        effectAwareTransforms: false,
+      }),
+    ).toBe(minify(SOURCE, { runtimeProfile: "lua53" }));
+  });
+
+  test("requires a separate local-lifetime opt-in for pure Lua", () => {
+    const defaultLua = minify(SOURCE, { runtimeProfile: "lua53" });
+    const optedInLua = minify(SOURCE, {
+      runtimeProfile: "lua53",
+      allowLocalLifetimeChanges: true,
+    });
+
+    expect(Buffer.byteLength(optedInLua)).toBeLessThan(
+      Buffer.byteLength(defaultLua),
+    );
+  });
+
+  test("does not run the lifetime opt-in when the safe transform master is off", () => {
+    const output = minify(SOURCE, {
+      runtimeProfile: "lua53",
+      allowLocalLifetimeChanges: true,
+      effectAwareTransforms: false,
+    });
+
+    expect(output).toBe(minify(SOURCE, { runtimeProfile: "lua53" }));
+  });
+});

--- a/test/nonAdjacentLocals.integration.test.ts
+++ b/test/nonAdjacentLocals.integration.test.ts
@@ -97,4 +97,20 @@ describe("effect-aware non-adjacent locals pipeline", () => {
     );
     expect(enabled).toBe(disabled);
   });
+
+  test("table-read opt-out does not disable local hoisting", () => {
+    const enabled = minify(SOURCE, {
+      runtimeProfile: "stormworks",
+      effectAwareTableReads: false,
+    });
+    const localDisabled = minify(SOURCE, {
+      runtimeProfile: "stormworks",
+      effectAwareTableReads: false,
+      effectAwareLocalHoist: false,
+    });
+
+    expect(Buffer.byteLength(enabled)).toBeLessThan(
+      Buffer.byteLength(localDisabled),
+    );
+  });
 });

--- a/test/nonAdjacentLocals.test.ts
+++ b/test/nonAdjacentLocals.test.ts
@@ -45,11 +45,17 @@ describe("non-adjacent local planner", () => {
 
   test("excludes a self-shadowing initializer without losing the next group", () => {
     const result = plan(
-      "local first=first local second=g() local third=h() local fourth=i()",
+      "local first=first tick() local second=g() tick() local third=h() tick() local fourth=i()",
     );
 
     expect(result.groups).toHaveLength(1);
-    expect(result.groups[0].indexes).toEqual([1, 2, 3]);
+    expect(result.groups[0].indexes).toEqual([2, 4, 6]);
+  });
+
+  test("leaves adjacent declarations to the existing local merge", () => {
+    expect(
+      plan("local first=f() local second=g() local third=h()").groups,
+    ).toEqual([]);
   });
 
   test("uses control flow and unsupported local shapes as boundaries", () => {
@@ -132,6 +138,7 @@ local first=f()
 tick()
 --# second
 local second=g()
+tick()
 --# third
 local third=h() --# trailing`;
     const chunk = Parser.parse(source, {
@@ -157,7 +164,7 @@ local third=h() --# trailing`;
       metadata.beforeOf(chunk.body[3]).map((comment) => comment.raw),
     ).toEqual(["--# second"]);
     expect(
-      metadata.trailingOf(chunk.body[4]).map((comment) => comment.raw),
+      metadata.trailingOf(chunk.body[5]).map((comment) => comment.raw),
     ).toEqual(["--# trailing"]);
   });
 });

--- a/test/nonAdjacentLocals.test.ts
+++ b/test/nonAdjacentLocals.test.ts
@@ -1,7 +1,11 @@
 import Parser from "luaparse";
 import { describe, expect, test } from "vitest";
-import { planNonAdjacentLocals } from "../src/nonAdjacentLocals";
+import {
+  applyNonAdjacentLocalPlan,
+  planNonAdjacentLocals,
+} from "../src/nonAdjacentLocals";
 import { resolveScopes, Symbol } from "../src/resolver";
+import { SourceMetadata } from "../src/sourceMetadata";
 
 function plan(
   source: string,
@@ -73,5 +77,87 @@ describe("non-adjacent local planner", () => {
     );
 
     expect(result.groups).toEqual([]);
+  });
+
+  test("hoists declarations while leaving initializers at their original points", () => {
+    const source =
+      "local first=f() tick() local second=g() value=1 local third=h()";
+    const chunk = Parser.parse(source, {
+      luaVersion: "5.3",
+      locations: true,
+      ranges: true,
+    });
+    const resolved = resolveScopes(chunk);
+    const result = applyNonAdjacentLocalPlan(
+      planNonAdjacentLocals(chunk, resolved, {
+        outputNameLengthOf: () => 1,
+        preserveRequireSplice: false,
+      }),
+    );
+
+    expect(result).toEqual({ changed: true, invalidatesResolve: true });
+    expect(chunk.body.map((statement) => statement.type)).toEqual([
+      "LocalStatement",
+      "AssignmentStatement",
+      "CallStatement",
+      "AssignmentStatement",
+      "AssignmentStatement",
+      "AssignmentStatement",
+    ]);
+    const declaration = chunk.body[0] as Parser.LocalStatement;
+    expect(declaration.variables.map((variable) => variable.name)).toEqual([
+      "first",
+      "second",
+      "third",
+    ]);
+    expect(declaration.init).toEqual([]);
+
+    const after = resolveScopes(chunk);
+    const writes = chunk.body
+      .filter(
+        (statement): statement is Parser.AssignmentStatement =>
+          statement.type === "AssignmentStatement" &&
+          statement.variables[0]?.type === "Identifier",
+      )
+      .map(
+        (statement) =>
+          after.symbolOf(statement.variables[0] as Parser.Identifier)?.name,
+      );
+    expect(writes).toEqual(["first", "second", undefined, "third"]);
+  });
+
+  test("preserves statement comments at the replacement boundaries", () => {
+    const source = `--# first
+local first=f()
+tick()
+--# second
+local second=g()
+--# third
+local third=h() --# trailing`;
+    const chunk = Parser.parse(source, {
+      luaVersion: "5.3",
+      comments: true,
+      locations: true,
+      ranges: true,
+    });
+    const metadata = new SourceMetadata(chunk, source);
+    const resolved = resolveScopes(chunk);
+    applyNonAdjacentLocalPlan(
+      planNonAdjacentLocals(chunk, resolved, {
+        outputNameLengthOf: () => 1,
+        preserveRequireSplice: false,
+      }),
+      metadata,
+    );
+
+    expect(
+      metadata.beforeOf(chunk.body[0]).map((comment) => comment.raw),
+    ).toEqual(["--# first"]);
+    expect(
+      metadata.beforeOf(chunk.body[3]).map((comment) => comment.raw),
+    ).toEqual(["--# second"]);
+    expect(
+      metadata.trailingOf(chunk.body[4]).map((comment) => comment.raw),
+    ).toEqual(["--# trailing"]);
   });
 });

--- a/test/nonAdjacentLocals.test.ts
+++ b/test/nonAdjacentLocals.test.ts
@@ -1,0 +1,77 @@
+import Parser from "luaparse";
+import { describe, expect, test } from "vitest";
+import { planNonAdjacentLocals } from "../src/nonAdjacentLocals";
+import { resolveScopes, Symbol } from "../src/resolver";
+
+function plan(
+  source: string,
+  outputNameLengthOf: (symbol: Symbol) => number | undefined = () => 1,
+  preserveRequireSplice = false,
+) {
+  const chunk = Parser.parse(source, { luaVersion: "5.3" });
+  const resolved = resolveScopes(chunk);
+  return planNonAdjacentLocals(chunk, resolved, {
+    outputNameLengthOf,
+    preserveRequireSplice,
+  });
+}
+
+describe("non-adjacent local planner", () => {
+  test("plans a profitable group across calls and assignments", () => {
+    const result = plan(
+      "local first=f() tick() local second=g() value=1 local third=h()",
+    );
+
+    expect(result.groups).toHaveLength(1);
+    expect(result.groups[0].indexes).toEqual([0, 2, 4]);
+    expect(result.groups[0].estimatedByteSavings).toBe(3);
+  });
+
+  test("rejects a two-local group whose separator-aware cost is not smaller", () => {
+    expect(plan("local first=f() tick() local second=g()").groups).toEqual([]);
+  });
+
+  test("rejects hoisting when it would shadow an intervening reference", () => {
+    const result = plan(
+      "local first=f() print(third) local second=g() local third=h() local fourth=i()",
+    );
+
+    expect(result.groups).toEqual([]);
+  });
+
+  test("excludes a self-shadowing initializer without losing the next group", () => {
+    const result = plan(
+      "local first=first local second=g() local third=h() local fourth=i()",
+    );
+
+    expect(result.groups).toHaveLength(1);
+    expect(result.groups[0].indexes).toEqual([1, 2, 3]);
+  });
+
+  test("uses control flow and unsupported local shapes as boundaries", () => {
+    const result = plan(
+      "local a=f() if flag then use() end local b,c=g() local d=h() local e=i()",
+    );
+
+    expect(result.groups).toEqual([]);
+  });
+
+  test("preserves SL require splice when requested", () => {
+    const result = plan(
+      'local a=f() local b=require("m") local c=g() local d=h()',
+      () => 1,
+      true,
+    );
+
+    expect(result.groups).toEqual([]);
+  });
+
+  test("rejects a group when predicted rename lengths cannot prove savings", () => {
+    const result = plan(
+      "local first=f() local second=g() local third=h()",
+      () => 2,
+    );
+
+    expect(result.groups).toEqual([]);
+  });
+});

--- a/test/optimizerDiagnostics.test.ts
+++ b/test/optimizerDiagnostics.test.ts
@@ -44,9 +44,64 @@ describe("optimization diagnostics", () => {
     expect(summary.acceptedCandidates).toBeGreaterThanOrEqual(2);
     expect(summary.rejectedCandidates).toBeGreaterThan(0);
     expect(summary.estimatedByteSavings).toBeGreaterThan(0);
+    expect(summary.buckets.some((bucket) => bucket.moduleName === "main")).toBe(
+      true,
+    );
     expect(
       collector.diagnostics.every((item) => item.moduleName === "main"),
     ).toBe(true);
+  });
+
+  test("classifies rejection reasons across a reproducible fixture corpus", () => {
+    const fixtures = [
+      "local t={x=1,y=2} local a=t.x tick() local b=t.y use(a,b)",
+      "local t={} local a=t[key] use(a)",
+      "local t={x=1} consume(t) local a=t.x use(a)",
+      "local a=1 tick() if ready then use(a) end local b=2 use(b)",
+      "local first=1 tick() local second=2 use(first,second)",
+    ];
+    const diagnostics = fixtures.flatMap((source, index) => {
+      const directory = fs.mkdtempSync(
+        path.join(os.tmpdir(), `storm-diagnostics-corpus-${String(index)}-`),
+      );
+      temporaryDirectories.push(directory);
+      const entry = path.join(directory, "main.lua");
+      fs.writeFileSync(entry, source);
+      const minifier = new Minifier(
+        entry,
+        { luaVersion: "5.3" },
+        {
+          moduleLikeLua: false,
+          runtimeProfile: "stormworks",
+          collectOptimizationDiagnostics: true,
+        },
+      );
+      minifier.parse();
+      return [...minifier.optimizationDiagnostics];
+    });
+    const reasons = new Set(diagnostics.map((item) => item.reason));
+    (
+      [
+        "profitable-group",
+        "dynamic-key",
+        "call-escape",
+        "control-flow-barrier",
+        "nonpositive-cost",
+      ] as const
+    ).forEach((reason) => expect(reasons.has(reason)).toBe(true));
+    expect(
+      diagnostics.every(
+        (item) =>
+          item.moduleName === "main" &&
+          item.runtimeProfile === "stormworks" &&
+          item.sourceRange !== undefined,
+      ),
+    ).toBe(true);
+    const summary = summarizeOptimizationDiagnostics(diagnostics);
+    expect(
+      summary.buckets.every((bucket) => bucket.runtimeProfile === "stormworks"),
+    ).toBe(true);
+    expect(JSON.parse(JSON.stringify(summary))).toEqual(summary);
   });
 
   test("collection does not change generated code or source map", () => {

--- a/test/optimizerDiagnostics.test.ts
+++ b/test/optimizerDiagnostics.test.ts
@@ -79,6 +79,24 @@ describe("optimization diagnostics", () => {
       minifier.parse();
       return [...minifier.optimizationDiagnostics];
     });
+    const luaDirectory = fs.mkdtempSync(
+      path.join(os.tmpdir(), "storm-diagnostics-corpus-lua53-"),
+    );
+    temporaryDirectories.push(luaDirectory);
+    const luaEntry = path.join(luaDirectory, "main.lua");
+    fs.writeFileSync(luaEntry, fixtures[0]);
+    const luaMinifier = new Minifier(
+      luaEntry,
+      { luaVersion: "5.3" },
+      {
+        moduleLikeLua: false,
+        runtimeProfile: "lua53",
+        allowLocalLifetimeChanges: true,
+        collectOptimizationDiagnostics: true,
+      },
+    );
+    luaMinifier.parse();
+    diagnostics.push(...luaMinifier.optimizationDiagnostics);
     const reasons = new Set(diagnostics.map((item) => item.reason));
     (
       [
@@ -93,14 +111,14 @@ describe("optimization diagnostics", () => {
       diagnostics.every(
         (item) =>
           item.moduleName === "main" &&
-          item.runtimeProfile === "stormworks" &&
+          item.runtimeProfile !== undefined &&
           item.sourceRange !== undefined,
       ),
     ).toBe(true);
     const summary = summarizeOptimizationDiagnostics(diagnostics);
     expect(
-      summary.buckets.every((bucket) => bucket.runtimeProfile === "stormworks"),
-    ).toBe(true);
+      new Set(summary.buckets.map((bucket) => bucket.runtimeProfile)),
+    ).toEqual(new Set(["stormworks", "lua53"]));
     expect(JSON.parse(JSON.stringify(summary))).toEqual(summary);
   });
 

--- a/test/optimizerDiagnostics.test.ts
+++ b/test/optimizerDiagnostics.test.ts
@@ -106,7 +106,9 @@ describe("optimization diagnostics", () => {
         "control-flow-barrier",
         "nonpositive-cost",
       ] as const
-    ).forEach((reason) => expect(reasons.has(reason)).toBe(true));
+    ).forEach((reason) => {
+      expect(reasons.has(reason)).toBe(true);
+    });
     expect(
       diagnostics.every(
         (item) =>

--- a/test/optimizerDiagnostics.test.ts
+++ b/test/optimizerDiagnostics.test.ts
@@ -1,0 +1,86 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import Parser from "luaparse";
+import { afterEach, describe, expect, test } from "vitest";
+import { Minifier } from "../src/minifier";
+import {
+  OptimizationDiagnosticCollector,
+  summarizeOptimizationDiagnostics,
+} from "../src/optimizerDiagnostics";
+import { planNonAdjacentLocals } from "../src/nonAdjacentLocals";
+import { resolveScopes } from "../src/resolver";
+import { analyzeTableEffects } from "../src/tableEffects";
+import { planTableReadMerges } from "../src/tableReadMerge";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  temporaryDirectories.splice(0).forEach((directory) => {
+    fs.rmSync(directory, { recursive: true, force: true });
+  });
+});
+
+describe("optimization diagnostics", () => {
+  test("summarizes accepted and rejected planner decisions", () => {
+    const source = "local t={x=1,y=2} local first=t.x tick() local second=t.y";
+    const chunk = Parser.parse(source, { luaVersion: "5.3" });
+    const resolved = resolveScopes(chunk);
+    const collector = new OptimizationDiagnosticCollector();
+
+    planTableReadMerges(chunk, analyzeTableEffects(chunk, resolved), {
+      dirtyGranularity: "static-key",
+      diagnostics: collector,
+      moduleName: "main",
+    });
+    planNonAdjacentLocals(chunk, resolved, {
+      outputNameLengthOf: () => 1,
+      preserveRequireSplice: true,
+      diagnostics: collector,
+      moduleName: "main",
+    });
+
+    const summary = summarizeOptimizationDiagnostics(collector.diagnostics);
+    expect(summary.acceptedCandidates).toBeGreaterThanOrEqual(2);
+    expect(summary.rejectedCandidates).toBeGreaterThan(0);
+    expect(summary.estimatedByteSavings).toBeGreaterThan(0);
+    expect(
+      collector.diagnostics.every((item) => item.moduleName === "main"),
+    ).toBe(true);
+  });
+
+  test("collection does not change generated code or source map", () => {
+    const directory = fs.mkdtempSync(
+      path.join(os.tmpdir(), "storm-optimizer-diagnostics-test-"),
+    );
+    temporaryDirectories.push(directory);
+    const entry = path.join(directory, "main.lua");
+    fs.writeFileSync(
+      entry,
+      "local t={x=1,y=2} local first=t.x tick() local second=t.y use(first,second)",
+    );
+    const create = (collectOptimizationDiagnostics: boolean) =>
+      new Minifier(
+        entry,
+        { luaVersion: "5.3" },
+        {
+          moduleLikeLua: false,
+          runtimeProfile: "stormworks",
+          collectOptimizationDiagnostics,
+        },
+      );
+    const disabled = create(false);
+    const enabled = create(true);
+    const disabledOutput = disabled
+      .parse()
+      .toStringWithSourceMap({ file: "main.min.lua" });
+    const enabledOutput = enabled
+      .parse()
+      .toStringWithSourceMap({ file: "main.min.lua" });
+
+    expect(enabledOutput.code).toBe(disabledOutput.code);
+    expect(enabledOutput.map.toString()).toBe(disabledOutput.map.toString());
+    expect(enabled.optimizationDiagnostics.length).toBeGreaterThan(0);
+    expect(disabled.optimizationDiagnostics).toEqual([]);
+  });
+});

--- a/test/optimizerPass.test.ts
+++ b/test/optimizerPass.test.ts
@@ -1,0 +1,63 @@
+import Parser from "luaparse";
+import { describe, expect, test } from "vitest";
+import { PassOrchestrator, UNCHANGED } from "../src/optimizerPass";
+import { resolveScopes } from "../src/resolver";
+
+describe("optimizer pass orchestrator", () => {
+  test("re-resolves immediately after an invalidating transform", () => {
+    const chunk = Parser.parse("local before=1 use(before)", {
+      luaVersion: "5.3",
+    });
+    const orchestrator = new PassOrchestrator(chunk, resolveScopes(chunk));
+    const original = orchestrator.resolved;
+
+    orchestrator.run("insert-local", () => {
+      chunk.body.unshift(
+        Parser.parse("local inserted=2", { luaVersion: "5.3" }).body[0],
+      );
+      return { changed: true, invalidatesResolve: true };
+    });
+
+    expect(orchestrator.resolved).not.toBe(original);
+    expect(orchestrator.resolveGeneration).toBe(1);
+    expect(orchestrator.resolved.symbols.map((symbol) => symbol.name)).toEqual([
+      "inserted",
+      "before",
+    ]);
+    expect(orchestrator.records).toEqual([
+      {
+        name: "insert-local",
+        changed: true,
+        invalidatesResolve: true,
+        resolveGenerationBefore: 0,
+        resolveGenerationAfter: 1,
+      },
+    ]);
+  });
+
+  test("keeps the analysis generation for a read-only pass", () => {
+    const chunk = Parser.parse("return 1", { luaVersion: "5.3" });
+    const orchestrator = new PassOrchestrator(chunk, resolveScopes(chunk));
+
+    orchestrator.run("inspect", () => UNCHANGED);
+
+    expect(orchestrator.resolveGeneration).toBe(0);
+    expect(orchestrator.records[0]).toMatchObject({
+      changed: false,
+      resolveGenerationBefore: 0,
+      resolveGenerationAfter: 0,
+    });
+  });
+
+  test("rejects an inconsistent invalidation result", () => {
+    const chunk = Parser.parse("return 1", { luaVersion: "5.3" });
+    const orchestrator = new PassOrchestrator(chunk, resolveScopes(chunk));
+
+    expect(() =>
+      orchestrator.run("invalid", () => ({
+        changed: false,
+        invalidatesResolve: true,
+      })),
+    ).toThrow(/cannot invalidate Resolve/);
+  });
+});

--- a/test/optimizerTransaction.test.ts
+++ b/test/optimizerTransaction.test.ts
@@ -1,0 +1,105 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { afterEach, describe, expect, test } from "vitest";
+import { selectTransactionalMinifierVariant } from "../src/optimizerTransaction";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  temporaryDirectories.splice(0).forEach((directory) => {
+    fs.rmSync(directory, { recursive: true, force: true });
+  });
+});
+
+function fixture(source: string): string {
+  const directory = fs.mkdtempSync(
+    path.join(os.tmpdir(), "storm-optimizer-transaction-"),
+  );
+  temporaryDirectories.push(directory);
+  const entry = path.join(directory, "main.lua");
+  fs.writeFileSync(entry, source);
+  return entry;
+}
+
+describe("transactional final-output selection", () => {
+  test("selects a strictly shorter effect-aware final artifact", () => {
+    const entryFilePath = fixture(`
+local t={x=1,y=2}
+local first=t.x
+tick()
+local second=t.y
+use(first,second)
+`);
+    const result = selectTransactionalMinifierVariant({
+      entryFilePath,
+      luaParseSettings: { luaVersion: "5.3" },
+      baselineMode: {
+        moduleLikeLua: false,
+        runtimeProfile: "stormworks",
+        effectAwareTransforms: false,
+      },
+      trialMode: {
+        moduleLikeLua: false,
+        runtimeProfile: "stormworks",
+      },
+    });
+    expect(result.accepted).toBe(true);
+    expect(result.byteSavings).toBeGreaterThan(0);
+    expect(result.selected).toEqual(result.trial);
+  });
+
+  test("keeps baseline and its source map when trial is not shorter", () => {
+    const entryFilePath = fixture(
+      "--# preserved\nlocal descriptive=1 return descriptive",
+    );
+    const result = selectTransactionalMinifierVariant({
+      entryFilePath,
+      luaParseSettings: { luaVersion: "5.3" },
+      baselineMode: { moduleLikeLua: false, rename: true },
+      trialMode: { moduleLikeLua: false, rename: false },
+    });
+    expect(result).toMatchObject({ accepted: false, reason: "not-shorter" });
+    expect(result.selected).toEqual(result.baseline);
+    expect(result.selected.code).toContain("--# preserved");
+    expect(JSON.parse(result.selected.sourceMap).sources).toContain("main.lua");
+  });
+
+  test("remains deterministic across modules", () => {
+    const entryFilePath = fixture('local child=require("child") return child');
+    fs.writeFileSync(
+      path.join(path.dirname(entryFilePath), "child.lua"),
+      "local value=1 return value",
+    );
+    const request = {
+      entryFilePath,
+      luaParseSettings: { luaVersion: "5.3" as const },
+      baselineMode: { moduleLikeLua: true },
+      trialMode: { moduleLikeLua: true },
+    };
+    const first = selectTransactionalMinifierVariant(request);
+    const second = selectTransactionalMinifierVariant(request);
+    expect(first).toEqual(second);
+    expect(first).toMatchObject({ accepted: false, reason: "not-shorter" });
+  });
+
+  test("isolates a trial failure from the selected baseline", () => {
+    const entryFilePath = fixture("local value=1 return value");
+    const failingReservedNames = {
+      [Symbol.iterator](): Iterator<string> {
+        throw new Error("trial-only failure");
+      },
+    } as ReadonlySet<string>;
+    const result = selectTransactionalMinifierVariant({
+      entryFilePath,
+      luaParseSettings: { luaVersion: "5.3" },
+      baselineMode: { moduleLikeLua: false },
+      trialMode: {
+        moduleLikeLua: false,
+        neverRenameGlobals: failingReservedNames,
+      },
+    });
+    expect(result).toMatchObject({ accepted: false, reason: "trial-failed" });
+    expect(result.selected).toEqual(result.baseline);
+  });
+});

--- a/test/optimizerTransaction.test.ts
+++ b/test/optimizerTransaction.test.ts
@@ -62,7 +62,10 @@ use(first,second)
     expect(result).toMatchObject({ accepted: false, reason: "not-shorter" });
     expect(result.selected).toEqual(result.baseline);
     expect(result.selected.code).toContain("--# preserved");
-    expect(JSON.parse(result.selected.sourceMap).sources).toContain("main.lua");
+    const sourceMap = JSON.parse(result.selected.sourceMap) as {
+      sources: unknown;
+    };
+    expect(sourceMap.sources).toContain("main.lua");
   });
 
   test("remains deterministic across modules", () => {

--- a/test/runtimeEnvironment.test.ts
+++ b/test/runtimeEnvironment.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "vitest";
+import {
+  checkParallelValueCount,
+  runtimeEnvironmentOf,
+} from "../src/runtimeEnvironment";
+
+describe("runtime environment capabilities", () => {
+  test("separates semantics from compiler resource policy", () => {
+    const lua = runtimeEnvironmentOf("lua53");
+    const stormworks = runtimeEnvironmentOf("stormworks");
+
+    expect(lua.semantics).toEqual({
+      mutableMetatables: true,
+      debugLocalIntrospection: true,
+    });
+    expect(stormworks.semantics).toEqual({
+      mutableMetatables: false,
+      debugLocalIntrospection: false,
+    });
+    expect(stormworks.resources).toEqual(lua.resources);
+  });
+
+  test("labels the 50-value boundary as a conservative policy", () => {
+    const environment = runtimeEnvironmentOf("stormworks");
+
+    expect(checkParallelValueCount(environment, 49)).toMatchObject({
+      allowed: true,
+      confidence: "conservative-policy",
+    });
+    expect(checkParallelValueCount(environment, 50).allowed).toBe(true);
+    expect(checkParallelValueCount(environment, 51)).toEqual({
+      allowed: false,
+      reason: "parallel-value-limit",
+      limit: 50,
+    });
+  });
+});

--- a/test/runtimeEnvironment.test.ts
+++ b/test/runtimeEnvironment.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, test } from "vitest";
 import {
+  analyzeLocalResourceUsage,
+  checkParallelEvaluation,
   checkParallelValueCount,
   runtimeEnvironmentOf,
 } from "../src/runtimeEnvironment";
+import Parser from "luaparse";
 
 describe("runtime environment capabilities", () => {
   test("separates semantics from compiler resource policy", () => {
@@ -32,6 +35,49 @@ describe("runtime environment capabilities", () => {
       allowed: false,
       reason: "parallel-value-limit",
       limit: 50,
+      estimatedPeakRegisters: 51,
     });
+  });
+
+  test("derives parallel headroom from active locals", () => {
+    const environment = runtimeEnvironmentOf("lua53");
+    expect(
+      checkParallelEvaluation(environment, {
+        activeLocalsBefore: 150,
+        parallelValueCount: 50,
+      }),
+    ).toMatchObject({ allowed: true, limit: 50 });
+    expect(
+      checkParallelEvaluation(environment, {
+        activeLocalsBefore: 151,
+        parallelValueCount: 50,
+      }),
+    ).toEqual({
+      allowed: false,
+      reason: "local-limit",
+      limit: 49,
+      estimatedPeakRegisters: 201,
+    });
+  });
+
+  test("counts active locals per lexical block and function", () => {
+    const chunk = Parser.parse(
+      "local a=1 do local b=2 use(a,b) end local function f(p) local q=1 use(p,q) end",
+      { luaVersion: "5.3" },
+    );
+    const usage = analyzeLocalResourceUsage(chunk);
+    const doStatement = chunk.body[1];
+    const nestedLocal =
+      doStatement.type === "DoStatement" ? doStatement.body[0] : undefined;
+    const nestedUse =
+      doStatement.type === "DoStatement" ? doStatement.body[1] : undefined;
+    const fn = chunk.body[2];
+    if (!nestedLocal || !nestedUse || fn.type !== "FunctionDeclaration") {
+      throw new Error("unexpected fixture shape");
+    }
+    expect(usage.activeLocalsBefore(nestedLocal)).toBe(1);
+    expect(usage.activeLocalsBefore(nestedUse)).toBe(2);
+    expect(usage.activeLocalsBefore(fn.body[0])).toBe(1);
+    expect(usage.activeLocalsBefore(fn.body[1])).toBe(2);
   });
 });

--- a/test/sourcemap.test.ts
+++ b/test/sourcemap.test.ts
@@ -143,6 +143,47 @@ test("sourcemap: 非連続localの合成代入左辺が元の宣言位置と名�
   });
 });
 
+test("sourcemap: table readを統合したlocalの変数とRHSが各元宣言へマップされる", async () => {
+  const { code, map } = runMinifier({
+    label: "sourcemap: effect-aware table read merge",
+    fixture: "effect-aware-table",
+    mode: {
+      moduleLikeLua: false,
+      runtimeProfile: "stormworks",
+      effectAwareLocalHoist: false,
+    },
+  });
+
+  await SourceMapConsumer.with(map, null, (consumer) => {
+    const secondVariable = consumer.generatedPositionFor({
+      source: "main.lua",
+      line: 4,
+      column: 6,
+    });
+    assert.ok(
+      secondVariable.line !== null && secondVariable.column !== null,
+      "second local variable must have a generated mapping",
+    );
+    const variableOrigin = consumer.originalPositionFor({
+      line: secondVariable.line,
+      column: secondVariable.column,
+    });
+    assert.equal(variableOrigin.source, "main.lua");
+    assert.equal(variableOrigin.line, 4);
+    assert.equal(variableOrigin.column, 6);
+    assert.equal(variableOrigin.name, "second");
+
+    const secondRead = locateInGenerated(code, ".y");
+    const readOrigin = consumer.originalPositionFor({
+      line: secondRead.line,
+      column: secondRead.column + 1,
+    });
+    assert.equal(readOrigin.source, "main.lua");
+    assert.equal(readOrigin.line, 4);
+    assert.equal(readOrigin.name, "y");
+  });
+});
+
 test("sourcemap: ドット区切りモジュール名のsourcesはOSに依存せず'/'区切りになる", () => {
   const { map } = runMinifier({
     label:

--- a/test/sourcemap.test.ts
+++ b/test/sourcemap.test.ts
@@ -122,6 +122,27 @@ test("sourcemap: #8bでエイリアス化された参照は、位置は元のま
   });
 });
 
+test("sourcemap: 非連続localの合成代入左辺が元の宣言位置と名前へマップされる", async () => {
+  const { code, map } = runMinifier({
+    label: "sourcemap: effect-aware local hoist",
+    fixture: "effect-aware",
+    mode: { moduleLikeLua: false, runtimeProfile: "stormworks" },
+  });
+
+  await SourceMapConsumer.with(map, null, (consumer) => {
+    const rhs = locateInGenerated(code, "makeSecond");
+    // 合成代入は`<renamed>=makeSecond()`。`=`の1 byteを戻った位置がlhs。
+    const lhs = consumer.originalPositionFor({
+      line: rhs.line,
+      column: rhs.column - 2,
+    });
+    assert.equal(lhs.source, "main.lua");
+    assert.equal(lhs.line, 3);
+    assert.equal(lhs.column, 6);
+    assert.equal(lhs.name, "second");
+  });
+});
+
 test("sourcemap: ドット区切りモジュール名のsourcesはOSに依存せず'/'区切りになる", () => {
   const { map } = runMinifier({
     label:

--- a/test/tableEffects.test.ts
+++ b/test/tableEffects.test.ts
@@ -67,6 +67,23 @@ describe("fresh table effect analysis", () => {
     ]);
   });
 
+  test("treats an alias assignment through a closure as an escape", () => {
+    const analysis = analyze(`
+local t={x=1,y=2}
+local alias
+local bind=function() alias=t end
+local mutate=function() alias.y=9 end
+local first=t.x
+bind()
+mutate()
+local second=t.y
+`);
+    expect(analysis.isNonescaping(analysis.freshTables[0])).toBe(false);
+    expect(analysis.escapes.map((escape) => escape.reason)).toContain(
+      "capture",
+    );
+  });
+
   test("keeps writes to different static keys distinct", () => {
     const analysis = analyze("local t={} t.x=1 t.y=2");
     expect(

--- a/test/tableEffects.test.ts
+++ b/test/tableEffects.test.ts
@@ -84,6 +84,20 @@ local second=t.y
     );
   });
 
+  test("does not classify a table assigned to an upvalue as fresh local", () => {
+    const analysis = analyze(`
+local t
+local function evil() t.y=9 end
+local function make()
+  t={x=1,y=2}
+  local a=t.x
+  evil()
+  local b=t.y
+end
+`);
+    expect(analysis.freshTables).toEqual([]);
+  });
+
   test("keeps writes to different static keys distinct", () => {
     const analysis = analyze("local t={} t.x=1 t.y=2");
     expect(

--- a/test/tableEffects.test.ts
+++ b/test/tableEffects.test.ts
@@ -18,15 +18,21 @@ describe("fresh table effect analysis", () => {
         effect.staticKey ?? "dynamic",
       ]),
     ).toEqual([
-      ["read", "x"],
-      ["write", "x"],
+      ["read", "78"],
+      ["write", "78"],
       ["read", "dynamic"],
     ]);
   });
 
-  test("does not decode escaped string keys as static", () => {
-    const analysis = analyze('local t={} return t["x\\n"]');
-    expect(analysis.effects[0].staticKey).toBeUndefined();
+  test("normalizes escaped and long-bracket keys by Lua bytes", () => {
+    const analysis = analyze(
+      'local t={} local a=t.x local b=t["\\120"] local c=t[ [[x]] ]',
+    );
+    expect(analysis.effects.map((effect) => effect.staticKey)).toEqual([
+      "78",
+      "78",
+      "78",
+    ]);
   });
 
   test("keeps a fresh table nonescaping across unrelated calls", () => {
@@ -52,8 +58,8 @@ describe("fresh table effect analysis", () => {
     expect(
       analysis.effects.map((effect) => [effect.access, effect.staticKey]),
     ).toEqual([
-      ["write", "x"],
-      ["write", "y"],
+      ["write", "78"],
+      ["write", "79"],
     ]);
   });
 });

--- a/test/tableEffects.test.ts
+++ b/test/tableEffects.test.ts
@@ -42,7 +42,6 @@ describe("fresh table effect analysis", () => {
   });
 
   test.each([
-    ["alias", "local t={} local alias=t", "alias"],
     ["call", "local t={} consume(t)", "call"],
     ["return", "local t={} return t", "return"],
     ["store", "local t={} global=t", "store"],
@@ -51,6 +50,21 @@ describe("fresh table effect analysis", () => {
     const analysis = analyze(source);
     expect(analysis.escapes.map((escape) => escape.reason)).toContain(reason);
     expect(analysis.isNonescaping(analysis.freshTables[0])).toBe(false);
+  });
+
+  test("tracks a local alias as the same nonescaping allocation", () => {
+    const analysis = analyze(
+      "local t={} local alias=t alias.x=1 local value=t.x",
+    );
+    expect(analysis.freshTables).toHaveLength(1);
+    expect(analysis.escapes).toEqual([]);
+    expect(
+      analysis.effects.map((effect) => effect.table.allocation.id),
+    ).toEqual([0, 0]);
+    expect(analysis.effects.map((effect) => effect.baseSymbol.name)).toEqual([
+      "alias",
+      "t",
+    ]);
   });
 
   test("keeps writes to different static keys distinct", () => {

--- a/test/tableEffects.test.ts
+++ b/test/tableEffects.test.ts
@@ -1,0 +1,59 @@
+import Parser from "luaparse";
+import { describe, expect, test } from "vitest";
+import { resolveScopes } from "../src/resolver";
+import { analyzeTableEffects } from "../src/tableEffects";
+
+function analyze(source: string) {
+  const chunk = Parser.parse(source, { luaVersion: "5.3" });
+  return analyzeTableEffects(chunk, resolveScopes(chunk));
+}
+
+describe("fresh table effect analysis", () => {
+  test("normalizes member and simple string index keys", () => {
+    const analysis = analyze('local t={} local a=t.x t["x"]=1 local b=t[key]');
+
+    expect(
+      analysis.effects.map((effect) => [
+        effect.access,
+        effect.staticKey ?? "dynamic",
+      ]),
+    ).toEqual([
+      ["read", "x"],
+      ["write", "x"],
+      ["read", "dynamic"],
+    ]);
+  });
+
+  test("does not decode escaped string keys as static", () => {
+    const analysis = analyze('local t={} return t["x\\n"]');
+    expect(analysis.effects[0].staticKey).toBeUndefined();
+  });
+
+  test("keeps a fresh table nonescaping across unrelated calls", () => {
+    const analysis = analyze("local t={x=1} tick() local value=t.x");
+    expect(analysis.freshTables).toHaveLength(1);
+    expect(analysis.isNonescaping(analysis.freshTables[0])).toBe(true);
+  });
+
+  test.each([
+    ["alias", "local t={} local alias=t", "alias"],
+    ["call", "local t={} consume(t)", "call"],
+    ["return", "local t={} return t", "return"],
+    ["store", "local t={} global=t", "store"],
+    ["capture", "local t={} local f=function() return t.x end", "capture"],
+  ] as const)("marks %s as an escape", (_label, source, reason) => {
+    const analysis = analyze(source);
+    expect(analysis.escapes.map((escape) => escape.reason)).toContain(reason);
+    expect(analysis.isNonescaping(analysis.freshTables[0])).toBe(false);
+  });
+
+  test("keeps writes to different static keys distinct", () => {
+    const analysis = analyze("local t={} t.x=1 t.y=2");
+    expect(
+      analysis.effects.map((effect) => [effect.access, effect.staticKey]),
+    ).toEqual([
+      ["write", "x"],
+      ["write", "y"],
+    ]);
+  });
+});

--- a/test/tableReadMerge.integration.test.ts
+++ b/test/tableReadMerge.integration.test.ts
@@ -135,4 +135,23 @@ use(first,second)
       Buffer.byteLength(apiDefault),
     );
   });
+
+  test("does not move a preserved comment across an intervening call", () => {
+    const source = `
+local tableValue={x=1,y=2}
+local first=tableValue.x
+tick()
+--# second stays after tick
+local second=tableValue.y
+use(first,second)
+`;
+    const enabled = minify(source, { effectAwareLocalHoist: false });
+    const disabled = minify(source, {
+      effectAwareTableReads: false,
+      effectAwareLocalHoist: false,
+    });
+
+    expect(enabled).toBe(disabled);
+    expect(enabled.indexOf("tick()")).toBeLessThan(enabled.indexOf("--#"));
+  });
 });

--- a/test/tableReadMerge.integration.test.ts
+++ b/test/tableReadMerge.integration.test.ts
@@ -1,0 +1,100 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import Parser from "luaparse";
+import { afterEach, describe, expect, test } from "vitest";
+import { Minifier, MinifierMode } from "../src/minifier";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  temporaryDirectories.splice(0).forEach((directory) => {
+    fs.rmSync(directory, { recursive: true, force: true });
+  });
+});
+
+function minify(source: string, mode: Partial<MinifierMode> = {}): string {
+  const directory = fs.mkdtempSync(
+    path.join(os.tmpdir(), "storm-table-read-merge-test-"),
+  );
+  temporaryDirectories.push(directory);
+  const entry = path.join(directory, "main.lua");
+  fs.writeFileSync(entry, source);
+  return new Minifier(
+    entry,
+    { locations: true, luaVersion: "5.3", ranges: true, scope: true },
+    { moduleLikeLua: false, runtimeProfile: "stormworks", ...mode },
+  )
+    .parse()
+    .toStringWithSourceMap({ file: "main.min.lua" }).code;
+}
+
+describe("effect-aware table read merge pipeline", () => {
+  test("merges stable fresh-table reads and shortens valid output", () => {
+    const source = `
+local tableValue={x=1,y=2}
+local first=tableValue.x
+tick()
+local second=tableValue.y
+use(first,second)
+`;
+    const enabled = minify(source, { effectAwareLocalHoist: false });
+    const disabled = minify(source, {
+      effectAwareTableReads: false,
+      effectAwareLocalHoist: false,
+    });
+
+    expect(Buffer.byteLength(enabled)).toBeLessThan(
+      Buffer.byteLength(disabled),
+    );
+    expect(() => Parser.parse(enabled, { luaVersion: "5.3" })).not.toThrow();
+  });
+
+  test("field-sensitive mode crosses a different-key write", () => {
+    const source = `
+local tableValue={x=1}
+local first=tableValue.x
+tableValue.y=2
+local second=tableValue.x
+use(first,second)
+`;
+    const fieldSensitive = minify(source, { effectAwareLocalHoist: false });
+    const wholeTable = minify(source, {
+      fieldSensitiveTableEffects: false,
+      effectAwareLocalHoist: false,
+    });
+
+    expect(Buffer.byteLength(fieldSensitive)).toBeLessThan(
+      Buffer.byteLength(wholeTable),
+    );
+  });
+
+  test("does not move reads for an escaped table", () => {
+    const source = `
+local tableValue={x=1,y=2}
+local first=tableValue.x
+consume(tableValue)
+local second=tableValue.y
+use(first,second)
+`;
+    expect(minify(source)).toBe(
+      minify(source, { effectAwareTableReads: false }),
+    );
+  });
+
+  test("master safe opt-out disables table read movement", () => {
+    const source = `
+local tableValue={x=1,y=2}
+local first=tableValue.x
+tick()
+local second=tableValue.y
+use(first,second)
+`;
+    expect(minify(source, { effectAwareTransforms: false })).toBe(
+      minify(source, {
+        effectAwareTableReads: false,
+        effectAwareLocalHoist: false,
+      }),
+    );
+  });
+});

--- a/test/tableReadMerge.integration.test.ts
+++ b/test/tableReadMerge.integration.test.ts
@@ -77,6 +77,26 @@ use(first,second)
     );
   });
 
+  test("merges reads through a stable local alias", () => {
+    const source = `
+local tableValue={x=1,y=2}
+local alias=tableValue
+local first=alias.x
+tick()
+local second=tableValue.y
+use(first,second)
+`;
+    const enabled = minify(source, { effectAwareLocalHoist: false });
+    const disabled = minify(source, {
+      effectAwareTableReads: false,
+      effectAwareLocalHoist: false,
+    });
+
+    expect(Buffer.byteLength(enabled)).toBeLessThan(
+      Buffer.byteLength(disabled),
+    );
+  });
+
   test("does not move reads for an escaped table", () => {
     const source = `
 local tableValue={x=1,y=2}

--- a/test/tableReadMerge.integration.test.ts
+++ b/test/tableReadMerge.integration.test.ts
@@ -127,6 +127,24 @@ use(first,second)
     );
   });
 
+  test("does not move reads for a fresh table assigned to an upvalue", () => {
+    const source = `
+local tableValue
+local function evil() tableValue.y=9 end
+local function make()
+  tableValue={x=1,y=2}
+  local first=tableValue.x
+  evil()
+  local second=tableValue.y
+  use(first,second)
+end
+make()
+`;
+    expect(minify(source)).toBe(
+      minify(source, { effectAwareTableReads: false }),
+    );
+  });
+
   test("master safe opt-out disables table read movement", () => {
     const source = `
 local tableValue={x=1,y=2}

--- a/test/tableReadMerge.integration.test.ts
+++ b/test/tableReadMerge.integration.test.ts
@@ -13,7 +13,7 @@ afterEach(() => {
   });
 });
 
-function minify(source: string, mode: Partial<MinifierMode> = {}): string {
+function minifyExact(source: string, mode: MinifierMode): string {
   const directory = fs.mkdtempSync(
     path.join(os.tmpdir(), "storm-table-read-merge-test-"),
   );
@@ -23,10 +23,18 @@ function minify(source: string, mode: Partial<MinifierMode> = {}): string {
   return new Minifier(
     entry,
     { locations: true, luaVersion: "5.3", ranges: true, scope: true },
-    { moduleLikeLua: false, runtimeProfile: "stormworks", ...mode },
+    mode,
   )
     .parse()
     .toStringWithSourceMap({ file: "main.min.lua" }).code;
+}
+
+function minify(source: string, mode: Partial<MinifierMode> = {}): string {
+  return minifyExact(source, {
+    moduleLikeLua: false,
+    runtimeProfile: "stormworks",
+    ...mode,
+  });
 }
 
 describe("effect-aware table read merge pipeline", () => {
@@ -95,6 +103,36 @@ use(first,second)
         effectAwareTableReads: false,
         effectAwareLocalHoist: false,
       }),
+    );
+  });
+
+  test("keeps the API default conservative for pure Lua", () => {
+    const source = `
+local tableValue={x=1,y=2}
+local first=tableValue.x
+tick()
+local second=tableValue.y
+use(first,second)
+`;
+    const apiDefault = minifyExact(source, {
+      moduleLikeLua: false,
+      effectAwareLocalHoist: false,
+    });
+    const explicitLua = minifyExact(source, {
+      moduleLikeLua: false,
+      runtimeProfile: "lua53",
+      effectAwareLocalHoist: false,
+    });
+    const optedInLua = minifyExact(source, {
+      moduleLikeLua: false,
+      runtimeProfile: "lua53",
+      allowLocalLifetimeChanges: true,
+      effectAwareLocalHoist: false,
+    });
+
+    expect(apiDefault).toBe(explicitLua);
+    expect(Buffer.byteLength(optedInLua)).toBeLessThan(
+      Buffer.byteLength(apiDefault),
     );
   });
 });

--- a/test/tableReadMerge.integration.test.ts
+++ b/test/tableReadMerge.integration.test.ts
@@ -110,6 +110,23 @@ use(first,second)
     );
   });
 
+  test("does not move reads when a closure publishes an alias", () => {
+    const source = `
+local tableValue={x=1,y=2}
+local alias
+local bind=function() alias=tableValue end
+local mutate=function() alias.y=9 end
+local first=tableValue.x
+bind()
+mutate()
+local second=tableValue.y
+use(first,second)
+`;
+    expect(minify(source)).toBe(
+      minify(source, { effectAwareTableReads: false }),
+    );
+  });
+
   test("master safe opt-out disables table read movement", () => {
     const source = `
 local tableValue={x=1,y=2}

--- a/test/tableReadMerge.test.ts
+++ b/test/tableReadMerge.test.ts
@@ -8,7 +8,10 @@ import {
   planTableReadMerges,
 } from "../src/tableReadMerge";
 
-function plan(source: string, fieldSensitive = false) {
+function plan(
+  source: string,
+  dirtyGranularity: "table" | "static-key" = "table",
+) {
   const chunk = Parser.parse(source, { luaVersion: "5.3" });
   const resolved = resolveScopes(chunk);
   return {
@@ -17,7 +20,7 @@ function plan(source: string, fieldSensitive = false) {
       chunk,
       analyzeBindingEffects(chunk, resolved),
       analyzeTableEffects(chunk, resolved),
-      { fieldSensitive },
+      { dirtyGranularity },
     ),
   };
 }
@@ -41,6 +44,31 @@ describe("fresh table read merge planner", () => {
 
   test("treats every write as dirty in whole-table mode", () => {
     const result = plan("local t={x=1} local first=t.x t.y=2 local second=t.x");
+    expect(result.plan.groups).toEqual([]);
+  });
+
+  test("crosses a write to a different key in static-key mode", () => {
+    const result = plan(
+      "local t={x=1} local first=t.x t.y=2 local second=t.x",
+      "static-key",
+    );
+    expect(result.plan.groups).toHaveLength(1);
+    expect(result.plan.groups[0].indexes).toEqual([1, 3]);
+  });
+
+  test("does not cross a write to the same canonical static key", () => {
+    const result = plan(
+      'local t={x=1} local first=t.x t["x"]=2 local second=t.x',
+      "static-key",
+    );
+    expect(result.plan.groups).toEqual([]);
+  });
+
+  test("treats a dynamic-key write as dirty for every static key", () => {
+    const result = plan(
+      "local t={x=1} local first=t.x t[key]=2 local second=t.x",
+      "static-key",
+    );
     expect(result.plan.groups).toEqual([]);
   });
 

--- a/test/tableReadMerge.test.ts
+++ b/test/tableReadMerge.test.ts
@@ -10,6 +10,7 @@ import {
 function plan(
   source: string,
   dirtyGranularity: "table" | "static-key" = "table",
+  maxMergeArityAt?: (statement: Parser.LocalStatement) => number,
 ) {
   const chunk = Parser.parse(source, { luaVersion: "5.3" });
   const resolved = resolveScopes(chunk);
@@ -17,6 +18,7 @@ function plan(
     chunk,
     plan: planTableReadMerges(chunk, analyzeTableEffects(chunk, resolved), {
       dirtyGranularity,
+      maxMergeArityAt,
     }),
   };
 }
@@ -183,6 +185,17 @@ make()
 
     expect(result.plan.groups.map((group) => group.statements.length)).toEqual([
       50, 50, 20,
+    ]);
+  });
+
+  test("uses the position-specific active-local headroom", () => {
+    const reads = Array.from(
+      { length: 51 },
+      (_, index) => `local value${String(index)}=t.x`,
+    ).join(" tick() ");
+    const result = plan(`local t={x=1} ${reads}`, "table", () => 49);
+    expect(result.plan.groups.map((group) => group.statements.length)).toEqual([
+      49, 2,
     ]);
   });
 });

--- a/test/tableReadMerge.test.ts
+++ b/test/tableReadMerge.test.ts
@@ -118,6 +118,11 @@ describe("fresh table read merge planner", () => {
     expect(() => resolveScopes(result.chunk)).not.toThrow();
   });
 
+  test("leaves adjacent reads to the existing local merge", () => {
+    const result = plan("local t={x=1,y=2} local first=t.x local second=t.y");
+    expect(result.plan.groups).toEqual([]);
+  });
+
   test("splits large groups to preserve Lua register headroom", () => {
     const reads = Array.from(
       { length: 120 },

--- a/test/tableReadMerge.test.ts
+++ b/test/tableReadMerge.test.ts
@@ -38,6 +38,20 @@ describe("fresh table read merge planner", () => {
     expect(result.plan.groups).toEqual([]);
   });
 
+  test("rejects movement when a closure publishes an alias", () => {
+    const result = plan(`
+local t={x=1,y=2}
+local alias
+local bind=function() alias=t end
+local mutate=function() alias.y=9 end
+local first=t.x
+bind()
+mutate()
+local second=t.y
+`);
+    expect(result.plan.groups).toEqual([]);
+  });
+
   test("treats every write as dirty in whole-table mode", () => {
     const result = plan("local t={x=1} local first=t.x t.y=2 local second=t.x");
     expect(result.plan.groups).toEqual([]);

--- a/test/tableReadMerge.test.ts
+++ b/test/tableReadMerge.test.ts
@@ -1,6 +1,5 @@
 import Parser from "luaparse";
 import { describe, expect, test } from "vitest";
-import { analyzeBindingEffects } from "../src/effectAnalysis";
 import { resolveScopes } from "../src/resolver";
 import { analyzeTableEffects } from "../src/tableEffects";
 import {
@@ -16,12 +15,9 @@ function plan(
   const resolved = resolveScopes(chunk);
   return {
     chunk,
-    plan: planTableReadMerges(
-      chunk,
-      analyzeBindingEffects(chunk, resolved),
-      analyzeTableEffects(chunk, resolved),
-      { dirtyGranularity },
-    ),
+    plan: planTableReadMerges(chunk, analyzeTableEffects(chunk, resolved), {
+      dirtyGranularity,
+    }),
   };
 }
 
@@ -75,6 +71,31 @@ describe("fresh table read merge planner", () => {
   test("rejects movement across a table binding reassignment", () => {
     const result = plan("local t={x=1} local first=t.x t={} local second=t.x");
     expect(result.plan.groups).toEqual([]);
+  });
+
+  test("merges reads through stable local aliases", () => {
+    const result = plan(
+      "local t={x=1,y=2} local alias=t local first=alias.x tick() local second=t.y",
+    );
+    expect(result.plan.groups).toHaveLength(1);
+    expect(result.plan.groups[0].indexes).toEqual([2, 4]);
+    expect(result.plan.groups[0].reads[0].table).toBe(
+      result.plan.groups[0].reads[1].table,
+    );
+  });
+
+  test("optimizes fresh allocations independently on each side of reassignment", () => {
+    const result = plan(
+      "local t={x=1,y=2} local a=t.x tick() local b=t.y t={x=3,y=4} local c=t.x tick() local d=t.y",
+    );
+    expect(result.plan.groups).toHaveLength(2);
+    expect(result.plan.groups.map((group) => group.indexes)).toEqual([
+      [1, 3],
+      [5, 7],
+    ]);
+    expect(result.plan.groups[0].reads[0].table).not.toBe(
+      result.plan.groups[1].reads[0].table,
+    );
   });
 
   test("rejects reads after the symbol was replaced before the group", () => {

--- a/test/tableReadMerge.test.ts
+++ b/test/tableReadMerge.test.ts
@@ -52,6 +52,22 @@ local second=t.y
     expect(result.plan.groups).toEqual([]);
   });
 
+  test("rejects movement for a fresh table assigned to an upvalue", () => {
+    const result = plan(`
+local t
+local function evil() t.y=9 end
+local function make()
+  t={x=1,y=2}
+  local a=t.x
+  evil()
+  local b=t.y
+  use(a,b)
+end
+make()
+`);
+    expect(result.plan.groups).toEqual([]);
+  });
+
   test("treats every write as dirty in whole-table mode", () => {
     const result = plan("local t={x=1} local first=t.x t.y=2 local second=t.x");
     expect(result.plan.groups).toEqual([]);

--- a/test/tableReadMerge.test.ts
+++ b/test/tableReadMerge.test.ts
@@ -77,6 +77,22 @@ describe("fresh table read merge planner", () => {
     expect(result.plan.groups).toEqual([]);
   });
 
+  test("rejects reads after the symbol was replaced before the group", () => {
+    const result = plan(
+      "local t={x=1} t=external local first=t.x tick() local second=t.x",
+      "static-key",
+    );
+    expect(result.plan.groups).toEqual([]);
+  });
+
+  test("rejects a replacement with a metatable-bearing table in pure Lua", () => {
+    const result = plan(
+      "local t={x=1} t=setmetatable({x=2},{}) local first=t.x tick() local second=t.x",
+      "static-key",
+    );
+    expect(result.plan.groups).toEqual([]);
+  });
+
   test("merges planned declarations and keeps expressions", () => {
     const result = plan(
       "local t={x=1,y=2} local first=t.x tick() local second=t.y",
@@ -100,5 +116,17 @@ describe("fresh table read merge planner", () => {
       "MemberExpression",
     ]);
     expect(() => resolveScopes(result.chunk)).not.toThrow();
+  });
+
+  test("splits large groups to preserve Lua register headroom", () => {
+    const reads = Array.from(
+      { length: 120 },
+      (_, index) => `local value${String(index)}=t.x`,
+    ).join(" tick() ");
+    const result = plan(`local t={x=1} ${reads}`);
+
+    expect(result.plan.groups.map((group) => group.statements.length)).toEqual([
+      50, 50, 20,
+    ]);
   });
 });

--- a/test/tableReadMerge.test.ts
+++ b/test/tableReadMerge.test.ts
@@ -1,0 +1,76 @@
+import Parser from "luaparse";
+import { describe, expect, test } from "vitest";
+import { analyzeBindingEffects } from "../src/effectAnalysis";
+import { resolveScopes } from "../src/resolver";
+import { analyzeTableEffects } from "../src/tableEffects";
+import {
+  applyTableReadMergePlan,
+  planTableReadMerges,
+} from "../src/tableReadMerge";
+
+function plan(source: string, fieldSensitive = false) {
+  const chunk = Parser.parse(source, { luaVersion: "5.3" });
+  const resolved = resolveScopes(chunk);
+  return {
+    chunk,
+    plan: planTableReadMerges(
+      chunk,
+      analyzeBindingEffects(chunk, resolved),
+      analyzeTableEffects(chunk, resolved),
+      { fieldSensitive },
+    ),
+  };
+}
+
+describe("fresh table read merge planner", () => {
+  test("moves stable reads across an unrelated call", () => {
+    const result = plan(
+      "local t={x=1,y=2} local first=t.x tick() local second=t.y",
+    );
+    expect(result.plan.groups).toHaveLength(1);
+    expect(result.plan.groups[0].indexes).toEqual([1, 3]);
+    expect(result.plan.groups[0].estimatedByteSavings).toBe(5);
+  });
+
+  test("rejects all movement for an escaping table", () => {
+    const result = plan(
+      "local t={x=1,y=2} local first=t.x consume(t) local second=t.y",
+    );
+    expect(result.plan.groups).toEqual([]);
+  });
+
+  test("treats every write as dirty in whole-table mode", () => {
+    const result = plan("local t={x=1} local first=t.x t.y=2 local second=t.x");
+    expect(result.plan.groups).toEqual([]);
+  });
+
+  test("rejects movement across a table binding reassignment", () => {
+    const result = plan("local t={x=1} local first=t.x t={} local second=t.x");
+    expect(result.plan.groups).toEqual([]);
+  });
+
+  test("merges planned declarations and keeps expressions", () => {
+    const result = plan(
+      "local t={x=1,y=2} local first=t.x tick() local second=t.y",
+    );
+    expect(applyTableReadMergePlan(result.plan)).toEqual({
+      changed: true,
+      invalidatesResolve: true,
+    });
+    expect(result.chunk.body.map((statement) => statement.type)).toEqual([
+      "LocalStatement",
+      "LocalStatement",
+      "CallStatement",
+    ]);
+    const merged = result.chunk.body[1] as Parser.LocalStatement;
+    expect(merged.variables.map((variable) => variable.name)).toEqual([
+      "first",
+      "second",
+    ]);
+    expect(merged.init.map((expression) => expression.type)).toEqual([
+      "MemberExpression",
+      "MemberExpression",
+    ]);
+    expect(() => resolveScopes(result.chunk)).not.toThrow();
+  });
+});

--- a/test/tableReadMerge.test.ts
+++ b/test/tableReadMerge.test.ts
@@ -24,6 +24,10 @@ function plan(
 }
 
 describe("fresh table read merge planner", () => {
+  test("ignores an uninitialized local declaration", () => {
+    expect(plan("local t local value=1").plan.groups).toEqual([]);
+  });
+
   test("moves stable reads across an unrelated call", () => {
     const result = plan(
       "local t={x=1,y=2} local first=t.x tick() local second=t.y",

--- a/test/valueFlow.test.ts
+++ b/test/valueFlow.test.ts
@@ -1,0 +1,66 @@
+import Parser from "luaparse";
+import { describe, expect, test } from "vitest";
+import { resolveScopes } from "../src/resolver";
+import { analyzeValueFlow } from "../src/valueFlow";
+
+function analyze(source: string) {
+  const chunk = Parser.parse(source, { luaVersion: "5.3" });
+  const resolved = resolveScopes(chunk);
+  return { chunk, resolved, flow: analyzeValueFlow(chunk, resolved) };
+}
+
+describe("linear allocation value flow", () => {
+  test("tracks allocation identity through an alias and kills it on reassignment", () => {
+    const { chunk, resolved, flow } = analyze(
+      "local t={} local alias=t use(alias) alias={} use(alias) use(t)",
+    );
+    const original = flow.allocations[0];
+    const replacement = flow.allocations[1];
+    const aliasDeclaration = chunk.body[1];
+    const firstUse = chunk.body[2];
+    const secondUse = chunk.body[4];
+    if (
+      aliasDeclaration.type !== "LocalStatement" ||
+      firstUse.type !== "CallStatement" ||
+      secondUse.type !== "CallStatement"
+    ) {
+      throw new Error("unexpected fixture shape");
+    }
+    const alias = resolved.symbolOf(aliasDeclaration.variables[0]);
+    const firstPoint = flow.controlFlow.pointOf(firstUse);
+    const secondPoint = flow.controlFlow.pointOf(secondUse);
+    if (!alias || !firstPoint || !secondPoint) throw new Error("missing facts");
+
+    expect(flow.valueBefore(firstPoint, alias)).toMatchObject({
+      kind: "allocations",
+    });
+    expect(flow.aliasesBefore(firstPoint, original).has(alias)).toBe(true);
+    expect(flow.aliasesBefore(secondPoint, original).has(alias)).toBe(false);
+    expect(flow.aliasesBefore(secondPoint, replacement).has(alias)).toBe(true);
+  });
+
+  test("does not carry an allocation across a control-flow barrier", () => {
+    const { chunk, resolved, flow } = analyze(
+      "local t={} if flag then use(t) end use(t)",
+    );
+    const declaration = chunk.body[0];
+    const use = chunk.body[2];
+    if (declaration.type !== "LocalStatement" || use.type !== "CallStatement") {
+      throw new Error("unexpected fixture shape");
+    }
+    const symbol = resolved.symbolOf(declaration.variables[0]);
+    const point = flow.controlFlow.pointOf(use);
+    if (!symbol || !point) throw new Error("missing facts");
+
+    expect(flow.valueBefore(point, symbol)).toEqual({
+      kind: "unknown",
+      reason: "region-entry",
+    });
+  });
+
+  test("assigns a distinct identity to each table constructor", () => {
+    const { flow } = analyze("local a={} local b={} a=b");
+    expect(flow.allocations.map((allocation) => allocation.id)).toEqual([0, 1]);
+    expect(flow.allocations[0].origin).not.toBe(flow.allocations[1].origin);
+  });
+});


### PR DESCRIPTION
Closes #47

## Summary
- add runtime-separated effect-aware local hoist and fresh-table read merging
- add pass orchestration, conservative CFG facts, allocation/reaching-definition/value-flow facts, Lua byte-string decoding, active-local resource policy, and runtime semantic checks as shared advanced-analysis foundations
- add deterministic candidate diagnostics and a reproducible optimizer report without changing generated code or source maps
- add isolated baseline/trial Minifier transactions that select only a strictly shorter final UTF-8 artifact
- preserve fail-closed handling for calls, escapes, dynamic keys, control-flow barriers, metatables, closure-published aliases, upvalue assignments, resource uncertainty, and failed transactions

## Options
- Stormworks meaning-preserving transforms are enabled by default and opt-out
- pure Lua local-lifetime changes require explicit opt-in
- meaning-changing assumptions require separate explicit opt-in; safe options do not enable them

## Verification
Run on Windows through cmd.exe and pnpm:
- pnpm run build
- pnpm run lint
- pnpm run format:check
- pnpm test: 35 files, 311 tests
- pnpm run verify:lua-budget: real luac53, existing 150 locals plus 49/50 accepted and 51 rejected
- pnpm run verify:effect-semantics: real lua53, 4 fixtures matched stdout/stderr/status exactly
- pnpm run report:optimizer: 5 reproducible fixtures, 14 candidates, accepted-table 55 to 49 bytes
- pnpm pack --dry-run

The seven follow-up issues created during implementation were reduced to three genuinely independent expansions: #63, #65, and #67. #61, #62, #64, and #66 were implemented within this branch and closed individually.

#63 and #65 are monitored in separate sessions and remain open. This PR includes only their reusable foundations: a deliberately incomplete conservative CFG representation and an isolated final-artifact transaction API. Full branch/loop/goto analysis and candidate-level competing-planner integration remain owned by those issues.
