### PR TITLE
Issue #42: local run plannerを三段階の安全性で統合

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,19 @@ CLIはStormworks向けツールとして、`--runtime-profile stormworks`を既�
 - `--no-effect-aware-table-reads`: fresh・nonescape tableの安定したreadのまとめ上げだけを無効にします
 - `--no-field-sensitive-table-effects`: tableの変更追跡をstatic key単位からtable全体へ戻します
 - `--allow-local-lifetime-changes`: Lua 5.3 profileで、debug APIから観測可能な`local`生存期間の変更を許可します
+- `--aggressive-table-read-merges`: tableへの変更を越えるreadも積極的なまとめ上げの対象にします（既定は無効）
 
-`-m` / `--module-like-lua`は`require`・`dofile`の出力方式を選ぶオプションであり、runtime profileとは独立です。また、現時点では未知の副作用を無視するような意味変更オプションは実装していません。将来追加する場合も、上記の意味保存オプションとは分けてopt-inにします。
+`-m` / `--module-like-lua`は`require`・`dofile`の出力方式を選ぶオプションであり、runtime profileとは独立です。
+
+### local宣言まとめ上げの安全性境界
+
+| 分類                   | API / CLIオプション                                            | 既定                                | 変換例                                  |
+| ---------------------- | -------------------------------------------------------------- | ----------------------------------- | --------------------------------------- |
+| 純Luaで意味保存        | `mergeLocals` / `--no-merge-locals`                            | 有効（opt-out）                     | 独立した連続localを1文へ結合            |
+| Stormworksで意味保存   | `effectAwareLocalHoist` / `--no-effect-aware-local-hoist`      | Stormworks profileで有効（opt-out） | 依存するinitializerを元位置の代入へ分離 |
+| Stormworksでも意味変更 | `aggressiveTableReadMerges` / `--aggressive-table-read-merges` | 無効（opt-in）                      | dirtyなtable readを変更より前へ移動     |
+
+2段目はlocalの生存期間を早めるため、`debug.getlocal`等を持つ純Luaでは既定で無効です。3段目は実際に読む値が変わり得ます。出力サイズを優先し、その違いを受け入れられるコードでだけ指定してください。
 
 # Source Map
 

--- a/docs/issue-47-effect-analysis.md
+++ b/docs/issue-47-effect-analysis.md
@@ -10,7 +10,7 @@
 2. 評価順、字句束縛、複数戻り値、制御フローの制約を満たす。
 3. 最終出力が厳密に短くなる。
 
-Issue #44 の定数伝搬・畳み込みは実装済みである。Issue #42 の local-run planner は未実装だが、#47 をその完了待ちにはしない。両 Issue が使える効果・コスト基盤を先に作り、連続・非連続候補の局所実装を重複させない。全面的な SSA、CFG、汎用 alias 解析は実測で必要になるまで導入しない。
+Issue #44 の定数伝搬・畳み込みは実装済みである。Issue #47 では、後続の Issue #42 が連続・非連続候補を同じ局所plannerで扱える効果・コスト基盤を先に作った。Issue #42 はこの基盤へ依存付きの連続local runを統合済みである。全面的な SSA、CFG、汎用 alias 解析は実測で必要になるまで導入しない。
 
 ## 意味論とオプション
 
@@ -90,7 +90,7 @@ table は fresh・nonescape を table 全体で dirty 管理し、次に static 
 
 適用する各変換は、出力構文の byte 差を保守的に計算し、厳密に短いと判断できる場合だけ適用する。判定不能なら拒否する。統合テストでは変換有効時の UTF-8 byte length が無効時より長くならないことを確認する。
 
-非連続 local は Rename と同じ予約名・module 順で provisional name を割り当て、その名前長を追加代入の上界に使う。変換で候補 Symbol の参照重みだけが増える限り、最終 Rename は旧割当を維持する案より悪くならない。一方、既存の連続 local merge と競合すると比較基準自体が変わるため、#42 で統合 planner を作るまでは、前後に local が隣接しない宣言だけを #47 の候補にする。
+非連続 local は Rename と同じ予約名・module 順で provisional name を割り当て、その名前長を追加代入の上界に使う。変換で候補 Symbol の参照重みだけが増える限り、最終 Rename は旧割当を維持する案より悪くならない。Issue #42 では、先頭initializerを結合後のlocal文に残し、依存する後続initializerだけを元位置の代入へ分離することで、連続local mergeとの境界を同じplannerへ統合した。依存のない隣接runは従来のmergeへ委譲する。
 
 table read merge は `local` と `=` の重複が消える固定構文差を使う。runtime semantics と compiler resource policy は別の capability とし、planner は中央の判定結果だけを参照する。字句block／functionごとのactive local数を文位置で数え、local上限、register上限、保守policyの最小headroomからarityを導出する。Windowsの`luac53`では、既存150 localsに対する49／50受理と51拒否を`pnpm run verify:lua-budget`で再現する。Stormworks compilerの詳細を導出できない場合は、このLua 5.3上限以下へfail-closedにfallbackする。
 
@@ -137,7 +137,7 @@ table read merge は `local` と `=` の重複が消える固定構文差を使�
 - `changed`／`invalidatesResolve`とResolve世代を集中管理し、#44、remove-unused、global alias、#47、#9を通すpass orchestrator
 - runtime／module／pass別の候補採否理由・件数・推定削減量と、再現可能なfixture report
 - 最終Rename／Print済みartifactを隔離比較するtransactional variant selector
-- RHS を元位置に残す、孤立した非連続 local 宣言の hoist
+- 先頭RHSを宣言に残し、後続RHSを元位置に残す、連続・非連続 local 宣言の hoist
 - fresh・nonescape tableの安定したstatic-key readを一つのlocal文へまとめる変換
 - table全体／static-key単位dirtyの個別切替、master／変換別opt-out
 - CLIのStormworks既定、APIのLua 5.3互換既定、純Lua lifetime変更の個別opt-in

--- a/src/cliOptions.ts
+++ b/src/cliOptions.ts
@@ -33,6 +33,10 @@ export function createCliProgram(): Command {
       "fresh tableの安定したreadのまとめ上げだけを無効にします",
     )
     .option(
+      "--aggressive-table-read-merges",
+      "tableの変更を越えるreadも積極的なまとめ上げの対象にします",
+    )
+    .option(
       "--no-field-sensitive-table-effects",
       "tableのdirty判定をstatic key単位からtable全体へ戻します",
     )

--- a/src/minifier.ts
+++ b/src/minifier.ts
@@ -44,6 +44,8 @@ export interface MinifierMode {
   effectAwareLocalHoist?: boolean;
   // fresh・nonescape tableの安定したreadを含むlocal mergeの個別opt-out。
   effectAwareTableReads?: boolean;
+  // dirtyなtable readも対象に含める積極的なopt-in。
+  aggressiveTableReadMerges?: boolean;
   // table全体ではなくstatic key単位でdirtyを追跡する精密化の個別opt-out。
   fieldSensitiveTableEffects?: boolean;
   // 純Luaでdebug APIから観測できるlocal lifetimeの変更を許可するopt-in。
@@ -337,6 +339,8 @@ export class Minifier {
               diagnostics: this.diagnosticCollector,
               moduleName,
               runtimeProfile: runtime.profile,
+              allowObservableValueChanges:
+                this.mode.aggressiveTableReadMerges === true,
             },
           );
           return applyTableReadMergePlan(

--- a/src/nonAdjacentLocals.ts
+++ b/src/nonAdjacentLocals.ts
@@ -1,5 +1,5 @@
 import Parser from "luaparse";
-import { AstWalkVisitor, walkStatement } from "./astWalk";
+import { AstWalkVisitor, walkExpression, walkStatement } from "./astWalk";
 import { ResolveResult, Symbol } from "./resolver";
 import { copyNodeOrigin, identifierWithOrigin } from "./generatedNode";
 import { SourceMetadata } from "./sourceMetadata";
@@ -82,16 +82,55 @@ export function planNonAdjacentLocals(
       rejectionReason: OptimizationDiagnosticReason = "insufficient-group",
     ) => {
       if (run.length >= 2) {
+        const hasSeparatedStatements = run.some(
+          (candidate, index) =>
+            index > 0 && candidate.index > run[index - 1].index + 1,
+        );
+        const priorSymbols = new Set<Symbol>();
+        const hasInitializerDependency = run.some((candidate) => {
+          const depends = candidate.statement.init.some((expression) => {
+            let depends = false;
+            const visitor: AstWalkVisitor = {
+              onIdentifierReference: (identifier) => {
+                const symbol = resolved.symbolOf(identifier);
+                if (symbol && priorSymbols.has(symbol)) depends = true;
+              },
+              onBlock: (nested) => {
+                nested.forEach((statement) => {
+                  walkStatement(statement, visitor);
+                });
+              },
+            };
+            walkExpression(expression, visitor);
+            return depends;
+          });
+          priorSymbols.add(candidate.symbol);
+          return depends;
+        });
+        if (!hasSeparatedStatements && !hasInitializerDependency) {
+          record(
+            "rejected",
+            "adjacent-local-owned-by-merge",
+            run.length,
+            undefined,
+            0,
+            rangeOf(run[0].statement),
+          );
+          run = [];
+          return;
+        }
         const lengths = run.map((candidate) =>
           options.outputNameLengthOf(candidate.symbol),
         );
         if (lengths.every((length): length is number => length !== undefined)) {
-          // N個の`local v=e`を`local v,...` + N個の`v=e`へ変える。
-          // token差に加え、新しい宣言と最初の代入間に必要な1 byte separatorも引く。
+          // 先頭initializerは結合後のlocal文に残し、2個目以降だけを元位置の
+          // assignmentへ分離する。これにより依存付きの隣接runも短くできる。
           const savings =
             4 * run.length -
             6 -
-            lengths.reduce((sum, length) => sum + length, 0);
+            lengths.reduce((sum, length) => sum + length, 0) +
+            lengths[0] +
+            2;
           if (savings > 0) {
             groups.push({
               body,
@@ -144,26 +183,6 @@ export function planNonAdjacentLocals(
 
     body.forEach((statement, index) => {
       if (isLinearInterveningStatement(statement)) return;
-
-      // 後続の既存local merge (#9) と候補選択を競合させない。隣接localを
-      // hoistすると、#47単体では短くても#9適用後を基準に出力が長くなり得る。
-      // #42で両案を同じplannerへ統合するまでは、孤立したlocalだけを扱う。
-      if (
-        statement.type === "LocalStatement" &&
-        (body[index - 1]?.type === "LocalStatement" ||
-          body[index + 1]?.type === "LocalStatement")
-      ) {
-        flush("adjacent-local-owned-by-merge");
-        record(
-          "rejected",
-          "adjacent-local-owned-by-merge",
-          1,
-          undefined,
-          0,
-          rangeOf(statement),
-        );
-        return;
-      }
 
       if (statement.type !== "LocalStatement") {
         flush("control-flow-barrier");
@@ -223,11 +242,11 @@ export function applyNonAdjacentLocalPlan(
     const declaration: Parser.LocalStatement = {
       type: "LocalStatement",
       variables: group.statements.map((statement) => statement.variables[0]),
-      init: [],
+      init: [group.statements[0].init[0]],
     };
     copyNodeOrigin(declaration, group.statements[0]);
 
-    const assignments = group.statements.map((statement) => {
+    const assignments = group.statements.slice(1).map((statement) => {
       const assignment: Parser.AssignmentStatement = {
         type: "AssignmentStatement",
         variables: [identifierWithOrigin(statement.variables[0])],
@@ -241,9 +260,7 @@ export function applyNonAdjacentLocalPlan(
       const index = group.indexes[offset];
       const source = group.statements[offset];
       const replacements =
-        offset === 0
-          ? [declaration, assignments[offset]]
-          : [assignments[offset]];
+        offset === 0 ? [declaration] : [assignments[offset - 1]];
       metadata?.replaceStatement(source, replacements);
       group.body.splice(index, 1, ...replacements);
     }

--- a/src/tableReadMerge.ts
+++ b/src/tableReadMerge.ts
@@ -32,6 +32,9 @@ export interface TableReadMergeOptions {
   readonly diagnostics?: OptimizationDiagnosticSink;
   readonly moduleName?: string;
   readonly runtimeProfile?: RuntimeProfile;
+  // 明示的な意味変更opt-in。tableへのwriteやbinding変更を越えてreadを前へ
+  // 移動し得るため、Stormworks profileでも安全とはみなさない。
+  readonly allowObservableValueChanges?: boolean;
 }
 
 interface Candidate {
@@ -182,7 +185,11 @@ export function planTableReadMerges(
         tableEffects,
         options.dirtyGranularity,
       );
-      if (shadowed || !stability.stable || dirtyReason) {
+      if (
+        shadowed ||
+        (!options.allowObservableValueChanges &&
+          (!stability.stable || dirtyReason))
+      ) {
         flush(
           shadowed
             ? "binding-shadow-hazard"

--- a/test/cliOptions.test.ts
+++ b/test/cliOptions.test.ts
@@ -44,6 +44,13 @@ describe("effect-aware CLI options", () => {
     });
   });
 
+  test("keeps aggressive table read movement as an opt-in", () => {
+    expect(optionsOf()).not.toHaveProperty("aggressiveTableReadMerges");
+    expect(optionsOf("--aggressive-table-read-merges")).toMatchObject({
+      aggressiveTableReadMerges: true,
+    });
+  });
+
   test("rejects an unknown runtime profile", () => {
     const program = createCliProgram();
     program.exitOverride();

--- a/test/localRunPlanner.integration.test.ts
+++ b/test/localRunPlanner.integration.test.ts
@@ -1,0 +1,91 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { afterEach, describe, expect, test } from "vitest";
+import { Minifier, MinifierMode } from "../src/minifier";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  temporaryDirectories.splice(0).forEach((directory) => {
+    fs.rmSync(directory, { recursive: true, force: true });
+  });
+});
+
+function minify(source: string, mode: Partial<MinifierMode>): string {
+  const directory = fs.mkdtempSync(
+    path.join(os.tmpdir(), "storm-local-run-planner-test-"),
+  );
+  temporaryDirectories.push(directory);
+  const entry = path.join(directory, "main.lua");
+  fs.writeFileSync(entry, source);
+  return new Minifier(
+    entry,
+    { locations: true, luaVersion: "5.3", ranges: true, scope: true },
+    { moduleLikeLua: false, requiredWhitespace: " ", ...mode },
+  )
+    .parse()
+    .toStringWithSourceMap({ file: "main.min.lua" }).code;
+}
+
+describe("Issue #42 local-run planner profiles", () => {
+  test("keeps pure-Lua independent merging as an opt-out", () => {
+    const source = "local first=f() local second=g() use(first,second)";
+    const enabled = minify(source, {
+      runtimeProfile: "lua53",
+      rename: false,
+    });
+    const disabled = minify(source, {
+      runtimeProfile: "lua53",
+      rename: false,
+      mergeLocals: false,
+    });
+
+    expect(enabled).toBe("local first,second=f(),g()use(first,second)");
+    expect(Buffer.byteLength(enabled)).toBeLessThan(
+      Buffer.byteLength(disabled),
+    );
+  });
+
+  test("separates dependent initializers by default only in Stormworks", () => {
+    const source = "local a=f() local b=g(a) use(a,b)";
+    const stormworks = minify(source, {
+      runtimeProfile: "stormworks",
+      rename: false,
+    });
+    const optedOut = minify(source, {
+      runtimeProfile: "stormworks",
+      rename: false,
+      effectAwareLocalHoist: false,
+    });
+    const lua = minify(source, { runtimeProfile: "lua53", rename: false });
+
+    expect(stormworks).toBe("local a,b=f()b=g(a)use(a,b)");
+    expect(optedOut).toBe(lua);
+    expect(Buffer.byteLength(stormworks)).toBeLessThan(
+      Buffer.byteLength(optedOut),
+    );
+  });
+
+  test("moves dirty table reads only with the explicit aggressive opt-in", () => {
+    const source =
+      "local tableValue={x=1} local before=tableValue.x tableValue.x=2 local after=tableValue.x use(before,after)";
+    const safe = minify(source, {
+      runtimeProfile: "stormworks",
+      rename: false,
+    });
+    const aggressive = minify(source, {
+      runtimeProfile: "stormworks",
+      rename: false,
+      aggressiveTableReadMerges: true,
+    });
+
+    expect(safe.replace(/\s+/g, " ")).toContain(
+      "tableValue.x=2 local after=tableValue.x",
+    );
+    expect(aggressive.replace(/\s+/g, " ")).toContain(
+      "local before,after=tableValue.x,tableValue.x tableValue.x=2",
+    );
+    expect(Buffer.byteLength(aggressive)).toBeLessThan(Buffer.byteLength(safe));
+  });
+});

--- a/test/nonAdjacentLocals.test.ts
+++ b/test/nonAdjacentLocals.test.ts
@@ -28,11 +28,13 @@ describe("non-adjacent local planner", () => {
 
     expect(result.groups).toHaveLength(1);
     expect(result.groups[0].indexes).toEqual([0, 2, 4]);
-    expect(result.groups[0].estimatedByteSavings).toBe(3);
+    expect(result.groups[0].estimatedByteSavings).toBe(6);
   });
 
-  test("rejects a two-local group whose separator-aware cost is not smaller", () => {
-    expect(plan("local first=f() tick() local second=g()").groups).toEqual([]);
+  test("keeps the first initializer in a profitable two-local group", () => {
+    expect(plan("local first=f() tick() local second=g()").groups).toHaveLength(
+      1,
+    );
   });
 
   test("rejects hoisting when it would shadow an intervening reference", () => {
@@ -40,7 +42,8 @@ describe("non-adjacent local planner", () => {
       "local first=f() print(third) local second=g() local third=h() local fourth=i()",
     );
 
-    expect(result.groups).toEqual([]);
+    expect(result.groups).toHaveLength(1);
+    expect(result.groups[0].indexes).toEqual([0, 2]);
   });
 
   test("excludes a self-shadowing initializer without losing the next group", () => {
@@ -104,7 +107,6 @@ describe("non-adjacent local planner", () => {
     expect(result).toEqual({ changed: true, invalidatesResolve: true });
     expect(chunk.body.map((statement) => statement.type)).toEqual([
       "LocalStatement",
-      "AssignmentStatement",
       "CallStatement",
       "AssignmentStatement",
       "AssignmentStatement",
@@ -116,7 +118,7 @@ describe("non-adjacent local planner", () => {
       "second",
       "third",
     ]);
-    expect(declaration.init).toEqual([]);
+    expect(declaration.init).toHaveLength(1);
 
     const after = resolveScopes(chunk);
     const writes = chunk.body
@@ -129,7 +131,7 @@ describe("non-adjacent local planner", () => {
         (statement) =>
           after.symbolOf(statement.variables[0] as Parser.Identifier)?.name,
       );
-    expect(writes).toEqual(["first", "second", undefined, "third"]);
+    expect(writes).toEqual(["second", undefined, "third"]);
   });
 
   test("preserves statement comments at the replacement boundaries", () => {
@@ -161,10 +163,10 @@ local third=h() --# trailing`;
       metadata.beforeOf(chunk.body[0]).map((comment) => comment.raw),
     ).toEqual(["--# first"]);
     expect(
-      metadata.beforeOf(chunk.body[3]).map((comment) => comment.raw),
+      metadata.beforeOf(chunk.body[2]).map((comment) => comment.raw),
     ).toEqual(["--# second"]);
     expect(
-      metadata.trailingOf(chunk.body[5]).map((comment) => comment.raw),
+      metadata.trailingOf(chunk.body[4]).map((comment) => comment.raw),
     ).toEqual(["--# trailing"]);
   });
 });

--- a/test/optimizerDiagnostics.test.ts
+++ b/test/optimizerDiagnostics.test.ts
@@ -39,6 +39,19 @@ describe("optimization diagnostics", () => {
       diagnostics: collector,
       moduleName: "main",
     });
+    const rejectedChunk = Parser.parse("local u={} local bad=u[key]", {
+      luaVersion: "5.3",
+    });
+    const rejectedResolved = resolveScopes(rejectedChunk);
+    planTableReadMerges(
+      rejectedChunk,
+      analyzeTableEffects(rejectedChunk, rejectedResolved),
+      {
+        dirtyGranularity: "static-key",
+        diagnostics: collector,
+        moduleName: "main",
+      },
+    );
 
     const summary = summarizeOptimizationDiagnostics(collector.diagnostics);
     expect(summary.acceptedCandidates).toBeGreaterThanOrEqual(2);
@@ -104,7 +117,6 @@ describe("optimization diagnostics", () => {
         "dynamic-key",
         "call-escape",
         "control-flow-barrier",
-        "nonpositive-cost",
       ] as const
     ).forEach((reason) => {
       expect(reasons.has(reason)).toBe(true);


### PR DESCRIPTION
## 概要

依存付きの連続 local run を既存の #47 planner へ統合し、先頭 initializer を宣言に残したまま後続 initializer を元位置の代入へ分離します。

## オプション境界

- 純Luaで意味保存: `mergeLocals` / `--no-merge-locals`（opt-out）
- Stormworksで意味保存: `effectAwareLocalHoist` / `--no-effect-aware-local-hoist`（opt-out）
- 積極的なtable read merge: `aggressiveTableReadMerges` / `--aggressive-table-read-merges`（opt-in）

依存のない隣接runは従来のlocal mergeへ委譲し、require splice、字句束縛、Source Map metadata、Resolve再計算を維持します。

## 検証

- Windows側 `pnpm test`: 315 tests passed
- `pnpm exec eslint src test`
- `pnpm run format:check`
- `pnpm run verify:lua-budget`
- `pnpm run verify:effect-semantics`

候補間の最終Rename/Print transactional選択は既存の #65 が引き継ぎます。

Closes #42