### PR TITLE
feat: add interprocedural optimizer summaries

### DIFF
--- a/src/callGraph.ts
+++ b/src/callGraph.ts
@@ -1,0 +1,395 @@
+import Parser from "luaparse";
+import { OptimizerFacts } from "./optimizerFacts";
+import { ResolveResult, Symbol } from "./resolver";
+
+export interface Callable {
+  readonly id: number;
+  readonly declaration: Parser.FunctionDeclaration;
+  readonly symbol?: Symbol;
+  readonly parameters: readonly Symbol[];
+}
+
+export interface CallSite {
+  readonly id: number;
+  readonly call:
+    | Parser.CallExpression
+    | Parser.TableCallExpression
+    | Parser.StringCallExpression;
+  readonly owner: Parser.Statement;
+  readonly caller?: Callable;
+  readonly targets: ReadonlySet<Callable>;
+  readonly hasUnknownTarget: boolean;
+  /** Name eligible for an explicit runtime/module contract; never a local spelling. */
+  readonly externalTargetName?: string;
+}
+
+export interface CallGraphScc {
+  readonly id: number;
+  readonly functions: readonly Callable[];
+  readonly recursive: boolean;
+}
+
+export interface CallGraphAnalysis {
+  readonly generation: number;
+  readonly functions: readonly Callable[];
+  readonly calls: readonly CallSite[];
+  readonly sccs: readonly CallGraphScc[];
+  functionOf(declaration: Parser.FunctionDeclaration): Callable | undefined;
+  functionOfSymbol(symbol: Symbol): Callable | undefined;
+  callSiteOf(
+    call:
+      | Parser.CallExpression
+      | Parser.TableCallExpression
+      | Parser.StringCallExpression,
+  ): CallSite | undefined;
+}
+
+/**
+ * Resolve identityに基づくmodule-local call graphを構築する。
+ *
+ * 名前文字列やsource rangeからcall targetを推測しない。現行のoptimizer snapshotは
+ * module単位なので、global/module/external edgeはknown targetと偽らずunknown bitとして
+ * 保持する。local aliasは単一代入の関数値だけを有限固定点で解決する。
+ */
+export function analyzeCallGraph(
+  chunk: Parser.Chunk,
+  resolved: ResolveResult,
+  facts: OptimizerFacts,
+): CallGraphAnalysis {
+  const functions: Callable[] = [];
+  const functionByDeclaration = new WeakMap<
+    Parser.FunctionDeclaration,
+    Callable
+  >();
+  const functionBySymbol = new Map<Symbol, Callable>();
+  const ownerFunction = new WeakMap<Parser.Statement, Callable>();
+  const directFunctionBySymbol = new Map<Symbol, Callable>();
+  const aliasSources = new Map<Symbol, Symbol>();
+  const assignmentOriginBySymbol = new Map<Symbol, Parser.Identifier>();
+  const conflictingBindings = new Set<Symbol>();
+
+  const registerFunction = (
+    declaration: Parser.FunctionDeclaration,
+    symbol?: Symbol,
+  ): Callable => {
+    const existing = functionByDeclaration.get(declaration);
+    if (existing) return existing;
+    const scope = resolved.scopeOfFunction(declaration);
+    const callable: Callable = {
+      id: functions.length,
+      declaration,
+      ...(symbol ? { symbol } : {}),
+      parameters:
+        scope?.symbols.filter((candidate) => candidate.kind === "param") ?? [],
+    };
+    functions.push(callable);
+    functionByDeclaration.set(declaration, callable);
+    if (symbol) directFunctionBySymbol.set(symbol, callable);
+    return callable;
+  };
+
+  const visitExpression = (
+    expression: Parser.Expression,
+    current?: Callable,
+  ): void => {
+    switch (expression.type) {
+      case "FunctionDeclaration": {
+        const callable = registerFunction(expression);
+        visitBlock(expression.body, callable);
+        return;
+      }
+      case "CallExpression":
+        visitExpression(expression.base, current);
+        expression.arguments.forEach((argument) => {
+          visitExpression(argument, current);
+        });
+        return;
+      case "TableCallExpression":
+        visitExpression(expression.base, current);
+        visitExpression(expression.arguments, current);
+        return;
+      case "StringCallExpression":
+        visitExpression(expression.base, current);
+        visitExpression(expression.argument, current);
+        return;
+      case "BinaryExpression":
+      case "LogicalExpression":
+        visitExpression(expression.left, current);
+        visitExpression(expression.right, current);
+        return;
+      case "UnaryExpression":
+        visitExpression(expression.argument, current);
+        return;
+      case "MemberExpression":
+        visitExpression(expression.base, current);
+        return;
+      case "IndexExpression":
+        visitExpression(expression.base, current);
+        visitExpression(expression.index, current);
+        return;
+      case "TableConstructorExpression":
+        expression.fields.forEach((field) => {
+          if (field.type === "TableKey") visitExpression(field.key, current);
+          visitExpression(field.value, current);
+        });
+        return;
+      case "Identifier":
+      case "NilLiteral":
+      case "BooleanLiteral":
+      case "NumericLiteral":
+      case "StringLiteral":
+      case "VarargLiteral":
+        return;
+    }
+  };
+
+  const rememberBinding = (
+    target: Parser.Identifier,
+    expression: Parser.Expression | undefined,
+    assignment = false,
+  ): void => {
+    const symbol = resolved.symbolOf(target);
+    if (!symbol || !expression) return;
+    if (
+      directFunctionBySymbol.has(symbol) ||
+      aliasSources.has(symbol) ||
+      assignmentOriginBySymbol.has(symbol)
+    )
+      conflictingBindings.add(symbol);
+    if (assignment) assignmentOriginBySymbol.set(symbol, target);
+    if (expression.type === "FunctionDeclaration") {
+      directFunctionBySymbol.set(symbol, registerFunction(expression, symbol));
+      return;
+    }
+    if (expression.type !== "Identifier") return;
+    const source = resolved.symbolOf(expression);
+    if (source) aliasSources.set(symbol, source);
+  };
+
+  function visitStatement(
+    statement: Parser.Statement,
+    current?: Callable,
+  ): void {
+    if (current) ownerFunction.set(statement, current);
+    switch (statement.type) {
+      case "LocalStatement":
+        statement.variables.forEach((target, index) => {
+          rememberBinding(target, statement.init[index]);
+        });
+        statement.init.forEach((expression) => {
+          visitExpression(expression, current);
+        });
+        return;
+      case "AssignmentStatement":
+        statement.variables.forEach((target, index) => {
+          if (target.type === "Identifier")
+            rememberBinding(target, statement.init[index], true);
+        });
+        statement.init.forEach((expression) => {
+          visitExpression(expression, current);
+        });
+        return;
+      case "FunctionDeclaration": {
+        const symbol =
+          statement.identifier?.type === "Identifier"
+            ? resolved.symbolOf(statement.identifier)
+            : undefined;
+        const callable = registerFunction(statement, symbol);
+        visitBlock(statement.body, callable);
+        return;
+      }
+      case "CallStatement":
+        visitExpression(statement.expression, current);
+        return;
+      case "ReturnStatement":
+        statement.arguments.forEach((expression) => {
+          visitExpression(expression, current);
+        });
+        return;
+      case "DoStatement":
+        visitBlock(statement.body, current);
+        return;
+      case "WhileStatement":
+        visitExpression(statement.condition, current);
+        visitBlock(statement.body, current);
+        return;
+      case "RepeatStatement":
+        visitBlock(statement.body, current);
+        visitExpression(statement.condition, current);
+        return;
+      case "IfStatement":
+        statement.clauses.forEach((clause) => {
+          if (clause.type !== "ElseClause")
+            visitExpression(clause.condition, current);
+          visitBlock(clause.body, current);
+        });
+        return;
+      case "ForNumericStatement":
+        visitExpression(statement.start, current);
+        visitExpression(statement.end, current);
+        if (statement.step) visitExpression(statement.step, current);
+        visitBlock(statement.body, current);
+        return;
+      case "ForGenericStatement":
+        statement.iterators.forEach((expression) => {
+          visitExpression(expression, current);
+        });
+        visitBlock(statement.body, current);
+        return;
+      case "BreakStatement":
+      case "LabelStatement":
+      case "GotoStatement":
+        return;
+    }
+  }
+
+  function visitBlock(
+    body: readonly Parser.Statement[],
+    current?: Callable,
+  ): void {
+    body.forEach((statement) => {
+      visitStatement(statement, current);
+    });
+  }
+
+  visitBlock(chunk.body);
+
+  const isStableBinding = (symbol: Symbol): boolean => {
+    if (conflictingBindings.has(symbol)) return false;
+    const writes = facts
+      .operationsOfSymbol(symbol)
+      .filter((operation) => operation.kind === "write");
+    const assignmentOrigin = assignmentOriginBySymbol.get(symbol);
+    return assignmentOrigin
+      ? writes.length === 1 && writes[0].origin === assignmentOrigin
+      : writes.length === 0;
+  };
+  directFunctionBySymbol.forEach((callable, symbol) => {
+    if (isStableBinding(symbol)) functionBySymbol.set(symbol, callable);
+  });
+  let changed = true;
+  while (changed) {
+    changed = false;
+    aliasSources.forEach((source, target) => {
+      if (functionBySymbol.has(target)) return;
+      if (!isStableBinding(target) || !isStableBinding(source)) return;
+      const callable = functionBySymbol.get(source);
+      if (!callable) return;
+      functionBySymbol.set(target, callable);
+      changed = true;
+    });
+  }
+
+  const calls: CallSite[] = [];
+  const callSiteByExpression = new WeakMap<
+    | Parser.CallExpression
+    | Parser.TableCallExpression
+    | Parser.StringCallExpression,
+    CallSite
+  >();
+  facts.operations.forEach((operation) => {
+    if (operation.kind !== "call") return;
+    const targets = new Set<Callable>();
+    if (
+      operation.target.kind === "local" ||
+      operation.target.kind === "parameter" ||
+      operation.target.kind === "upvalue"
+    ) {
+      const target = functionBySymbol.get(operation.target.symbol);
+      if (target) targets.add(target);
+    }
+    const site: CallSite = {
+      id: calls.length,
+      call: operation.call,
+      owner: operation.owner,
+      caller: ownerFunction.get(operation.owner),
+      targets,
+      hasUnknownTarget: targets.size === 0,
+      ...(operation.call.base.type === "Identifier" &&
+      (operation.target.kind === "global" ||
+        operation.target.kind === "external")
+        ? { externalTargetName: operation.call.base.name }
+        : {}),
+    };
+    calls.push(site);
+    callSiteByExpression.set(operation.call, site);
+  });
+
+  const sccs = stronglyConnectedComponents(functions, calls);
+  return {
+    generation: facts.generation,
+    functions,
+    calls,
+    sccs,
+    functionOf: (declaration) => functionByDeclaration.get(declaration),
+    functionOfSymbol: (symbol) => functionBySymbol.get(symbol),
+    callSiteOf: (call) => callSiteByExpression.get(call),
+  };
+}
+
+function stronglyConnectedComponents(
+  functions: readonly Callable[],
+  calls: readonly CallSite[],
+): CallGraphScc[] {
+  const edges = new Map<Callable, Set<Callable>>(
+    functions.map((callable) => [callable, new Set()]),
+  );
+  calls.forEach((call) => {
+    if (!call.caller) return;
+    const outgoing = edges.get(call.caller);
+    call.targets.forEach((target) => outgoing?.add(target));
+  });
+  let nextIndex = 0;
+  const index = new Map<Callable, number>();
+  const lowlink = new Map<Callable, number>();
+  const stack: Callable[] = [];
+  const onStack = new Set<Callable>();
+  const components: Callable[][] = [];
+
+  const connect = (callable: Callable): void => {
+    index.set(callable, nextIndex);
+    lowlink.set(callable, nextIndex++);
+    stack.push(callable);
+    onStack.add(callable);
+    edges.get(callable)?.forEach((target) => {
+      if (!index.has(target)) {
+        connect(target);
+        const callableLowlink = lowlink.get(callable);
+        const targetLowlink = lowlink.get(target);
+        if (callableLowlink === undefined || targetLowlink === undefined)
+          throw new Error("Tarjan lowlink is missing");
+        lowlink.set(callable, Math.min(callableLowlink, targetLowlink));
+      } else if (onStack.has(target)) {
+        const callableLowlink = lowlink.get(callable);
+        const targetIndex = index.get(target);
+        if (callableLowlink === undefined || targetIndex === undefined)
+          throw new Error("Tarjan index is missing");
+        lowlink.set(callable, Math.min(callableLowlink, targetIndex));
+      }
+    });
+    if (lowlink.get(callable) !== index.get(callable)) return;
+    const component: Callable[] = [];
+    while (stack.length > 0) {
+      const member = stack.pop();
+      if (!member) throw new Error("Tarjan stack underflow");
+      onStack.delete(member);
+      component.push(member);
+      if (member === callable) break;
+    }
+    components.push(component.sort((left, right) => left.id - right.id));
+  };
+  functions.forEach((callable) => {
+    if (!index.has(callable)) connect(callable);
+  });
+  return components
+    .sort((left, right) => left[0].id - right[0].id)
+    .map((component, id) => ({
+      id,
+      functions: component,
+      recursive:
+        component.length > 1 ||
+        (component.length === 1 &&
+          edges.get(component[0])?.has(component[0])) ||
+        false,
+    }));
+}

--- a/src/interproceduralAnalysis.ts
+++ b/src/interproceduralAnalysis.ts
@@ -1,0 +1,1230 @@
+import Parser from "luaparse";
+import { CallGraphAnalysis, CallSite, Callable } from "./callGraph";
+import {
+  EMPTY_OPTIMIZER_TUPLE,
+  FiniteOptimizerTuple,
+  FiniteOptimizerValue,
+  finiteOptimizerTuple,
+  finiteOptimizerValue,
+  joinOptimizerTuples,
+  joinOptimizerValues,
+  OptimizerValueAtom,
+  unknownOptimizerValue,
+  valueAtOptimizerTupleSlot,
+} from "./optimizerValueDomain";
+import { ResolveResult, Symbol } from "./resolver";
+import { luaByteStringKey, luaByteStringOfText } from "./luaString";
+import { decodeLuaStringLiteral } from "./luaString";
+
+export type SummaryEffectAccess = "read" | "write";
+export interface ParameterFieldEffect {
+  readonly parameterIndex: number;
+  readonly access: SummaryEffectAccess;
+  readonly staticKey?: string;
+}
+
+export type ParameterEscapeReason =
+  "unknown-call" | "store" | "capture" | "return";
+
+export interface ParameterEscape {
+  readonly parameterIndex: number;
+  readonly reason: ParameterEscapeReason;
+}
+
+export interface ExternalSummaryEffect {
+  readonly access: "read" | "write" | "call";
+  readonly id: string;
+}
+
+export interface AllocationShapeField {
+  readonly staticKey: string;
+  readonly value: FiniteOptimizerValue;
+}
+
+export interface AllocationShape {
+  readonly templateId: string;
+  readonly fields: readonly AllocationShapeField[];
+  readonly unknownKeyWrite: boolean;
+}
+
+export interface FunctionSummary {
+  readonly callable: Callable;
+  readonly returns: FiniteOptimizerTuple;
+  readonly effects: readonly ParameterFieldEffect[];
+  readonly escapes: readonly ParameterEscape[];
+  readonly externalEffects: readonly ExternalSummaryEffect[];
+  readonly allocationShapes: readonly AllocationShape[];
+  readonly escapedAllocations: readonly string[];
+  readonly mayError: boolean;
+  readonly mayInvokeMetamethod: boolean;
+  readonly converged: boolean;
+}
+
+export interface InterproceduralDiagnostic {
+  readonly reason:
+    | "resolved-call-target"
+    | "unknown-call-target"
+    | "recursive-scc-converged"
+    | "parameter-field-effect"
+    | "parameter-escape"
+    | "external-contract-used";
+  readonly callId?: number;
+  readonly functionId?: number;
+  readonly sourceRange?: readonly [number, number];
+}
+
+export interface InstantiatedCallEffect {
+  readonly argumentIndex: number;
+  readonly access: SummaryEffectAccess;
+  readonly staticKey?: string;
+}
+
+export interface ExternalFunctionContract {
+  readonly name: string;
+  readonly provenance:
+    | { readonly kind: "runtime"; readonly profile: string }
+    | { readonly kind: "module-contract"; readonly moduleName: string };
+  readonly returns: FiniteOptimizerTuple;
+  readonly effects?: readonly InstantiatedCallEffect[];
+  readonly escapingArguments?: ReadonlySet<number>;
+  readonly mayError?: boolean;
+  readonly mayInvokeMetamethod?: boolean;
+}
+
+export interface InterproceduralOptions {
+  readonly externalContracts?: ReadonlyMap<string, ExternalFunctionContract>;
+}
+
+export interface InterproceduralAnalysis {
+  readonly generation: number;
+  readonly callGraph: CallGraphAnalysis;
+  readonly summaries: readonly FunctionSummary[];
+  readonly diagnostics: readonly InterproceduralDiagnostic[];
+  summaryOf(callable: Callable): FunctionSummary;
+  symbolicReturnsOf(call: CallSite): FiniteOptimizerTuple;
+  returnsOf(call: CallSite): FiniteOptimizerTuple;
+  effectsOf(call: CallSite): readonly InstantiatedCallEffect[];
+  escapesArgument(call: CallSite, argumentIndex: number): boolean;
+  shapeOfAllocation(allocationId: string): AllocationShape | undefined;
+}
+
+interface MutableSummary {
+  returns?: FiniteOptimizerTuple;
+  effects: ParameterFieldEffect[];
+  escapes: ParameterEscape[];
+  externalEffects: ExternalSummaryEffect[];
+  allocationShapes: AllocationShape[];
+  escapedAllocations: string[];
+  mayError: boolean;
+  mayInvokeMetamethod: boolean;
+}
+
+interface Evaluation {
+  readonly returns: FiniteOptimizerTuple[];
+  readonly effects: ParameterFieldEffect[];
+  readonly escapes: ParameterEscape[];
+  readonly externalEffects: ExternalSummaryEffect[];
+  readonly allocationShapes: AllocationShape[];
+  readonly escapedAllocations: string[];
+  readonly evaluatedCalls: WeakMap<Parser.Expression, EvaluatedCall>;
+  mayError: boolean;
+  mayInvokeMetamethod: boolean;
+}
+
+interface EvaluatedCall {
+  readonly actuals: readonly FiniteOptimizerValue[];
+  readonly returns: FiniteOptimizerTuple;
+}
+
+type Environment = Map<Symbol, FiniteOptimizerValue>;
+
+/**
+ * Function summaries are symbolic transfers over parameter atoms. Recursive SCCs start at
+ * lattice bottom and grow monotonically, so a recursive edge cannot erase a provable base case.
+ */
+export function analyzeInterprocedural(
+  chunk: Parser.Chunk,
+  resolved: ResolveResult,
+  callGraph: CallGraphAnalysis,
+  options: InterproceduralOptions = {},
+): InterproceduralAnalysis {
+  const mutable = new Map<Callable, MutableSummary>(
+    callGraph.functions.map((callable) => [
+      callable,
+      {
+        returns: undefined,
+        effects: [],
+        escapes: [],
+        externalEffects: [],
+        allocationShapes: [],
+        escapedAllocations: [],
+        mayError: false,
+        mayInvokeMetamethod: false,
+      },
+    ]),
+  );
+  const callByExpression = new WeakMap<Parser.Expression, CallSite>();
+  callGraph.calls.forEach((call) => callByExpression.set(call.call, call));
+  const allocationTemplate = new WeakMap<
+    Parser.TableConstructorExpression,
+    string
+  >();
+  let nextAllocation = 0;
+  const contractOf = (call: CallSite): ExternalFunctionContract | undefined =>
+    call.externalTargetName
+      ? options.externalContracts?.get(call.externalTargetName)
+      : undefined;
+  visitExpressions(chunk.body, (expression) => {
+    if (expression.type === "TableConstructorExpression")
+      allocationTemplate.set(expression, `table:${String(nextAllocation++)}`);
+  });
+
+  let changed = true;
+  let iterations = 0;
+  const iterationLimit = Math.max(1, callGraph.functions.length * 64);
+  while (changed) {
+    if (iterations++ > iterationLimit)
+      throw new Error("Interprocedural finite lattice failed to converge");
+    changed = false;
+    callGraph.functions.forEach((callable) => {
+      const evaluated = evaluateFunction(callable);
+      const previous = mutable.get(callable);
+      if (!previous) throw new Error("Function summary is missing");
+      const next: MutableSummary = {
+        returns: joinOptimizerTuples([
+          ...(previous.returns ? [previous.returns] : []),
+          ...evaluated.returns,
+        ]),
+        effects: uniqueEffects([...previous.effects, ...evaluated.effects]),
+        escapes: uniqueEscapes([...previous.escapes, ...evaluated.escapes]),
+        externalEffects: uniqueExternalEffects([
+          ...previous.externalEffects,
+          ...evaluated.externalEffects,
+        ]),
+        allocationShapes: joinAllocationShapes([
+          ...previous.allocationShapes,
+          ...evaluated.allocationShapes,
+        ]),
+        escapedAllocations: uniqueStrings([
+          ...previous.escapedAllocations,
+          ...evaluated.escapedAllocations,
+        ]),
+        mayError: previous.mayError || evaluated.mayError,
+        mayInvokeMetamethod:
+          previous.mayInvokeMetamethod || evaluated.mayInvokeMetamethod,
+      };
+      if (summaryKey(previous) !== summaryKey(next)) {
+        mutable.set(callable, next);
+        changed = true;
+      }
+    });
+  }
+
+  const summaries = callGraph.functions.map((callable) => {
+    const summary = mutable.get(callable);
+    if (!summary) throw new Error("Function summary is missing");
+    return {
+      callable,
+      ...summary,
+      returns: summary.returns ?? EMPTY_OPTIMIZER_TUPLE,
+      converged: true,
+    } satisfies FunctionSummary;
+  });
+  const summaryByCallable = new Map(
+    summaries.map((summary) => [summary.callable, summary]),
+  );
+  const diagnostics: InterproceduralDiagnostic[] = [
+    ...callGraph.calls.map((call) => ({
+      reason: contractOf(call)
+        ? ("external-contract-used" as const)
+        : call.hasUnknownTarget
+          ? ("unknown-call-target" as const)
+          : ("resolved-call-target" as const),
+      callId: call.id,
+      ...sourceRangeOf(call.call),
+    })),
+    ...callGraph.sccs
+      .filter((scc) => scc.recursive)
+      .map((scc) => ({
+        reason: "recursive-scc-converged" as const,
+        functionId: scc.functions[0].id,
+        ...sourceRangeOf(scc.functions[0].declaration),
+      })),
+    ...summaries.flatMap((summary) => [
+      ...summary.effects.map(() => ({
+        reason: "parameter-field-effect" as const,
+        functionId: summary.callable.id,
+        ...sourceRangeOf(summary.callable.declaration),
+      })),
+      ...summary.escapes.map(() => ({
+        reason: "parameter-escape" as const,
+        functionId: summary.callable.id,
+        ...sourceRangeOf(summary.callable.declaration),
+      })),
+    ]),
+  ];
+
+  const returnsOf = (call: CallSite): FiniteOptimizerTuple => {
+    const actuals = actualValues(call.call, new Map());
+    const instantiated = [...call.targets].map((target) =>
+      instantiateTuple(
+        safeSummaryReturns(summaryByCallable.get(target)),
+        actuals,
+        call,
+      ),
+    );
+    const contract = contractOf(call);
+    if (contract)
+      instantiated.push(instantiateTuple(contract.returns, actuals, call));
+    else if (call.hasUnknownTarget)
+      instantiated.push(
+        finiteOptimizerTuple([], {
+          kind: "unknown",
+          reasons: ["unknown-call-target"],
+        }),
+      );
+    return instantiated.length > 0
+      ? joinOptimizerTuples(instantiated)
+      : finiteOptimizerTuple([], {
+          kind: "unknown",
+          reasons: ["unresolved-call-target"],
+        });
+  };
+
+  const symbolicReturnsOf = (call: CallSite): FiniteOptimizerTuple => {
+    const tuples = [...call.targets].map((target) =>
+      safeSummaryReturns(summaryByCallable.get(target)),
+    );
+    const contract = contractOf(call);
+    if (contract) tuples.push(contract.returns);
+    else if (call.hasUnknownTarget)
+      tuples.push(
+        finiteOptimizerTuple([], {
+          kind: "unknown",
+          reasons: ["unknown-call-target"],
+        }),
+      );
+    return tuples.length > 0
+      ? joinOptimizerTuples(tuples)
+      : EMPTY_OPTIMIZER_TUPLE;
+  };
+
+  return {
+    generation: callGraph.generation,
+    callGraph,
+    summaries,
+    diagnostics,
+    summaryOf: (callable) => {
+      const summary = summaryByCallable.get(callable);
+      if (!summary) throw new Error("Function summary is missing");
+      return summary;
+    },
+    symbolicReturnsOf,
+    returnsOf,
+    effectsOf: (call) => {
+      const effects = [...call.targets].flatMap(
+        (target) => summaryByCallable.get(target)?.effects ?? [],
+      );
+      return uniqueInstantiatedEffects([
+        ...effects.map((effect) => ({
+          argumentIndex: effect.parameterIndex,
+          access: effect.access,
+          ...(effect.staticKey === undefined
+            ? {}
+            : { staticKey: effect.staticKey }),
+        })),
+        ...(contractOf(call)?.effects ?? []),
+      ]);
+    },
+    escapesArgument: (call, argumentIndex) =>
+      (call.hasUnknownTarget &&
+        (contractOf(call)
+          ? (contractOf(call)?.escapingArguments?.has(argumentIndex) ?? false)
+          : true)) ||
+      [...call.targets].some((target) =>
+        (summaryByCallable.get(target)?.escapes ?? []).some(
+          (escape) =>
+            escape.parameterIndex === argumentIndex &&
+            escape.reason !== "return",
+        ),
+      ),
+    shapeOfAllocation: (allocationId) => {
+      const templateId = allocationId.split("/").at(-1);
+      return summaries
+        .flatMap((summary) => summary.allocationShapes)
+        .find((shape) => shape.templateId === templateId);
+    },
+  };
+
+  function evaluateFunction(callable: Callable): Evaluation {
+    const evaluation: Evaluation = {
+      returns: [],
+      effects: [],
+      escapes: [],
+      externalEffects: [],
+      allocationShapes: [],
+      escapedAllocations: [],
+      evaluatedCalls: new WeakMap(),
+      mayError: false,
+      mayInvokeMetamethod: false,
+    };
+    const environment: Environment = new Map();
+    callable.parameters.forEach((parameter, index) =>
+      environment.set(
+        parameter,
+        finiteOptimizerValue([{ kind: "parameter", index }]),
+      ),
+    );
+    evaluateBlock(callable.declaration.body, environment, evaluation);
+    if (evaluation.returns.length === 0)
+      evaluation.returns.push(EMPTY_OPTIMIZER_TUPLE);
+    return evaluation;
+  }
+
+  function evaluateBlock(
+    body: readonly Parser.Statement[],
+    environment: Environment,
+    evaluation: Evaluation,
+  ): void {
+    body.forEach((statement) => {
+      switch (statement.type) {
+        case "LocalStatement":
+        case "AssignmentStatement": {
+          const values = valuesOfExpressionList(
+            statement.init,
+            environment,
+            evaluation,
+            statement.variables.length,
+          );
+          statement.variables.forEach((target, index) => {
+            if (target.type === "Identifier") {
+              const symbol = resolved.symbolOf(target);
+              if (
+                symbol &&
+                (statement.type === "LocalStatement" || environment.has(symbol))
+              )
+                environment.set(
+                  symbol,
+                  values[index] ?? finiteOptimizerValue([{ kind: "nil" }]),
+                );
+              else {
+                recordStoreEscapes(
+                  values[index] ?? finiteOptimizerValue([{ kind: "nil" }]),
+                  evaluation,
+                );
+                evaluation.externalEffects.push({
+                  access: "write",
+                  id: symbol ? `upvalue:${String(symbol.id)}` : target.name,
+                });
+              }
+            } else {
+              recordStoreEscapes(
+                values[index] ?? finiteOptimizerValue([{ kind: "nil" }]),
+                evaluation,
+              );
+              recordTableEffect(target, "write", environment, evaluation);
+            }
+          });
+          return;
+        }
+        case "ReturnStatement": {
+          const tuple = tupleOfExpressionList(
+            statement.arguments,
+            environment,
+            evaluation,
+          );
+          tuple.prefix.forEach((value) => {
+            parameterIndexes(value).forEach((parameterIndex) =>
+              evaluation.escapes.push({
+                parameterIndex,
+                reason: "return",
+              }),
+            );
+          });
+          evaluation.returns.push(tuple);
+          return;
+        }
+        case "CallStatement":
+          valueOf(statement.expression, environment, evaluation);
+          return;
+        case "IfStatement": {
+          const branches = statement.clauses.map((clause) => {
+            if (clause.type !== "ElseClause")
+              valueOf(clause.condition, environment, evaluation);
+            const branch = new Map(environment);
+            evaluateBlock(clause.body, branch, evaluation);
+            return branch;
+          });
+          if (!statement.clauses.some((clause) => clause.type === "ElseClause"))
+            branches.push(new Map(environment));
+          joinEnvironments(environment, branches);
+          return;
+        }
+        case "DoStatement": {
+          const block = new Map(environment);
+          evaluateBlock(statement.body, block, evaluation);
+          projectOuterEnvironment(environment, block);
+          return;
+        }
+        case "WhileStatement":
+        case "RepeatStatement": {
+          valueOf(statement.condition, environment, evaluation);
+          const loop = new Map(environment);
+          evaluateBlock(statement.body, loop, evaluation);
+          joinEnvironments(environment, [environment, loop]);
+          return;
+        }
+        case "ForNumericStatement": {
+          valueOf(statement.start, environment, evaluation);
+          valueOf(statement.end, environment, evaluation);
+          if (statement.step) valueOf(statement.step, environment, evaluation);
+          const loop = new Map(environment);
+          evaluateBlock(statement.body, loop, evaluation);
+          joinEnvironments(environment, [new Map(environment), loop]);
+          return;
+        }
+        case "ForGenericStatement": {
+          valuesOfExpressionList(
+            statement.iterators,
+            environment,
+            evaluation,
+            statement.variables.length,
+          );
+          const loop = new Map(environment);
+          evaluateBlock(statement.body, loop, evaluation);
+          joinEnvironments(environment, [new Map(environment), loop]);
+          return;
+        }
+        case "FunctionDeclaration":
+          recordCaptures(statement, environment, evaluation);
+          return;
+        case "BreakStatement":
+        case "LabelStatement":
+        case "GotoStatement":
+          return;
+      }
+    });
+  }
+
+  function valueOf(
+    expression: Parser.Expression | undefined,
+    environment: Environment,
+    evaluation: Evaluation,
+  ): FiniteOptimizerValue {
+    if (!expression) return finiteOptimizerValue([{ kind: "nil" }]);
+    switch (expression.type) {
+      case "NilLiteral":
+        return finiteOptimizerValue([{ kind: "nil" }]);
+      case "BooleanLiteral":
+        return finiteOptimizerValue([
+          { kind: "boolean", value: expression.value },
+        ]);
+      case "NumericLiteral":
+        return finiteOptimizerValue([{ kind: "number", raw: expression.raw }]);
+      case "StringLiteral":
+        return finiteOptimizerValue([
+          { kind: "string", value: expression.value },
+        ]);
+      case "Identifier": {
+        const symbol = resolved.symbolOf(expression);
+        const knownFunction = symbol
+          ? callGraph.functionOfSymbol(symbol)
+          : undefined;
+        if (knownFunction)
+          return finiteOptimizerValue([
+            { kind: "function", id: String(knownFunction.id) },
+          ]);
+        return symbol
+          ? (environment.get(symbol) ??
+              unknownOptimizerValue("symbol-value-unavailable"))
+          : (evaluation.externalEffects.push({
+              access: "read",
+              id: expression.name,
+            }),
+            finiteOptimizerValue(
+              [{ kind: "external", id: expression.name }],
+              ["external-value"],
+            ));
+      }
+      case "FunctionDeclaration": {
+        const target = callGraph.functionOf(expression);
+        recordCaptures(expression, environment, evaluation);
+        return target
+          ? finiteOptimizerValue([{ kind: "function", id: String(target.id) }])
+          : unknownOptimizerValue("function-unindexed");
+      }
+      case "TableConstructorExpression": {
+        const fields: AllocationShapeField[] = [];
+        let unknownKeyWrite = false;
+        let arrayIndex = 1;
+        expression.fields.forEach((field) => {
+          let staticKey: string | undefined;
+          if (field.type === "TableKeyString") {
+            staticKey = luaByteStringKey(luaByteStringOfText(field.key.name));
+          } else if (field.type === "TableKey") {
+            if (field.key.type === "StringLiteral") {
+              const decoded = decodeLuaStringLiteral(field.key);
+              if (decoded.ok) staticKey = luaByteStringKey(decoded.value);
+            }
+            valueOf(field.key, environment, evaluation);
+          } else {
+            staticKey = `number:${String(arrayIndex++)}`;
+          }
+          const fieldValue = valueOf(field.value, environment, evaluation);
+          if (staticKey === undefined) unknownKeyWrite = true;
+          else fields.push({ staticKey, value: fieldValue });
+        });
+        const templateId =
+          allocationTemplate.get(expression) ?? "table:unindexed";
+        evaluation.allocationShapes.push({
+          templateId,
+          fields,
+          unknownKeyWrite,
+        });
+        return finiteOptimizerValue([
+          {
+            kind: "allocation",
+            allocationKind: "table",
+            id: templateId,
+          },
+        ]);
+      }
+      case "MemberExpression":
+      case "IndexExpression":
+        recordTableEffect(expression, "read", environment, evaluation);
+        evaluation.mayError = true;
+        evaluation.mayInvokeMetamethod = true;
+        return unknownOptimizerValue("table-read-value");
+      case "CallExpression":
+      case "TableCallExpression":
+      case "StringCallExpression": {
+        const cached = evaluation.evaluatedCalls.get(expression);
+        if (cached) return valueAtOptimizerTupleSlot(cached.returns, 0);
+        const call = callByExpression.get(expression);
+        const actuals = actualValues(expression, environment, evaluation);
+        const contract = call ? contractOf(call) : undefined;
+        if (!call || (call.hasUnknownTarget && !contract)) {
+          evaluation.externalEffects.push({
+            access: "call",
+            id:
+              expression.base.type === "Identifier"
+                ? expression.base.name
+                : "unknown-call",
+          });
+          actuals.forEach((actual) => {
+            recordStoreEscapes(actual, evaluation, "unknown-call");
+            parameterIndexes(actual).forEach((parameterIndex) =>
+              evaluation.escapes.push({
+                parameterIndex,
+                reason: "unknown-call",
+              }),
+            );
+          });
+          evaluation.mayError = true;
+          evaluation.mayInvokeMetamethod = true;
+        }
+        if (!call) return unknownOptimizerValue("call-unindexed");
+        const tuples = [...call.targets].flatMap((target) => {
+          const targetSummary = mutable.get(target);
+          if (!targetSummary) throw new Error("Function summary is missing");
+          targetSummary.effects.forEach((effect) => {
+            parameterIndexes(actuals[effect.parameterIndex]).forEach(
+              (parameterIndex) =>
+                evaluation.effects.push({
+                  parameterIndex,
+                  access: effect.access,
+                  ...(effect.staticKey === undefined
+                    ? {}
+                    : { staticKey: effect.staticKey }),
+                }),
+            );
+          });
+          targetSummary.escapes.forEach((escape) => {
+            if (escape.reason !== "return")
+              allocationIds(actuals[escape.parameterIndex]).forEach((id) =>
+                evaluation.escapedAllocations.push(id),
+              );
+            parameterIndexes(actuals[escape.parameterIndex]).forEach(
+              (parameterIndex) =>
+                evaluation.escapes.push({
+                  parameterIndex,
+                  reason: escape.reason,
+                }),
+            );
+          });
+          evaluation.externalEffects.push(...targetSummary.externalEffects);
+          evaluation.mayError ||= targetSummary.mayError;
+          evaluation.mayInvokeMetamethod ||= targetSummary.mayInvokeMetamethod;
+          return targetSummary.returns
+            ? [
+                instantiateTuple(
+                  rejectEscapedAllocations(
+                    targetSummary.returns,
+                    targetSummary.escapedAllocations,
+                  ),
+                  actuals,
+                  call,
+                ),
+              ]
+            : [];
+        });
+        if (contract) {
+          evaluation.mayError ||= contract.mayError ?? false;
+          evaluation.mayInvokeMetamethod ||=
+            contract.mayInvokeMetamethod ?? false;
+          (contract.effects ?? []).forEach((effect) => {
+            parameterIndexes(actuals[effect.argumentIndex]).forEach(
+              (parameterIndex) =>
+                evaluation.effects.push({
+                  parameterIndex,
+                  access: effect.access,
+                  ...(effect.staticKey === undefined
+                    ? {}
+                    : { staticKey: effect.staticKey }),
+                }),
+            );
+          });
+          contract.escapingArguments?.forEach((argumentIndex) => {
+            const actual = actuals.at(argumentIndex);
+            if (actual) recordStoreEscapes(actual, evaluation, "unknown-call");
+            parameterIndexes(actual).forEach((parameterIndex) =>
+              evaluation.escapes.push({
+                parameterIndex,
+                reason: "unknown-call",
+              }),
+            );
+          });
+          tuples.push(instantiateTuple(contract.returns, actuals, call));
+        } else if (call.hasUnknownTarget)
+          tuples.push(
+            finiteOptimizerTuple([], {
+              kind: "unknown",
+              reasons: ["unknown-call-target"],
+            }),
+          );
+        const returns =
+          tuples.length > 0
+            ? joinOptimizerTuples(tuples)
+            : call.targets.size > 0
+              ? finiteOptimizerTuple([], {
+                  kind: "unknown",
+                  reasons: ["recursive-summary-bottom"],
+                })
+              : EMPTY_OPTIMIZER_TUPLE;
+        evaluation.evaluatedCalls.set(expression, { actuals, returns });
+        return valueAtOptimizerTupleSlot(returns, 0);
+      }
+      case "BinaryExpression":
+      case "LogicalExpression":
+        valueOf(expression.left, environment, evaluation);
+        valueOf(expression.right, environment, evaluation);
+        evaluation.mayError = true;
+        evaluation.mayInvokeMetamethod = true;
+        return unknownOptimizerValue("computed-expression");
+      case "UnaryExpression":
+        valueOf(expression.argument, environment, evaluation);
+        evaluation.mayError = true;
+        evaluation.mayInvokeMetamethod = true;
+        return unknownOptimizerValue("computed-expression");
+      case "VarargLiteral":
+        return unknownOptimizerValue("vararg-value");
+    }
+  }
+
+  function actualValues(
+    call:
+      | Parser.CallExpression
+      | Parser.TableCallExpression
+      | Parser.StringCallExpression,
+    environment: Environment,
+    evaluation?: Evaluation,
+  ): FiniteOptimizerValue[] {
+    const sink =
+      evaluation ??
+      ({
+        returns: [],
+        effects: [],
+        escapes: [],
+        externalEffects: [],
+        allocationShapes: [],
+        escapedAllocations: [],
+        evaluatedCalls: new WeakMap(),
+        mayError: false,
+        mayInvokeMetamethod: false,
+      } satisfies Evaluation);
+    const explicit =
+      call.type === "CallExpression"
+        ? call.arguments
+        : [
+            call.type === "TableCallExpression"
+              ? call.arguments
+              : call.argument,
+          ];
+    const receiver =
+      call.base.type === "MemberExpression" && call.base.indexer === ":"
+        ? [call.base.base]
+        : [];
+    return valuesOfExpressionList(
+      [...receiver, ...explicit],
+      environment,
+      sink,
+      Number.POSITIVE_INFINITY,
+    );
+  }
+
+  function valuesOfExpressionList(
+    expressions: readonly Parser.Expression[],
+    environment: Environment,
+    evaluation: Evaluation,
+    count: number,
+  ): FiniteOptimizerValue[] {
+    const tuple = tupleOfExpressionList(expressions, environment, evaluation);
+    const available = Number.isFinite(count)
+      ? count
+      : Math.max(expressions.length, tuple.prefix.length);
+    return Array.from({ length: available }, (_, index) =>
+      valueAtOptimizerTupleSlot(tuple, index),
+    );
+  }
+
+  function tupleOfExpressionList(
+    expressions: readonly Parser.Expression[],
+    environment: Environment,
+    evaluation: Evaluation,
+  ): FiniteOptimizerTuple {
+    if (expressions.length === 0) return EMPTY_OPTIMIZER_TUPLE;
+    const leading = expressions
+      .slice(0, -1)
+      .map((expression) => valueOf(expression, environment, evaluation));
+    const last = expressions.at(-1);
+    if (!last) return finiteOptimizerTuple(leading);
+    const single = valueOf(last, environment, evaluation);
+    const tail = tupleOfLastExpression(last, environment, evaluation, single);
+    return finiteOptimizerTuple([...leading, ...tail.prefix], tail.tail);
+  }
+
+  function tupleOfLastExpression(
+    expression: Parser.Expression,
+    environment: Environment,
+    evaluation: Evaluation,
+    singleValue: FiniteOptimizerValue,
+  ): FiniteOptimizerTuple {
+    if (expression.type === "VarargLiteral") {
+      return finiteOptimizerTuple([], {
+        kind: "unknown",
+        reasons: ["vararg-tail"],
+      });
+    }
+    if (
+      expression.type !== "CallExpression" &&
+      expression.type !== "TableCallExpression" &&
+      expression.type !== "StringCallExpression"
+    )
+      return finiteOptimizerTuple([singleValue]);
+    const call = callByExpression.get(expression);
+    if (!call)
+      return finiteOptimizerTuple([], {
+        kind: "unknown",
+        reasons: ["call-unindexed"],
+      });
+    valueOf(expression, environment, evaluation);
+    const actuals = evaluation.evaluatedCalls.get(expression)?.actuals;
+    if (!actuals)
+      return finiteOptimizerTuple([], {
+        kind: "unknown",
+        reasons: ["call-evaluation-missing"],
+      });
+    const tuples = [...call.targets].flatMap((target) => {
+      const returns = mutable.get(target)?.returns;
+      return returns
+        ? [
+            instantiateTuple(
+              rejectEscapedAllocations(
+                returns,
+                mutable.get(target)?.escapedAllocations ?? [],
+              ),
+              actuals,
+              call,
+            ),
+          ]
+        : [];
+    });
+    const contract = contractOf(call);
+    if (contract)
+      tuples.push(instantiateTuple(contract.returns, actuals, call));
+    else if (call.hasUnknownTarget)
+      tuples.push(
+        finiteOptimizerTuple([], {
+          kind: "unknown",
+          reasons: ["unknown-call-target"],
+        }),
+      );
+    return tuples.length > 0
+      ? joinOptimizerTuples(tuples)
+      : call.targets.size > 0
+        ? finiteOptimizerTuple([], {
+            kind: "unknown",
+            reasons: ["recursive-summary-bottom"],
+          })
+        : EMPTY_OPTIMIZER_TUPLE;
+  }
+
+  function recordTableEffect(
+    expression: Parser.MemberExpression | Parser.IndexExpression,
+    access: SummaryEffectAccess,
+    environment: Environment,
+    evaluation: Evaluation,
+  ): void {
+    const base = valueOf(expression.base, environment, evaluation);
+    const staticKey =
+      expression.type === "MemberExpression"
+        ? luaByteStringKey(luaByteStringOfText(expression.identifier.name))
+        : expression.index.type === "StringLiteral"
+          ? (() => {
+              const decoded = decodeLuaStringLiteral(expression.index);
+              return decoded.ok ? luaByteStringKey(decoded.value) : undefined;
+            })()
+          : undefined;
+    parameterIndexes(base).forEach((parameterIndex) =>
+      evaluation.effects.push({
+        parameterIndex,
+        access,
+        ...(staticKey === undefined ? {} : { staticKey }),
+      }),
+    );
+    if (expression.type === "IndexExpression")
+      valueOf(expression.index, environment, evaluation);
+  }
+
+  function recordCaptures(
+    declaration: Parser.FunctionDeclaration,
+    environment: Environment,
+    evaluation: Evaluation,
+  ): void {
+    visitExpressions(declaration.body, (expression) => {
+      if (expression.type !== "Identifier") return;
+      const symbol = resolved.symbolOf(expression);
+      const value = symbol ? environment.get(symbol) : undefined;
+      parameterIndexes(value).forEach((parameterIndex) =>
+        evaluation.escapes.push({ parameterIndex, reason: "capture" }),
+      );
+    });
+  }
+}
+
+function instantiateTuple(
+  tuple: FiniteOptimizerTuple,
+  actuals: readonly FiniteOptimizerValue[],
+  call: CallSite,
+): FiniteOptimizerTuple {
+  const instantiate = (value: FiniteOptimizerValue): FiniteOptimizerValue =>
+    joinOptimizerValues([
+      finiteOptimizerValue(
+        value.atoms.flatMap((atom): OptimizerValueAtom[] => {
+          if (atom.kind === "parameter")
+            return [...(actuals[atom.index]?.atoms ?? [])];
+          if (atom.kind === "allocation")
+            return [{ ...atom, id: `call:${String(call.id)}/${atom.id}` }];
+          return [atom];
+        }),
+        value.unknownReasons,
+      ),
+      ...value.atoms
+        .filter(
+          (atom): atom is Extract<OptimizerValueAtom, { kind: "parameter" }> =>
+            atom.kind === "parameter",
+        )
+        .map(
+          (atom) =>
+            actuals[atom.index] ?? unknownOptimizerValue("missing-argument"),
+        ),
+    ]);
+  return finiteOptimizerTuple(
+    tuple.prefix.map(instantiate),
+    tuple.tail.kind === "vararg"
+      ? { kind: "vararg", value: instantiate(tuple.tail.value) }
+      : tuple.tail,
+  );
+}
+
+function safeSummaryReturns(
+  summary: FunctionSummary | undefined,
+): FiniteOptimizerTuple {
+  return summary
+    ? rejectEscapedAllocations(summary.returns, summary.escapedAllocations)
+    : EMPTY_OPTIMIZER_TUPLE;
+}
+
+function rejectEscapedAllocations(
+  tuple: FiniteOptimizerTuple,
+  escapedAllocations: readonly string[],
+): FiniteOptimizerTuple {
+  if (escapedAllocations.length === 0) return tuple;
+  const escaped = new Set(escapedAllocations);
+  const reject = (value: FiniteOptimizerValue): FiniteOptimizerValue => {
+    const retained = value.atoms.filter(
+      (atom) => atom.kind !== "allocation" || !escaped.has(atom.id),
+    );
+    return finiteOptimizerValue(
+      retained,
+      retained.length === value.atoms.length
+        ? value.unknownReasons
+        : [...value.unknownReasons, "escaped-allocation"],
+    );
+  };
+  return finiteOptimizerTuple(
+    tuple.prefix.map(reject),
+    tuple.tail.kind === "vararg"
+      ? { kind: "vararg", value: reject(tuple.tail.value) }
+      : tuple.tail,
+  );
+}
+
+function parameterIndexes(value: FiniteOptimizerValue | undefined): number[] {
+  return value
+    ? value.atoms.flatMap((atom) =>
+        atom.kind === "parameter" ? [atom.index] : [],
+      )
+    : [];
+}
+
+function recordStoreEscapes(
+  value: FiniteOptimizerValue,
+  evaluation: Evaluation,
+  parameterReason: ParameterEscapeReason = "store",
+): void {
+  parameterIndexes(value).forEach((parameterIndex) =>
+    evaluation.escapes.push({ parameterIndex, reason: parameterReason }),
+  );
+  allocationIds(value).forEach((id) => evaluation.escapedAllocations.push(id));
+}
+
+function allocationIds(value: FiniteOptimizerValue | undefined): string[] {
+  return value
+    ? value.atoms.flatMap((atom) =>
+        atom.kind === "allocation" ? [atom.id] : [],
+      )
+    : [];
+}
+
+function projectOuterEnvironment(
+  target: Environment,
+  source: Environment,
+): void {
+  [...target.keys()].forEach((symbol) => {
+    const value = source.get(symbol);
+    if (value) target.set(symbol, value);
+  });
+}
+
+function uniqueStrings(values: readonly string[]): string[] {
+  return [...new Set(values)].sort();
+}
+
+function joinEnvironments(
+  target: Environment,
+  branches: readonly Environment[],
+): void {
+  const symbols = new Set(branches.flatMap((branch) => [...branch.keys()]));
+  symbols.forEach((symbol) =>
+    target.set(
+      symbol,
+      joinOptimizerValues(
+        branches.map(
+          (branch) =>
+            branch.get(symbol) ?? unknownOptimizerValue("branch-local"),
+        ),
+      ),
+    ),
+  );
+}
+
+function uniqueEffects(
+  effects: readonly ParameterFieldEffect[],
+): ParameterFieldEffect[] {
+  const byKey = new Map<string, ParameterFieldEffect>();
+  effects.forEach((effect) =>
+    byKey.set(
+      `${String(effect.parameterIndex)}:${effect.access}:${effect.staticKey ?? "*"}`,
+      effect,
+    ),
+  );
+  return [...byKey.entries()]
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([, effect]) => effect);
+}
+
+function uniqueInstantiatedEffects(
+  effects: readonly InstantiatedCallEffect[],
+): InstantiatedCallEffect[] {
+  const byKey = new Map<string, InstantiatedCallEffect>();
+  effects.forEach((effect) =>
+    byKey.set(
+      `${String(effect.argumentIndex)}:${effect.access}:${effect.staticKey ?? "*"}`,
+      effect,
+    ),
+  );
+  return [...byKey.entries()]
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([, effect]) => effect);
+}
+
+function uniqueEscapes(escapes: readonly ParameterEscape[]): ParameterEscape[] {
+  const byKey = new Map<string, ParameterEscape>();
+  escapes.forEach((escape) =>
+    byKey.set(`${String(escape.parameterIndex)}:${escape.reason}`, escape),
+  );
+  return [...byKey.entries()]
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([, escape]) => escape);
+}
+
+function uniqueExternalEffects(
+  effects: readonly ExternalSummaryEffect[],
+): ExternalSummaryEffect[] {
+  const byKey = new Map<string, ExternalSummaryEffect>();
+  effects.forEach((effect) =>
+    byKey.set(`${effect.access}:${effect.id}`, effect),
+  );
+  return [...byKey.entries()]
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([, effect]) => effect);
+}
+
+function joinAllocationShapes(
+  shapes: readonly AllocationShape[],
+): AllocationShape[] {
+  const byTemplate = new Map<string, AllocationShape[]>();
+  shapes.forEach((shape) => {
+    const entries = byTemplate.get(shape.templateId) ?? [];
+    entries.push(shape);
+    byTemplate.set(shape.templateId, entries);
+  });
+  return [...byTemplate.entries()]
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([templateId, alternatives]) => {
+      const keys = new Set(
+        alternatives.flatMap((shape) =>
+          shape.fields.map((field) => field.staticKey),
+        ),
+      );
+      const fields = [...keys].sort().flatMap((staticKey) => {
+        const values = alternatives.flatMap((shape) => {
+          const field = shape.fields.find(
+            (candidate) => candidate.staticKey === staticKey,
+          );
+          return field ? [field.value] : [];
+        });
+        return values.length === alternatives.length
+          ? [{ staticKey, value: joinOptimizerValues(values) }]
+          : [];
+      });
+      return {
+        templateId,
+        fields,
+        unknownKeyWrite: alternatives.some((shape) => shape.unknownKeyWrite),
+      };
+    });
+}
+
+function summaryKey(summary: MutableSummary): string {
+  return JSON.stringify(summary);
+}
+
+function sourceRangeOf(node: Parser.Node): {
+  readonly sourceRange?: readonly [number, number];
+} {
+  const range = (node as { range?: [number, number] }).range;
+  return range ? { sourceRange: range } : {};
+}
+
+function visitExpressions(
+  body: readonly Parser.Statement[],
+  visit: (expression: Parser.Expression) => void,
+): void {
+  const expression = (value: Parser.Expression): void => {
+    visit(value);
+    switch (value.type) {
+      case "FunctionDeclaration":
+        visitExpressions(value.body, visit);
+        return;
+      case "CallExpression":
+        expression(value.base);
+        value.arguments.forEach(expression);
+        return;
+      case "TableCallExpression":
+        expression(value.base);
+        expression(value.arguments);
+        return;
+      case "StringCallExpression":
+        expression(value.base);
+        expression(value.argument);
+        return;
+      case "BinaryExpression":
+      case "LogicalExpression":
+        expression(value.left);
+        expression(value.right);
+        return;
+      case "UnaryExpression":
+        expression(value.argument);
+        return;
+      case "MemberExpression":
+        expression(value.base);
+        return;
+      case "IndexExpression":
+        expression(value.base);
+        expression(value.index);
+        return;
+      case "TableConstructorExpression":
+        value.fields.forEach((field) => {
+          if (field.type === "TableKey") expression(field.key);
+          expression(field.value);
+        });
+        return;
+      default:
+        return;
+    }
+  };
+  body.forEach((statement) => {
+    switch (statement.type) {
+      case "LocalStatement":
+      case "AssignmentStatement":
+        statement.init.forEach(expression);
+        return;
+      case "CallStatement":
+        expression(statement.expression);
+        return;
+      case "ReturnStatement":
+        statement.arguments.forEach(expression);
+        return;
+      case "FunctionDeclaration":
+        visit(statement);
+        visitExpressions(statement.body, visit);
+        return;
+      case "DoStatement":
+      case "WhileStatement":
+      case "RepeatStatement":
+        if ("condition" in statement) expression(statement.condition);
+        visitExpressions(statement.body, visit);
+        return;
+      case "IfStatement":
+        statement.clauses.forEach((clause) => {
+          if (clause.type !== "ElseClause") expression(clause.condition);
+          visitExpressions(clause.body, visit);
+        });
+        return;
+      case "ForNumericStatement":
+        expression(statement.start);
+        expression(statement.end);
+        if (statement.step) expression(statement.step);
+        visitExpressions(statement.body, visit);
+        return;
+      case "ForGenericStatement":
+        statement.iterators.forEach(expression);
+        visitExpressions(statement.body, visit);
+        return;
+      default:
+        return;
+    }
+  });
+}

--- a/src/interproceduralConstants.ts
+++ b/src/interproceduralConstants.ts
@@ -1,0 +1,142 @@
+import Parser from "luaparse";
+import { InterproceduralAnalysis } from "./interproceduralAnalysis";
+import { OptimizerValueAtom } from "./optimizerValueDomain";
+
+/**
+ * Replace a direct, pure, single-return call with its proven scalar result.
+ *
+ * This is intentionally narrower than #76 inlining. It accepts only a one-statement return body,
+ * no actual arguments, a non-recursive target, and a literal no longer than the shortest possible
+ * renamed `a()` call. Thus evaluation can be removed without alpha conversion and without relying
+ * on later function DCE to make the local rewrite profitable.
+ */
+export function propagateInterproceduralConstants(
+  chunk: Parser.Chunk,
+  analysis: InterproceduralAnalysis,
+): boolean {
+  let changed = false;
+
+  const replacementOf = (
+    expression: Parser.Expression,
+  ): Parser.Expression | undefined => {
+    if (
+      expression.type !== "CallExpression" ||
+      expression.arguments.length !== 0 ||
+      expression.base.type !== "Identifier"
+    )
+      return undefined;
+    const call = analysis.callGraph.callSiteOf(expression);
+    if (!call || call.hasUnknownTarget || call.targets.size !== 1)
+      return undefined;
+    const target = [...call.targets][0];
+    if (
+      analysis.callGraph.sccs.some(
+        (scc) => scc.recursive && scc.functions.includes(target),
+      ) ||
+      target.declaration.body.length !== 1 ||
+      target.declaration.body[0].type !== "ReturnStatement"
+    )
+      return undefined;
+    const summary = analysis.summaryOf(target);
+    if (
+      summary.effects.length > 0 ||
+      summary.escapes.length > 0 ||
+      summary.externalEffects.length > 0 ||
+      summary.mayError ||
+      summary.mayInvokeMetamethod ||
+      summary.returns.prefix.length !== 1 ||
+      summary.returns.tail.kind !== "none"
+    )
+      return undefined;
+    const value = summary.returns.prefix[0];
+    if (value.unknownReasons.length > 0 || value.atoms.length !== 1)
+      return undefined;
+    const replacement = literalOf(value.atoms[0], expression);
+    if (!replacement || printedLength(replacement) > 3) return undefined;
+    return replacement;
+  };
+
+  const rewriteBlock = (body: Parser.Statement[]): void => {
+    body.forEach((statement) => {
+      if (
+        (statement.type === "LocalStatement" ||
+          statement.type === "AssignmentStatement") &&
+        statement.variables.length === 1 &&
+        statement.init.length === 1
+      ) {
+        const replacement = replacementOf(statement.init[0]);
+        if (replacement) {
+          statement.init[0] = replacement;
+          changed = true;
+        }
+      }
+      switch (statement.type) {
+        case "DoStatement":
+        case "WhileStatement":
+        case "RepeatStatement":
+        case "FunctionDeclaration":
+        case "ForNumericStatement":
+        case "ForGenericStatement":
+          rewriteBlock(statement.body);
+          return;
+        case "IfStatement":
+          statement.clauses.forEach((clause) => {
+            rewriteBlock(clause.body);
+          });
+          return;
+        default:
+          return;
+      }
+    });
+  };
+  rewriteBlock(chunk.body);
+  return changed;
+}
+
+function literalOf(
+  atom: OptimizerValueAtom,
+  source: Parser.Expression,
+): Parser.Expression | undefined {
+  const metadata = {
+    ...(source.loc ? { loc: source.loc } : {}),
+    ...("range" in source
+      ? { range: (source as { range?: [number, number] }).range }
+      : {}),
+  };
+  switch (atom.kind) {
+    case "nil":
+      return { type: "NilLiteral", value: null, raw: "nil", ...metadata };
+    case "boolean":
+      return {
+        type: "BooleanLiteral",
+        value: atom.value,
+        raw: atom.value ? "true" : "false",
+        ...metadata,
+      };
+    case "number":
+      return {
+        type: "NumericLiteral",
+        value: Number(atom.raw),
+        raw: atom.raw,
+        ...metadata,
+      };
+    case "string": {
+      const raw = JSON.stringify(atom.value);
+      return { type: "StringLiteral", value: atom.value, raw, ...metadata };
+    }
+    default:
+      return undefined;
+  }
+}
+
+function printedLength(expression: Parser.Expression): number {
+  switch (expression.type) {
+    case "NilLiteral":
+    case "BooleanLiteral":
+    case "NumericLiteral":
+    case "StringLiteral":
+      return expression.raw.length;
+    default:
+      return Infinity;
+  }
+}

--- a/src/minifier.ts
+++ b/src/minifier.ts
@@ -31,7 +31,12 @@ import {
   analyzeOptimizerFactsAtGeneration,
   OPTIMIZER_FACTS_CACHE_KEY,
 } from "./optimizerFacts";
-import { analyzeOptimizer } from "./optimizerAnalysis";
+import {
+  analyzeOptimizer,
+  analyzeOptimizerAtGeneration,
+  OPTIMIZER_ANALYSIS_CACHE_KEY,
+} from "./optimizerAnalysis";
+import { propagateInterproceduralConstants } from "./interproceduralConstants";
 
 export type { RuntimeProfile } from "./runtimeEnvironment";
 
@@ -413,10 +418,9 @@ export class Minifier {
       }
       resolved = passes.resolved;
       const runtime = runtimeEnvironmentOf(this.mode.runtimeProfile ?? "lua53");
-      const optimizerAnalysisKey = {};
       const optimizerAnalysis = () =>
         passes.analysis(
-          optimizerAnalysisKey,
+          OPTIMIZER_ANALYSIS_CACHE_KEY,
           (chunk, currentResolve, generation) =>
             analyzeOptimizer(chunk, currentResolve, {
               generation,
@@ -464,6 +468,20 @@ export class Minifier {
               );
         passes.run("statement-scheduler", (currentResolve) => {
           const analysis = optimizerAnalysis();
+          analysis.interprocedural.diagnostics.forEach((diagnostic) =>
+            this.diagnosticCollector?.record({
+              pass: "interprocedural-summary",
+              moduleName,
+              runtimeProfile: runtime.profile,
+              decision:
+                diagnostic.reason === "unknown-call-target"
+                  ? "rejected"
+                  : "accepted",
+              reason: diagnostic.reason,
+              candidateSize: 1,
+              sourceRange: diagnostic.sourceRange,
+            }),
+          );
           const metadata = this.getSourceMetadata(moduleName);
           const canMoveAnnotatedStatement = (
             statement: Parser.LocalStatement,
@@ -623,6 +641,17 @@ export class Minifier {
       const resolved = this.moduleResolve.get(moduleName);
       if (!ast || !resolved) throw new Error(moduleName + " is not found");
       const passes = new PassOrchestrator(ast, resolved);
+      passes.run("interprocedural-constants", () => {
+        const analysis = passes.analysis(
+          OPTIMIZER_ANALYSIS_CACHE_KEY,
+          analyzeOptimizerAtGeneration,
+        );
+        const changed = propagateInterproceduralConstants(
+          ast,
+          analysis.interprocedural,
+        );
+        return { changed, invalidatesResolve: changed };
+      });
       passes.runUntilStable("fold-constants", (currentResolve) => {
         const facts = passes.analysis(
           OPTIMIZER_FACTS_CACHE_KEY,

--- a/src/optimizerAnalysis.ts
+++ b/src/optimizerAnalysis.ts
@@ -11,10 +11,22 @@ import {
   analyzeStatementDataflow,
   StatementDataflowAnalysis,
 } from "./statementDataflow";
+import { analyzeCallGraph, CallGraphAnalysis } from "./callGraph";
+import {
+  analyzeInterprocedural,
+  InterproceduralAnalysis,
+  InterproceduralOptions,
+} from "./interproceduralAnalysis";
+
+export interface OptimizerAnalysisOptions extends OptimizerFactOptions {
+  readonly interprocedural?: InterproceduralOptions;
+}
 
 export interface OptimizerAnalysis {
   readonly generation: number;
   readonly facts: OptimizerFacts;
+  readonly callGraph: CallGraphAnalysis;
+  readonly interprocedural: InterproceduralAnalysis;
   readonly valueFlow: ValueFlowAnalysis;
   readonly tableEffects: TableEffectAnalysis;
   readonly statementDataflow: StatementDataflowAnalysis;
@@ -32,17 +44,44 @@ export const OPTIMIZER_ANALYSIS_CACHE_KEY = {};
 export function analyzeOptimizer(
   chunk: Parser.Chunk,
   resolved: ResolveResult,
-  options: OptimizerFactOptions = {},
+  options: OptimizerAnalysisOptions = {},
 ): OptimizerAnalysis {
   const generation = options.generation ?? 0;
   const facts = analyzeOptimizerFacts(chunk, resolved, {
     ...options,
     generation,
   });
-  const valueFlow = analyzeValueFlow(chunk, resolved, facts, generation);
-  const tableEffects = analyzeTableEffects(chunk, resolved, valueFlow, facts);
+  const callGraph = analyzeCallGraph(chunk, resolved, facts);
+  const interprocedural = analyzeInterprocedural(
+    chunk,
+    resolved,
+    callGraph,
+    options.interprocedural,
+  );
+  const valueFlow = analyzeValueFlow(
+    chunk,
+    resolved,
+    facts,
+    generation,
+    interprocedural,
+  );
+  const tableEffects = analyzeTableEffects(
+    chunk,
+    resolved,
+    valueFlow,
+    facts,
+    interprocedural,
+  );
   const statementDataflow = analyzeStatementDataflow(chunk, facts, valueFlow);
-  return { generation, facts, valueFlow, tableEffects, statementDataflow };
+  return {
+    generation,
+    facts,
+    callGraph,
+    interprocedural,
+    valueFlow,
+    tableEffects,
+    statementDataflow,
+  };
 }
 
 export function analyzeOptimizerAtGeneration(

--- a/src/optimizerDiagnostics.ts
+++ b/src/optimizerDiagnostics.ts
@@ -35,7 +35,13 @@ export type OptimizationDiagnosticReason =
   | "dependency-metamethod-order"
   | "dependency-allocation-order"
   | "dependency-control-order"
-  | "dependency-scope-order";
+  | "dependency-scope-order"
+  | "resolved-call-target"
+  | "unknown-call-target"
+  | "recursive-scc-converged"
+  | "parameter-field-effect"
+  | "parameter-escape"
+  | "external-contract-used";
 
 export interface OptimizationDiagnostic {
   readonly pass: string;

--- a/src/optimizerValueDomain.ts
+++ b/src/optimizerValueDomain.ts
@@ -1,0 +1,292 @@
+export type OptimizerValueAtom =
+  | { readonly kind: "nil" }
+  | { readonly kind: "boolean"; readonly value: boolean }
+  | { readonly kind: "number"; readonly raw: string }
+  | { readonly kind: "string"; readonly value: string }
+  | { readonly kind: "function"; readonly id: string }
+  | {
+      readonly kind: "allocation";
+      readonly allocationKind: "table" | "function";
+      readonly id: string;
+    }
+  | { readonly kind: "parameter"; readonly index: number }
+  | { readonly kind: "external"; readonly id: string };
+
+/**
+ * A value keeps proven alternatives independently from incomplete knowledge.
+ * For example, `{42} + unknown` is more useful than top while remaining sound.
+ */
+export interface FiniteOptimizerValue {
+  readonly atoms: readonly OptimizerValueAtom[];
+  readonly unknownReasons: readonly string[];
+}
+
+export type OptimizerTupleTail =
+  | { readonly kind: "none" }
+  | { readonly kind: "vararg"; readonly value: FiniteOptimizerValue }
+  | { readonly kind: "unknown"; readonly reasons: readonly string[] };
+
+export interface FiniteOptimizerTuple {
+  readonly prefix: readonly FiniteOptimizerValue[];
+  readonly tail: OptimizerTupleTail;
+}
+
+export interface OptimizerValueDomainLimits {
+  readonly maxAtoms: number;
+  readonly maxUnknownReasons: number;
+  readonly maxTuplePrefix: number;
+}
+
+export const DEFAULT_OPTIMIZER_VALUE_DOMAIN_LIMITS: OptimizerValueDomainLimits =
+  Object.freeze({
+    maxAtoms: 16,
+    maxUnknownReasons: 8,
+    maxTuplePrefix: 16,
+  });
+
+export const NIL_ATOM: OptimizerValueAtom = Object.freeze({ kind: "nil" });
+
+export const EMPTY_OPTIMIZER_VALUE: FiniteOptimizerValue = Object.freeze({
+  atoms: Object.freeze([]),
+  unknownReasons: Object.freeze([]),
+});
+
+export const EMPTY_OPTIMIZER_TUPLE: FiniteOptimizerTuple = Object.freeze({
+  prefix: Object.freeze([]),
+  tail: Object.freeze({ kind: "none" }),
+});
+
+export function finiteOptimizerValue(
+  atoms: readonly OptimizerValueAtom[] = [],
+  unknownReasons: readonly string[] = [],
+  limits: OptimizerValueDomainLimits = DEFAULT_OPTIMIZER_VALUE_DOMAIN_LIMITS,
+): FiniteOptimizerValue {
+  validateLimits(limits);
+  const normalizedAtoms = uniqueSorted(atoms, atomKey);
+  const normalizedReasons = uniqueSorted(unknownReasons, (reason) => reason);
+  const atomOverflow = normalizedAtoms.length > limits.maxAtoms;
+  const reasons = atomOverflow
+    ? [...normalizedReasons, "atom-cap-exceeded"]
+    : normalizedReasons;
+  return Object.freeze({
+    atoms: Object.freeze(normalizedAtoms.slice(0, limits.maxAtoms)),
+    unknownReasons: Object.freeze(
+      capReasons(reasons, limits.maxUnknownReasons),
+    ),
+  });
+}
+
+export function unknownOptimizerValue(
+  reason: string,
+  limits: OptimizerValueDomainLimits = DEFAULT_OPTIMIZER_VALUE_DOMAIN_LIMITS,
+): FiniteOptimizerValue {
+  return finiteOptimizerValue([], [reason], limits);
+}
+
+export function joinOptimizerValues(
+  values: readonly FiniteOptimizerValue[],
+  limits: OptimizerValueDomainLimits = DEFAULT_OPTIMIZER_VALUE_DOMAIN_LIMITS,
+): FiniteOptimizerValue {
+  return finiteOptimizerValue(
+    values.flatMap((value) => value.atoms),
+    values.flatMap((value) => value.unknownReasons),
+    limits,
+  );
+}
+
+export function finiteOptimizerTuple(
+  prefix: readonly FiniteOptimizerValue[],
+  tail: OptimizerTupleTail = { kind: "none" },
+  limits: OptimizerValueDomainLimits = DEFAULT_OPTIMIZER_VALUE_DOMAIN_LIMITS,
+): FiniteOptimizerTuple {
+  validateLimits(limits);
+  const normalizedPrefix = prefix
+    .slice(0, limits.maxTuplePrefix)
+    .map((value) =>
+      finiteOptimizerValue(value.atoms, value.unknownReasons, limits),
+    );
+  const normalizedTail =
+    prefix.length > limits.maxTuplePrefix
+      ? joinTupleTails(
+          [
+            tail,
+            {
+              kind: "unknown",
+              reasons: ["tuple-prefix-cap-exceeded"],
+            },
+          ],
+          limits,
+        )
+      : normalizeTail(tail, limits);
+  return Object.freeze({
+    prefix: Object.freeze(normalizedPrefix),
+    tail: normalizedTail,
+  });
+}
+
+export function valueAtOptimizerTupleSlot(
+  tuple: FiniteOptimizerTuple,
+  index: number,
+  limits: OptimizerValueDomainLimits = DEFAULT_OPTIMIZER_VALUE_DOMAIN_LIMITS,
+): FiniteOptimizerValue {
+  if (!Number.isInteger(index) || index < 0)
+    throw new RangeError("Tuple slot index must be a non-negative integer");
+  if (index < tuple.prefix.length) return tuple.prefix[index];
+  switch (tuple.tail.kind) {
+    case "none":
+      return finiteOptimizerValue([NIL_ATOM], [], limits);
+    case "vararg":
+      // A vararg may contain fewer values than the requested slot.
+      return joinOptimizerValues(
+        [tuple.tail.value, finiteOptimizerValue([NIL_ATOM], [], limits)],
+        limits,
+      );
+    case "unknown":
+      return finiteOptimizerValue([], tuple.tail.reasons, limits);
+  }
+}
+
+export function joinOptimizerTuples(
+  tuples: readonly FiniteOptimizerTuple[],
+  limits: OptimizerValueDomainLimits = DEFAULT_OPTIMIZER_VALUE_DOMAIN_LIMITS,
+): FiniteOptimizerTuple {
+  validateLimits(limits);
+  if (tuples.length === 0) return EMPTY_OPTIMIZER_TUPLE;
+  const prefixLength = Math.min(
+    Math.max(...tuples.map((tuple) => tuple.prefix.length)),
+    limits.maxTuplePrefix,
+  );
+  const prefix = Array.from({ length: prefixLength }, (_, index) =>
+    joinOptimizerValues(
+      tuples.map((tuple) => valueAtOptimizerTupleSlot(tuple, index, limits)),
+      limits,
+    ),
+  );
+  const overflow = tuples.some(
+    (tuple) => tuple.prefix.length > limits.maxTuplePrefix,
+  );
+  const tail = joinTupleTails(
+    [
+      ...tuples.map((tuple) => tuple.tail),
+      ...(overflow
+        ? ([
+            {
+              kind: "unknown",
+              reasons: ["tuple-prefix-cap-exceeded"],
+            },
+          ] as const)
+        : []),
+    ],
+    limits,
+  );
+  return finiteOptimizerTuple(prefix, tail, limits);
+}
+
+function joinTupleTails(
+  tails: readonly OptimizerTupleTail[],
+  limits: OptimizerValueDomainLimits,
+): OptimizerTupleTail {
+  const unknownReasons = tails.flatMap((tail) =>
+    tail.kind === "unknown" ? tail.reasons : [],
+  );
+  if (unknownReasons.length > 0) {
+    return Object.freeze({
+      kind: "unknown",
+      reasons: Object.freeze(
+        capReasons(unknownReasons, limits.maxUnknownReasons),
+      ),
+    });
+  }
+  const varargs = tails.filter(
+    (tail): tail is Extract<OptimizerTupleTail, { kind: "vararg" }> =>
+      tail.kind === "vararg",
+  );
+  if (varargs.length === 0) return Object.freeze({ kind: "none" });
+  const values = varargs.map((tail) => tail.value);
+  if (tails.some((tail) => tail.kind === "none")) {
+    values.push(finiteOptimizerValue([NIL_ATOM], [], limits));
+  }
+  return Object.freeze({
+    kind: "vararg",
+    value: joinOptimizerValues(values, limits),
+  });
+}
+
+function normalizeTail(
+  tail: OptimizerTupleTail,
+  limits: OptimizerValueDomainLimits,
+): OptimizerTupleTail {
+  switch (tail.kind) {
+    case "none":
+      return Object.freeze({ kind: "none" });
+    case "vararg":
+      return Object.freeze({
+        kind: "vararg",
+        value: finiteOptimizerValue(
+          tail.value.atoms,
+          tail.value.unknownReasons,
+          limits,
+        ),
+      });
+    case "unknown":
+      return Object.freeze({
+        kind: "unknown",
+        reasons: Object.freeze(
+          capReasons(tail.reasons, limits.maxUnknownReasons),
+        ),
+      });
+  }
+}
+
+function atomKey(atom: OptimizerValueAtom): string {
+  switch (atom.kind) {
+    case "nil":
+      return "0:nil";
+    case "boolean":
+      return `1:boolean:${atom.value ? "1" : "0"}`;
+    case "number":
+      return `2:number:${atom.raw}`;
+    case "string":
+      return `3:string:${JSON.stringify(atom.value)}`;
+    case "function":
+      return `4:function:${atom.id}`;
+    case "allocation":
+      return `5:allocation:${atom.allocationKind}:${atom.id}`;
+    case "parameter":
+      return `6:parameter:${String(atom.index).padStart(12, "0")}`;
+    case "external":
+      return `7:external:${atom.id}`;
+  }
+}
+
+function uniqueSorted<T>(
+  values: readonly T[],
+  keyOf: (value: T) => string,
+): T[] {
+  const byKey = new Map<string, T>();
+  values.forEach((value) => byKey.set(keyOf(value), value));
+  return [...byKey.entries()]
+    .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
+    .map(([, value]) => value);
+}
+
+function capReasons(reasons: readonly string[], maximum: number): string[] {
+  const normalized = uniqueSorted(reasons, (reason) => reason);
+  if (normalized.length <= maximum) return normalized;
+  if (maximum === 0) return [];
+  return [
+    ...normalized.slice(0, Math.max(0, maximum - 1)),
+    "reason-cap-exceeded",
+  ];
+}
+
+function validateLimits(limits: OptimizerValueDomainLimits): void {
+  Object.entries(limits).forEach(([name, value]) => {
+    if (!Number.isInteger(value) || value < 0)
+      throw new RangeError(`${name} must be a non-negative integer`);
+  });
+  // At least one slot is necessary to preserve the fact that a cap discarded
+  // information. An empty reason set means the atom set is exhaustive.
+  if (limits.maxUnknownReasons === 0)
+    throw new RangeError("maxUnknownReasons must be at least one");
+}

--- a/src/tableEffects.ts
+++ b/src/tableEffects.ts
@@ -2,12 +2,13 @@ import Parser from "luaparse";
 import { ResolveResult, Symbol } from "./resolver";
 import { Allocation, ValueFlowAnalysis } from "./valueFlow";
 import { OptimizerFacts } from "./optimizerFacts";
+import { InterproceduralAnalysis } from "./interproceduralAnalysis";
 
 export interface FreshTable {
   readonly allocation: Allocation;
   readonly symbol: Symbol;
   readonly declaration: Parser.LocalStatement | Parser.AssignmentStatement;
-  readonly constructor: Parser.TableConstructorExpression;
+  readonly constructor?: Parser.TableConstructorExpression;
   readonly functionDepth: number;
 }
 
@@ -16,7 +17,7 @@ export interface TableEffect {
   readonly table: FreshTable;
   // undefinedは動的keyまたは安全にdecodeできない文字列literal。
   readonly staticKey: string | undefined;
-  readonly expression: Parser.MemberExpression | Parser.IndexExpression;
+  readonly expression?: Parser.MemberExpression | Parser.IndexExpression;
   readonly owner: Parser.Statement;
   readonly baseSymbol: Symbol;
 }
@@ -61,6 +62,7 @@ export function analyzeTableEffects(
   resolved: ResolveResult,
   valueFlow: ValueFlowAnalysis,
   facts: OptimizerFacts,
+  interprocedural?: InterproceduralAnalysis,
 ): TableEffectAnalysis {
   const freshTables: FreshTable[] = [];
   const freshByAllocation = new Map<Allocation, FreshTable>();
@@ -78,7 +80,9 @@ export function analyzeTableEffects(
       allocation,
       symbol: binding.symbol,
       declaration: binding.declaration,
-      constructor: allocation.origin,
+      ...(allocation.origin.type === "TableConstructorExpression"
+        ? { constructor: allocation.origin }
+        : {}),
       functionDepth: depthOf(allocation.unit),
     };
     freshTables.push(table);
@@ -163,28 +167,13 @@ export function analyzeTableEffects(
         analyzeTableAccess(expression, "read", owner, functionDepth);
         return;
       case "CallExpression":
-        analyzeCallParts(
-          expression.base,
-          expression.arguments,
-          owner,
-          functionDepth,
-        );
+        analyzeCall(expression, owner, functionDepth);
         return;
       case "TableCallExpression":
-        analyzeCallParts(
-          expression.base,
-          [expression.arguments],
-          owner,
-          functionDepth,
-        );
+        analyzeCall(expression, owner, functionDepth);
         return;
       case "StringCallExpression":
-        analyzeCallParts(
-          expression.base,
-          [expression.argument],
-          owner,
-          functionDepth,
-        );
+        analyzeCall(expression, owner, functionDepth);
         return;
       case "FunctionDeclaration":
         analyzeBlock(expression.body, functionDepth + 1);
@@ -206,20 +195,59 @@ export function analyzeTableEffects(
     }
   }
 
-  function analyzeCallParts(
-    base: Parser.Expression,
-    args: Parser.Expression[],
+  function analyzeCall(
+    call:
+      | Parser.CallExpression
+      | Parser.TableCallExpression
+      | Parser.StringCallExpression,
     owner: Parser.Statement,
     functionDepth: number,
   ): void {
-    analyzeExpression(base, owner, "call", functionDepth);
-    args.forEach((argument) => {
+    analyzeExpression(call.base, owner, "call", functionDepth);
+    const explicitArgs =
+      call.type === "CallExpression"
+        ? call.arguments
+        : [
+            call.type === "TableCallExpression"
+              ? call.arguments
+              : call.argument,
+          ];
+    const args =
+      call.base.type === "MemberExpression" && call.base.indexer === ":"
+        ? [call.base.base, ...explicitArgs]
+        : explicitArgs;
+    const callSite = interprocedural?.callGraph.callSiteOf(call);
+    args.forEach((argument, argumentIndex) => {
+      const symbol =
+        argument.type === "Identifier"
+          ? resolved.symbolOf(argument)
+          : undefined;
+      const table = tableOfBase(argument, owner);
+      if (table && symbol && callSite && interprocedural) {
+        interprocedural
+          .effectsOf(callSite)
+          .filter((effect) => effect.argumentIndex === argumentIndex)
+          .forEach((effect) =>
+            effects.push({
+              access: effect.access,
+              table,
+              staticKey: effect.staticKey,
+              owner,
+              baseSymbol: symbol,
+            }),
+          );
+        if (!interprocedural.escapesArgument(callSite, argumentIndex)) return;
+      }
       analyzeExpression(argument, owner, "call", functionDepth);
     });
-    if (base.type === "MemberExpression" && base.indexer === ":") {
-      const table = tableOfBase(base.base, owner);
-      if (table && base.base.type === "Identifier") {
-        escapeIdentifier(base.base, "call", owner, functionDepth);
+    if (
+      call.base.type === "MemberExpression" &&
+      call.base.indexer === ":" &&
+      !callSite
+    ) {
+      const table = tableOfBase(call.base.base, owner);
+      if (table && call.base.base.type === "Identifier") {
+        escapeIdentifier(call.base.base, "call", owner, functionDepth);
       }
     }
   }

--- a/src/valueFlow.ts
+++ b/src/valueFlow.ts
@@ -8,11 +8,19 @@ import {
 } from "./controlFlow";
 import { ResolveResult, Symbol } from "./resolver";
 import { OptimizerFacts, ValueSlotFact } from "./optimizerFacts";
+import { InterproceduralAnalysis } from "./interproceduralAnalysis";
+import { FiniteOptimizerValue } from "./optimizerValueDomain";
+import { OptimizerValueAtom } from "./optimizerValueDomain";
 
 export interface Allocation {
   readonly id: number;
   readonly kind: "table";
-  readonly origin: Parser.TableConstructorExpression;
+  readonly origin:
+    | Parser.TableConstructorExpression
+    | Parser.CallExpression
+    | Parser.TableCallExpression
+    | Parser.StringCallExpression;
+  readonly templateId?: string;
   readonly owner: Parser.Statement;
   readonly unit: ExecutionUnit;
 }
@@ -79,6 +87,7 @@ export function analyzeValueFlow(
   resolved: ResolveResult,
   facts: OptimizerFacts,
   version = facts.generation,
+  interprocedural?: InterproceduralAnalysis,
 ): ValueFlowAnalysis {
   if (facts.generation !== version) {
     throw new Error("Value flow requires facts from the same AST generation");
@@ -89,6 +98,10 @@ export function analyzeValueFlow(
   const allocationByOrigin = new WeakMap<
     Parser.TableConstructorExpression,
     Allocation
+  >();
+  const callAllocations = new WeakMap<
+    Parser.Expression,
+    Map<string, Allocation>
   >();
   const writesByNode = new Map<ControlFlowNode, readonly Write[]>();
   const beforeByNode = new Map<
@@ -124,6 +137,43 @@ export function analyzeValueFlow(
     };
     allocations.push(allocation);
     allocationByOrigin.set(operation.origin, allocation);
+  });
+
+  interprocedural?.callGraph.calls.forEach((call) => {
+    const point = controlFlow.pointOf(call.owner);
+    if (!point) return;
+    const byTemplate = new Map<string, Allocation>();
+    interprocedural.returnsOf(call).prefix.forEach((value) => {
+      const templates = value.atoms.filter(
+        (
+          atom,
+        ): atom is Extract<OptimizerValueAtom, { kind: "allocation" }> & {
+          readonly allocationKind: "table";
+        } => atom.kind === "allocation" && atom.allocationKind === "table",
+      );
+      if (
+        value.unknownReasons.length > 0 ||
+        templates.length === 0 ||
+        templates.length !== value.atoms.length
+      )
+        return;
+      const existing = templates
+        .map((template) => byTemplate.get(template.id))
+        .find((allocation) => allocation !== undefined);
+      const allocation =
+        existing ??
+        ({
+          id: allocations.length,
+          kind: "table",
+          origin: call.call,
+          templateId: templates.map((template) => template.id).join("|"),
+          owner: call.owner,
+          unit: point.unit,
+        } satisfies Allocation);
+      if (!existing) allocations.push(allocation);
+      templates.forEach((template) => byTemplate.set(template.id, allocation));
+    });
+    if (byTemplate.size > 0) callAllocations.set(call.call, byTemplate);
   });
 
   controlFlow.nodes.forEach((node) => {
@@ -197,6 +247,8 @@ export function analyzeValueFlow(
             before,
             resolved,
             allocationByOrigin,
+            interprocedural,
+            callAllocations,
           );
           write.definition.value = value;
           after.set(write.definition.symbol, value);
@@ -303,11 +355,10 @@ function abstractSlot(
   values: ReadonlyMap<Symbol, AbstractValue>,
   resolved: ResolveResult,
   allocations: WeakMap<Parser.TableConstructorExpression, Allocation>,
+  interprocedural?: InterproceduralAnalysis,
+  callAllocations?: WeakMap<Parser.Expression, Map<string, Allocation>>,
 ): AbstractValue {
   if (!slot || slot.source.kind === "nil-padding") return { kind: "nil" };
-  if (slot.source.kind === "tail-expansion" && slot.source.offset > 0) {
-    return { kind: "unknown", reason: "multi-value-tail" };
-  }
   const expression = slot.source.expression;
   if (expression.type === "TableConstructorExpression") {
     const allocation = allocations.get(expression);
@@ -321,8 +372,116 @@ function abstractSlot(
       ? (values.get(symbol) ?? UNKNOWN_ENTRY)
       : { kind: "unknown", reason: "global-or-unresolved" };
   }
+  if (
+    expression.type === "CallExpression" ||
+    expression.type === "TableCallExpression" ||
+    expression.type === "StringCallExpression"
+  ) {
+    const call = interprocedural?.callGraph.callSiteOf(expression);
+    if (call && interprocedural) {
+      const result = interprocedural.returnsOf(call);
+      const index =
+        slot.source.kind === "tail-expansion" ? slot.source.offset : 0;
+      const value = result.prefix.at(index);
+      if (value) {
+        const abstracted = abstractInterproceduralValue(
+          value,
+          callAllocations?.get(expression),
+        );
+        if (abstracted.kind !== "unknown") return abstracted;
+        const symbolic = interprocedural
+          .symbolicReturnsOf(call)
+          .prefix.at(index);
+        const argumentsValue = symbolic
+          ? abstractParameterAliases(
+              symbolic,
+              callArguments(expression),
+              values,
+              resolved,
+              allocations,
+            )
+          : undefined;
+        if (argumentsValue) return argumentsValue;
+        return abstracted;
+      }
+    }
+  }
+  if (slot.source.kind === "tail-expansion" && slot.source.offset > 0) {
+    return { kind: "unknown", reason: "multi-value-tail" };
+  }
   if (expression.type === "NilLiteral") return { kind: "nil" };
   return { kind: "unknown", reason: "unsupported-expression" };
+}
+
+function callArguments(
+  call:
+    | Parser.CallExpression
+    | Parser.TableCallExpression
+    | Parser.StringCallExpression,
+): readonly Parser.Expression[] {
+  const explicit =
+    call.type === "CallExpression"
+      ? call.arguments
+      : [call.type === "TableCallExpression" ? call.arguments : call.argument];
+  return call.base.type === "MemberExpression" && call.base.indexer === ":"
+    ? [call.base.base, ...explicit]
+    : explicit;
+}
+
+function abstractParameterAliases(
+  value: FiniteOptimizerValue,
+  actuals: readonly Parser.Expression[],
+  values: ReadonlyMap<Symbol, AbstractValue>,
+  resolved: ResolveResult,
+  allocations: WeakMap<Parser.TableConstructorExpression, Allocation>,
+): AbstractValue | undefined {
+  if (
+    value.unknownReasons.length > 0 ||
+    value.atoms.length === 0 ||
+    !value.atoms.every((atom) => atom.kind === "parameter")
+  )
+    return undefined;
+  const alternatives = value.atoms.map((atom) => {
+    const actual = actuals.at(atom.index);
+    if (!actual) return { kind: "nil" } satisfies AbstractValue;
+    if (actual.type === "Identifier") {
+      const symbol = resolved.symbolOf(actual);
+      return symbol ? (values.get(symbol) ?? UNKNOWN_ENTRY) : UNKNOWN_ENTRY;
+    }
+    if (actual.type === "TableConstructorExpression") {
+      const allocation = allocations.get(actual);
+      return allocation
+        ? ({
+            kind: "allocations",
+            allocations: new Set([allocation]),
+          } satisfies AbstractValue)
+        : UNKNOWN_ENTRY;
+    }
+    if (actual.type === "NilLiteral")
+      return { kind: "nil" } satisfies AbstractValue;
+    return UNKNOWN_ENTRY;
+  });
+  return alternatives.reduce(joinValue);
+}
+
+function abstractInterproceduralValue(
+  value: FiniteOptimizerValue,
+  allocations: ReadonlyMap<string, Allocation> | undefined,
+): AbstractValue {
+  if (value.unknownReasons.length > 0)
+    return { kind: "unknown", reason: value.unknownReasons.join(",") };
+  const mapped = value.atoms.flatMap((atom) => {
+    if (atom.kind !== "allocation" || atom.allocationKind !== "table")
+      return [];
+    const allocation = allocations?.get(atom.id);
+    return allocation ? [allocation] : [];
+  });
+  const resolved = new Set(mapped);
+  if (mapped.length === value.atoms.length && resolved.size > 0)
+    return { kind: "allocations", allocations: resolved };
+  if (value.atoms.length === 1 && value.atoms[0].kind === "nil")
+    return { kind: "nil" };
+  return { kind: "unknown", reason: "interprocedural-nonallocation-value" };
 }
 
 function joinValueMaps(

--- a/test/callGraph.test.ts
+++ b/test/callGraph.test.ts
@@ -1,0 +1,52 @@
+import Parser from "luaparse";
+import { describe, expect, test } from "vitest";
+import { analyzeCallGraph } from "../src/callGraph";
+import { analyzeOptimizerFacts } from "../src/optimizerFacts";
+import { resolveScopes } from "../src/resolver";
+
+function graphOf(source: string) {
+  const chunk = Parser.parse(source, { luaVersion: "5.3" });
+  const resolved = resolveScopes(chunk);
+  const facts = analyzeOptimizerFacts(chunk, resolved);
+  return analyzeCallGraph(chunk, resolved, facts);
+}
+
+describe("module-local call graph", () => {
+  test("resolves local functions and stable local aliases by symbol identity", () => {
+    const graph = graphOf(
+      "local function factory() return {} end local alias=factory local value=alias()",
+    );
+    expect(graph.functions).toHaveLength(1);
+    const call = graph.calls.at(-1);
+    expect(call?.hasUnknownTarget).toBe(false);
+    expect([...(call?.targets ?? [])]).toEqual([graph.functions[0]]);
+  });
+
+  test("keeps external calls explicitly unknown", () => {
+    const graph = graphOf("local value=externalFactory() use(value)");
+    expect(graph.calls).toHaveLength(2);
+    expect(graph.calls.every((call) => call.hasUnknownTarget)).toBe(true);
+  });
+
+  test("does not retain a stale function target after reassignment", () => {
+    const graph = graphOf(
+      "local target=function() return 1 end target=external target()",
+    );
+    expect(graph.calls.at(-1)?.hasUnknownTarget).toBe(true);
+    expect(graph.calls.at(-1)?.targets.size).toBe(0);
+  });
+
+  test("finds recursive SCCs without initializing unknown edges as targets", () => {
+    const graph = graphOf(`
+local even,odd
+even=function(n) if n==0 then return true end return odd(n-1) end
+odd=function(n) if n==0 then return false end return even(n-1) end
+return even(4)
+`);
+    const recursive = graph.sccs.find((scc) => scc.recursive);
+    expect(recursive?.functions).toHaveLength(2);
+    expect(graph.calls.filter((call) => !call.hasUnknownTarget)).toHaveLength(
+      3,
+    );
+  });
+});

--- a/test/constantFold.test.ts
+++ b/test/constantFold.test.ts
@@ -72,6 +72,41 @@ function minifyWith(code: string, foldConstants: boolean): string {
   }
 }
 
+test("propagates a pure function summary into a direct scalar call", () => {
+  const source = `
+local function answer() return 42 end
+local value=answer()
+print(value)
+`;
+  const enabled = minifyWith(source, true);
+  const disabled = minifyWith(source, false);
+
+  assert.match(enabled, /42/);
+  assert.doesNotMatch(enabled, /function/);
+  assert.ok(Buffer.byteLength(enabled) < Buffer.byteLength(disabled));
+});
+
+test("does not erase an effectful or recursive call from a constant summary", () => {
+  const effectful = `
+local function answer() print('effect') return 1 end
+local value=answer()
+print(value)
+`;
+  const recursive = `
+local function answer() return answer() end
+local value=answer()
+print(value)
+`;
+  const globalWrite = `
+local function answer() output=1 return 1 end
+local value=answer()
+print(value,output)
+`;
+  assert.match(minifyWith(effectful, true), /effect/);
+  assert.match(minifyWith(recursive, true), /function/);
+  assert.match(minifyWith(globalWrite, true), /output=1/);
+});
+
 function runFoldedMinifier(code: string): string {
   return minifyWith(code, true);
 }

--- a/test/interproceduralAnalysis.test.ts
+++ b/test/interproceduralAnalysis.test.ts
@@ -1,0 +1,265 @@
+import Parser from "luaparse";
+import { describe, expect, test } from "vitest";
+import { analyzeCallGraph } from "../src/callGraph";
+import { analyzeInterprocedural } from "../src/interproceduralAnalysis";
+import { analyzeOptimizerFacts } from "../src/optimizerFacts";
+import { resolveScopes } from "../src/resolver";
+import {
+  finiteOptimizerTuple,
+  finiteOptimizerValue,
+} from "../src/optimizerValueDomain";
+
+function analyze(source: string) {
+  const chunk = Parser.parse(source, {
+    luaVersion: "5.3",
+    ranges: true,
+    locations: true,
+  });
+  const resolved = resolveScopes(chunk);
+  const facts = analyzeOptimizerFacts(chunk, resolved);
+  const callGraph = analyzeCallGraph(chunk, resolved, facts);
+  return {
+    callGraph,
+    analysis: analyzeInterprocedural(chunk, resolved, callGraph),
+  };
+}
+
+function analyzeWithContract(source: string) {
+  const chunk = Parser.parse(source, {
+    luaVersion: "5.3",
+    ranges: true,
+  });
+  const resolved = resolveScopes(chunk);
+  const facts = analyzeOptimizerFacts(chunk, resolved);
+  const callGraph = analyzeCallGraph(chunk, resolved, facts);
+  return {
+    callGraph,
+    analysis: analyzeInterprocedural(chunk, resolved, callGraph, {
+      externalContracts: new Map([
+        [
+          "runtimeValue",
+          {
+            name: "runtimeValue",
+            provenance: { kind: "runtime", profile: "stormworks" },
+            returns: finiteOptimizerTuple([
+              finiteOptimizerValue([{ kind: "number", raw: "7" }]),
+            ]),
+          },
+        ],
+      ]),
+    }),
+  };
+}
+
+function requireLast<T>(items: readonly T[]): T {
+  const value = items.at(-1);
+  if (value === undefined) throw new Error("expected a final item");
+  return value;
+}
+
+describe("interprocedural summaries", () => {
+  test("propagates constants and parameter aliases through wrappers", () => {
+    const { analysis, callGraph } = analyze(`
+local function identity(value) return value end
+local function wrapper(value) return identity(value) end
+local result=wrapper(42)
+`);
+    const call = requireLast(callGraph.calls);
+    expect(analysis.returnsOf(call).prefix[0]).toEqual({
+      atoms: [{ kind: "number", raw: "42" }],
+      unknownReasons: [],
+    });
+  });
+
+  test("gives separate allocation identities to separate factory calls", () => {
+    const { analysis, callGraph } = analyze(`
+local function factory() return {x=1} end
+local first=factory()
+local second=factory()
+`);
+    const returns = callGraph.calls.map((call) => analysis.returnsOf(call));
+    const first = returns[0].prefix[0].atoms[0];
+    const second = returns[1].prefix[0].atoms[0];
+    expect(first).toMatchObject({
+      kind: "allocation",
+      allocationKind: "table",
+    });
+    expect(second).toMatchObject({
+      kind: "allocation",
+      allocationKind: "table",
+    });
+    expect(first).not.toEqual(second);
+    if (first.kind !== "allocation") throw new Error("missing allocation");
+    const shape = analysis.shapeOfAllocation(first.id);
+    expect(shape?.fields.length).toBeGreaterThan(0);
+    expect(typeof shape?.fields[0]?.staticKey).toBe("string");
+  });
+
+  test("preserves multiple return slots through a wrapper tail", () => {
+    const { analysis, callGraph } = analyze(`
+local function pair() return 1,2 end
+local function wrapper() return pair() end
+local first,second=wrapper()
+`);
+    const result = analysis.returnsOf(requireLast(callGraph.calls));
+    expect(result.prefix[0].atoms).toContainEqual({ kind: "number", raw: "1" });
+    expect(result.prefix[1].atoms).toContainEqual({ kind: "number", raw: "2" });
+    expect(result.tail).toEqual({ kind: "none" });
+  });
+
+  test("projects helper field effects without dirtying unrelated keys", () => {
+    const { analysis, callGraph } = analyze(`
+local function writeX(value) value.x=1 end
+local tableValue={}
+writeX(tableValue)
+`);
+    expect(analysis.effectsOf(callGraph.calls[0])).toEqual([
+      expect.objectContaining({ argumentIndex: 0, access: "write" }),
+    ]);
+    expect(analysis.effectsOf(callGraph.calls[0])[0].staticKey).toBeDefined();
+  });
+
+  test("recursive summaries retain a provable base result", () => {
+    const { analysis, callGraph } = analyze(`
+local recursive
+recursive=function(flag)
+  if flag then return 1 end
+  return recursive(true)
+end
+local result=recursive(false)
+`);
+    const recursive = callGraph.sccs.find((scc) => scc.recursive);
+    expect(recursive).toBeDefined();
+    expect(
+      analysis.returnsOf(requireLast(callGraph.calls)).prefix[0].atoms,
+    ).toContainEqual({
+      kind: "number",
+      raw: "1",
+    });
+  });
+
+  test("does not confuse a non-returning recursive tail with nil", () => {
+    const { analysis, callGraph } = analyze(`
+local function forever() return forever() end
+local value=forever()
+`);
+    const result = analysis.returnsOf(requireLast(callGraph.calls));
+    expect(result.prefix).toEqual([]);
+    expect(result.tail).toMatchObject({ kind: "unknown" });
+  });
+
+  test("records a parameter captured by a returned closure as escaping", () => {
+    const { analysis, callGraph } = analyze(`
+local function bind(value)
+  return function() return value end
+end
+local closure=bind(1)
+`);
+    const call = requireLast(callGraph.calls);
+    expect(analysis.escapesArgument(call, 0)).toBe(true);
+    expect(analysis.summaryOf([...call.targets][0]).escapes).toContainEqual({
+      parameterIndex: 0,
+      reason: "capture",
+    });
+  });
+
+  test("an unknown target remains local to its return and argument escapes", () => {
+    const { analysis, callGraph } = analyze(`
+local function wrapper(value) return external(value) end
+local other=1
+local result=wrapper(other)
+`);
+    const externalCall = callGraph.calls[0];
+    expect(analysis.returnsOf(externalCall).tail).toMatchObject({
+      kind: "unknown",
+    });
+    expect(analysis.escapesArgument(externalCall, 0)).toBe(true);
+    const diagnostic = analysis.diagnostics.find(
+      (candidate) =>
+        candidate.reason === "unknown-call-target" &&
+        candidate.callId === externalCall.id,
+    );
+    expect(Array.isArray(diagnostic?.sourceRange)).toBe(true);
+  });
+
+  test("uses an explicit external contract without treating it as language proof", () => {
+    const { analysis, callGraph } = analyzeWithContract(
+      "local function wrapper() return runtimeValue() end local value=wrapper()",
+    );
+    const contractCall = callGraph.calls[0];
+    const wrapperCall = callGraph.calls[1];
+    expect(analysis.returnsOf(wrapperCall).prefix[0].atoms).toEqual([
+      { kind: "number", raw: "7" },
+    ]);
+    expect(analysis.diagnostics).toContainEqual(
+      expect.objectContaining({
+        reason: "external-contract-used",
+        callId: contractCall.id,
+      }),
+    );
+    expect(analysis.escapesArgument(contractCall, 0)).toBe(false);
+  });
+
+  test("joins fallthrough and propagates writes from lexical blocks", () => {
+    const { analysis, callGraph } = analyze(`
+local function branch(flag)
+  local value=1
+  if flag then value=2 end
+  do value=3 end
+  return value
+end
+local result=branch(false)
+`);
+    expect(
+      analysis.returnsOf(requireLast(callGraph.calls)).prefix[0].atoms,
+    ).toEqual([{ kind: "number", raw: "3" }]);
+  });
+
+  test("expands the final call in assignments and actual arguments", () => {
+    const { analysis, callGraph } = analyze(`
+local function pair() return 1,2 end
+local function second(first,value) return value end
+local function wrapper()
+  local first,value=pair()
+  return second(pair()),value
+end
+local first,value=wrapper()
+`);
+    const result = analysis.returnsOf(requireLast(callGraph.calls));
+    expect(result.prefix[0].atoms).toContainEqual({ kind: "number", raw: "2" });
+    expect(result.prefix[1].atoms).toContainEqual({ kind: "number", raw: "2" });
+  });
+
+  test("does not instantiate an allocation that escaped before return", () => {
+    const { analysis, callGraph } = analyze(`
+local leaked
+local function factory()
+  local value={x=1}
+  leaked=value
+  return value
+end
+local result=factory()
+`);
+    const returned = analysis.returnsOf(requireLast(callGraph.calls)).prefix[0];
+    expect(returned.atoms).toEqual([]);
+    expect(returned.unknownReasons).toContain("escaped-allocation");
+  });
+
+  test("does not apply an external contract to a shadowing local", () => {
+    const { analysis, callGraph } = analyzeWithContract(`
+local function runtimeValue() return 9 end
+local value=runtimeValue()
+`);
+    const call = requireLast(callGraph.calls);
+    expect(analysis.returnsOf(call).prefix[0].atoms).toEqual([
+      { kind: "number", raw: "9" },
+    ]);
+    expect(
+      analysis.diagnostics.some(
+        (diagnostic) =>
+          diagnostic.reason === "external-contract-used" &&
+          diagnostic.callId === call.id,
+      ),
+    ).toBe(false);
+  });
+});

--- a/test/optimizerDiagnostics.test.ts
+++ b/test/optimizerDiagnostics.test.ts
@@ -70,6 +70,7 @@ describe("optimization diagnostics", () => {
       "local t={x=1} consume(t) local a=t.x use(a)",
       "local a=1 tick() if ready then use(a) end local b=2 use(b)",
       "local first=1 tick() local second=2 use(first,second)",
+      "local function factory() return {x=1,y=2} end local t=factory() local a=t.x tick() local b=t.y use(a,b)",
     ];
     const diagnostics = fixtures.flatMap((source, index) => {
       const { minifier } = minifyTemporaryLuaSource(
@@ -101,11 +102,17 @@ describe("optimization diagnostics", () => {
     );
     diagnostics.push(...luaMinifier.optimizationDiagnostics);
     const reasons = new Set(diagnostics.map((item) => item.reason));
-    (["profitable-group", "dynamic-key", "call-escape"] as const).forEach(
-      (reason) => {
-        expect(reasons.has(reason)).toBe(true);
-      },
-    );
+    (
+      [
+        "profitable-group",
+        "dynamic-key",
+        "call-escape",
+        "resolved-call-target",
+        "unknown-call-target",
+      ] as const
+    ).forEach((reason) => {
+      expect(reasons.has(reason)).toBe(true);
+    });
     expect(
       diagnostics.every(
         (item) =>

--- a/test/optimizerPass.test.ts
+++ b/test/optimizerPass.test.ts
@@ -2,6 +2,10 @@ import Parser from "luaparse";
 import { describe, expect, test } from "vitest";
 import { PassOrchestrator, UNCHANGED } from "../src/optimizerPass";
 import { resolveScopes } from "../src/resolver";
+import {
+  analyzeOptimizerAtGeneration,
+  OPTIMIZER_ANALYSIS_CACHE_KEY,
+} from "../src/optimizerAnalysis";
 
 describe("optimizer pass orchestrator", () => {
   test("re-resolves immediately after an invalidating transform", () => {
@@ -100,5 +104,36 @@ describe("optimizer pass orchestrator", () => {
     expect(() => orchestrator.analysis({}, () => ({ generation: 99 }))).toThrow(
       /stale AST generation/,
     );
+  });
+
+  test("invalidates call graph and function summaries with the AST generation", () => {
+    const chunk = Parser.parse(
+      "local function value() return 1 end local result=value()",
+      { luaVersion: "5.3" },
+    );
+    const orchestrator = new PassOrchestrator(chunk, resolveScopes(chunk));
+    const first = orchestrator.analysis(
+      OPTIMIZER_ANALYSIS_CACHE_KEY,
+      analyzeOptimizerAtGeneration,
+    );
+    const declaration = chunk.body[0] as Parser.FunctionDeclaration;
+    const returned = (declaration.body[0] as Parser.ReturnStatement)
+      .arguments[0] as Parser.NumericLiteral;
+    returned.value = 2;
+    returned.raw = "2";
+    orchestrator.run("change-return-value", () => ({
+      changed: true,
+      invalidatesResolve: false,
+    }));
+    const second = orchestrator.analysis(
+      OPTIMIZER_ANALYSIS_CACHE_KEY,
+      analyzeOptimizerAtGeneration,
+    );
+
+    expect(second).not.toBe(first);
+    expect(second.interprocedural.generation).toBe(1);
+    expect(
+      second.interprocedural.summaries[0].returns.prefix[0].atoms,
+    ).toContainEqual({ kind: "number", raw: "2" });
   });
 });

--- a/test/optimizerValueDomain.test.ts
+++ b/test/optimizerValueDomain.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, test } from "vitest";
+import {
+  finiteOptimizerTuple,
+  finiteOptimizerValue,
+  joinOptimizerTuples,
+  joinOptimizerValues,
+  valueAtOptimizerTupleSlot,
+} from "../src/optimizerValueDomain";
+
+const limits = {
+  maxAtoms: 3,
+  maxUnknownReasons: 3,
+  maxTuplePrefix: 2,
+};
+
+describe("finite optimizer value domain", () => {
+  test("joins atoms and unknown knowledge independently and deterministically", () => {
+    const joined = joinOptimizerValues(
+      [
+        finiteOptimizerValue(
+          [
+            { kind: "string", value: "answer" },
+            { kind: "number", raw: "42" },
+          ],
+          ["external-call"],
+          limits,
+        ),
+        finiteOptimizerValue(
+          [
+            { kind: "boolean", value: true },
+            { kind: "number", raw: "42" },
+          ],
+          ["dynamic-branch"],
+          limits,
+        ),
+      ],
+      limits,
+    );
+
+    expect(joined).toEqual({
+      atoms: [
+        { kind: "boolean", value: true },
+        { kind: "number", raw: "42" },
+        { kind: "string", value: "answer" },
+      ],
+      unknownReasons: ["dynamic-branch", "external-call"],
+    });
+  });
+
+  test("caps atoms without discarding the fact that alternatives were lost", () => {
+    const value = finiteOptimizerValue(
+      [
+        { kind: "external", id: "runtime" },
+        { kind: "parameter", index: 1 },
+        { kind: "function", id: "helper" },
+        { kind: "allocation", allocationKind: "table", id: "factory:1" },
+      ],
+      [],
+      limits,
+    );
+
+    expect(value.atoms).toHaveLength(3);
+    expect(value.unknownReasons).toContain("atom-cap-exceeded");
+  });
+
+  test("joins tuple slots with nil padding without poisoning other slots", () => {
+    const left = finiteOptimizerTuple(
+      [
+        finiteOptimizerValue([{ kind: "number", raw: "1" }], [], limits),
+        finiteOptimizerValue([{ kind: "string", value: "x" }], [], limits),
+      ],
+      { kind: "none" },
+      limits,
+    );
+    const right = finiteOptimizerTuple(
+      [finiteOptimizerValue([{ kind: "number", raw: "1" }], [], limits)],
+      { kind: "none" },
+      limits,
+    );
+
+    const joined = joinOptimizerTuples([right, left], limits);
+
+    expect(joined.prefix[0]).toEqual({
+      atoms: [{ kind: "number", raw: "1" }],
+      unknownReasons: [],
+    });
+    expect(joined.prefix[1].atoms).toEqual([
+      { kind: "nil" },
+      { kind: "string", value: "x" },
+    ]);
+  });
+
+  test("a vararg tail includes nil for a missing runtime slot", () => {
+    const tuple = finiteOptimizerTuple(
+      [],
+      {
+        kind: "vararg",
+        value: finiteOptimizerValue(
+          [{ kind: "parameter", index: 0 }],
+          [],
+          limits,
+        ),
+      },
+      limits,
+    );
+
+    expect(valueAtOptimizerTupleSlot(tuple, 4, limits).atoms).toEqual([
+      { kind: "nil" },
+      { kind: "parameter", index: 0 },
+    ]);
+  });
+
+  test("tuple prefix overflow becomes an explicit unknown tail", () => {
+    const tuple = finiteOptimizerTuple(
+      [
+        finiteOptimizerValue([{ kind: "nil" }], [], limits),
+        finiteOptimizerValue([{ kind: "boolean", value: false }], [], limits),
+        finiteOptimizerValue([{ kind: "string", value: "lost" }], [], limits),
+      ],
+      { kind: "none" },
+      limits,
+    );
+
+    expect(tuple.prefix).toHaveLength(2);
+    expect(tuple.tail).toEqual({
+      kind: "unknown",
+      reasons: ["tuple-prefix-cap-exceeded"],
+    });
+  });
+
+  test("rejects a reason cap that could hide loss of information", () => {
+    expect(() =>
+      finiteOptimizerValue([], [], { ...limits, maxUnknownReasons: 0 }),
+    ).toThrow(/at least one/);
+  });
+});

--- a/test/tableReadMerge.integration.test.ts
+++ b/test/tableReadMerge.integration.test.ts
@@ -57,6 +57,45 @@ use(first,second)
     );
   });
 
+  test("projects a known helper write onto only the affected field", () => {
+    const source = `
+local function writeY(value) value.y=2 end
+local tableValue={x=1}
+local first=tableValue.x
+writeY(tableValue)
+local second=tableValue.x
+use(first,second)
+`;
+    const fieldSensitive = minify(source, { effectAwareLocalHoist: false });
+    const wholeTable = minify(source, {
+      fieldSensitiveTableEffects: false,
+      effectAwareLocalHoist: false,
+    });
+
+    expect(Buffer.byteLength(fieldSensitive)).toBeLessThan(
+      Buffer.byteLength(wholeTable),
+    );
+  });
+
+  test("does not treat a proven no-escape helper argument as an unknown escape", () => {
+    const source = `
+local function observe(value) return value.x end
+local tableValue={x=1,y=2}
+local first=tableValue.x
+observe(tableValue)
+local second=tableValue.y
+use(first,second)
+`;
+    const enabled = minify(source, { effectAwareLocalHoist: false });
+    const disabled = minify(source, {
+      effectAwareTableReads: false,
+      effectAwareLocalHoist: false,
+    });
+    expect(Buffer.byteLength(enabled)).toBeLessThan(
+      Buffer.byteLength(disabled),
+    );
+  });
+
   test("merges reads through a stable local alias", () => {
     const source = `
 local tableValue={x=1,y=2}
@@ -75,6 +114,27 @@ use(first,second)
     expect(Buffer.byteLength(enabled)).toBeLessThan(
       Buffer.byteLength(disabled),
     );
+  });
+
+  test("merges reads from a proven fresh factory call", () => {
+    const source = `
+local function makeValue() return {x=1,y=2} end
+local tableValue=makeValue()
+local first=tableValue.x
+tick()
+local second=tableValue.y
+use(first,second)
+`;
+    const enabled = minify(source, { effectAwareLocalHoist: false });
+    const disabled = minify(source, {
+      effectAwareTableReads: false,
+      effectAwareLocalHoist: false,
+    });
+
+    expect(Buffer.byteLength(enabled)).toBeLessThan(
+      Buffer.byteLength(disabled),
+    );
+    expect(() => Parser.parse(enabled, { luaVersion: "5.3" })).not.toThrow();
   });
 
   test("does not move reads for an escaped table", () => {

--- a/test/valueFlow.test.ts
+++ b/test/valueFlow.test.ts
@@ -110,4 +110,92 @@ describe("CFG allocation value flow", () => {
       reason: "multi-value-tail",
     });
   });
+
+  test("instantiates a distinct fresh allocation for each proven factory call", () => {
+    const { chunk, resolved, flow } = analyze(`
+local function factory() return {} end
+local first=factory()
+local second=factory()
+use(first,second)
+`);
+    const firstDeclaration = chunk.body[1] as Parser.LocalStatement;
+    const secondDeclaration = chunk.body[2] as Parser.LocalStatement;
+    const use = chunk.body[3] as Parser.CallStatement;
+    const first = resolved.symbolOf(firstDeclaration.variables[0]);
+    const second = resolved.symbolOf(secondDeclaration.variables[0]);
+    const point = flow.controlFlow.pointOf(use);
+    if (!first || !second || !point) throw new Error("missing facts");
+
+    const firstValue = flow.valueBefore(point, first);
+    const secondValue = flow.valueBefore(point, second);
+    expect(firstValue.kind).toBe("allocations");
+    expect(secondValue.kind).toBe("allocations");
+    if (firstValue.kind !== "allocations" || secondValue.kind !== "allocations")
+      throw new Error("unexpected values");
+    expect([...firstValue.allocations]).not.toEqual([
+      ...secondValue.allocations,
+    ]);
+  });
+
+  test("keeps branch-joined fresh factory alternatives as one call-instance identity", () => {
+    const { chunk, resolved, flow } = analyze(`
+local function factory(flag)
+  if flag then return {x=1} else return {x=2} end
+end
+local value=factory(condition)
+use(value)
+`);
+    const declaration = chunk.body[1] as Parser.LocalStatement;
+    const use = chunk.body[2] as Parser.CallStatement;
+    const symbol = resolved.symbolOf(declaration.variables[0]);
+    const point = flow.controlFlow.pointOf(use);
+    if (!symbol || !point) throw new Error("missing facts");
+    const value = flow.valueBefore(point, symbol);
+    expect(value.kind).toBe("allocations");
+    if (value.kind !== "allocations") throw new Error("unexpected value");
+    expect(value.allocations.size).toBe(1);
+  });
+
+  test("substitutes a parameter return alias with the caller allocation", () => {
+    const { chunk, resolved, flow } = analyze(`
+local function identity(value) return value end
+local original={}
+local alias=identity(original)
+use(alias)
+`);
+    const originalDeclaration = chunk.body[1] as Parser.LocalStatement;
+    const aliasDeclaration = chunk.body[2] as Parser.LocalStatement;
+    const use = chunk.body[3] as Parser.CallStatement;
+    const original = resolved.symbolOf(originalDeclaration.variables[0]);
+    const alias = resolved.symbolOf(aliasDeclaration.variables[0]);
+    const point = flow.controlFlow.pointOf(use);
+    if (!original || !alias || !point) throw new Error("missing facts");
+    expect(flow.valueBefore(point, alias)).toEqual(
+      flow.valueBefore(point, original),
+    );
+  });
+
+  test("does not instantiate captured shared storage or metatable-dependent values as fresh", () => {
+    for (const source of [
+      `
+local shared={}
+local function factory() return shared end
+local value=factory()
+use(value)
+`,
+      `
+local function factory() return setmetatable({},meta) end
+local value=factory()
+use(value)
+`,
+    ]) {
+      const { chunk, resolved, flow } = analyze(source);
+      const declaration = chunk.body.at(-2) as Parser.LocalStatement;
+      const use = chunk.body.at(-1) as Parser.CallStatement;
+      const symbol = resolved.symbolOf(declaration.variables[0]);
+      const point = flow.controlFlow.pointOf(use);
+      if (!symbol || !point) throw new Error("missing facts");
+      expect(flow.valueBefore(point, symbol).kind).toBe("unknown");
+    }
+  });
 });


### PR DESCRIPTION
## Summary

- build a resolver-identity call graph for stable local function values and aliases
- propagate bounded scalar/function/allocation/parameter tuples, table shapes, field effects, escapes, and external effects through recursive SCC summaries
- feed proven factory allocation identities and helper effects into value flow/table effects, and add limited pure zero-argument constant-call folding under the existing fold-constants opt-in
- expose explicit runtime/module contracts without guessing across unresolved module boundaries, and record summary diagnostics in the existing collector

## Soundness boundaries

- escaped/shared allocations are rejected before per-call fresh identities are created
- unknown targets invalidate affected arguments only
- branch fallthrough, lexical block/loop writes, Lua tail expansion/varargs, recursive bottom, shadowed external-contract names, metatable/error flags, and analysis-generation invalidation have regression coverage
- general inline/parameter pruning/function DCE remain #76; interference coloring remains #75, as recorded on #74 before exclusion

## Validation

- pnpm lint
- pnpm test: 40 files / 369 tests
- pnpm verify:lua-budget: 49/50 accepted, 51 rejected with 150 active locals
- pnpm verify:effect-semantics: 4 lua53 fixtures matched exactly
- pnpm report:optimizer: 15 accepted / 13 rejected, 43 estimated bytes saved

## Pinned n-tracs benchmark

Fixture: n-tracs 0b0d3c0, baseline: develop 2c45c8b. Syntax and all 10 exported names passed.

- default: 90,542 bytes on both revisions
- all opt-ins (--global-rename --fold-constants --aggressive-table-read-merges): 90,147 bytes on both revisions
- all measured option combinations were byte-identical; focused factory/helper integration fixtures cover concrete output gains, but this corpus contains no additional accepted size reduction
- five all-opt-in in-process runs: current median 4.658 s (3.812–4.988), develop median 3.136 s (2.998–3.384), approximately +49%
- diagnostic records: current 436 accepted / 1,545 rejected; develop 17 / 224. The increase largely exposes proof/rejection evidence and is not itself an output gain.

## Future reduction opportunities

The byte-identical n-tracs result means that currently resolved module-local calls do not add a final-cost-positive rewrite in this corpus. Remaining opportunities are explicit:

- Calls through required module exports and table members are intentionally unknown today. A linked-program snapshot or explicit module contracts can summarize those edges without name-based guessing; n-tracs uses these call shapes heavily.
- #76 can consume return, alias, escape, effect, and call-graph evidence for general inlining, parameter pruning, and function DCE. Those transformations are deliberately not hidden inside #74.
- Current consumers are narrow: factory table reads, helper field effects, and very small pure zero-argument constants. Extending constant/value and table-shape consumers while retaining the final artifact cost gate can turn more resolved summaries into byte reductions.
- Diagnostics show where evidence exists and where unknown-call-target remains dominant. Future work should compare newly accepted output transformations, not count summary diagnostics as gains.
- The approximately 49% corpus runtime increase is a clear optimization target. Reusing summaries across unchanged generations, skipping construction when no consumer is enabled, and materializing detailed diagnostics lazily can reduce it without weakening soundness.

Closes #74