### PR TITLE
Implement liveness-based identifier coloring

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ Luaコード内で完結し、意味論を変更しない最適化は既定で�
 - `--no-remove-unused-globals`: 将来追加する未使用グローバル削除だけを無効にします（ローカル削除は続けます）
 - `--reserved-globals-config <path>`: `{"neverRenameGlobals": ["name", ...]}`形式のJSONファイルを指定し、**代入されていても常にリネームしないグローバル名**を列挙します
 
+ローカル識別子は、CFGのlivenessから作る干渉グラフを重み付きでcoloringし、同時に生きないlocal・parameter・for変数へ同じ短名を再利用します。branch join、loop back-edge、upvalue capture、字句shadowingを考慮し、割当後には全参照を再Resolveして元と同じ宣言へ結び付くことを検証します。`stormworks` profileではdebug APIによるlocal lifetime観測がないため同一scope内でも再利用します。`lua53` profileでは既定で同一scope内の再利用を抑止し、`--allow-local-lifetime-changes`を明示した場合だけ有効にします。`--@storm keep-name`、予約global、module splice、Source Map上の元identifier名は従来どおり維持されます。
+
 ## 定数の事前計算と定数伝搬（opt-in）
 
 `--fold-constants`を指定すると、定数式の事前計算（例: `1+2`を`3`に）と、再代入されない定数ローカル変数の伝搬（例: `local x=1 print(x)`を`print(1)`に）を行います。上記の識別子短縮関連のオプションと違い、**このオプションは既定では無効**です（指定しない限り、このパスは一切実行されません）。

--- a/src/minifier.ts
+++ b/src/minifier.ts
@@ -348,23 +348,33 @@ export class Minifier {
       return;
     }
     this.linkOrder.forEach((moduleName) => {
+      const ast = this.moduleAST.get(moduleName);
       const resolved = this.moduleResolve.get(moduleName);
-      if (!resolved) {
+      if (!ast || !resolved) {
         throw new Error(moduleName + " is not found");
       }
-      const result = assignRenames(
-        resolved,
-        this.identifiersInUse,
-        this.globalRenames,
-        new Set(
-          resolved.symbols.filter(
-            (symbol) =>
-              this.getSourceMetadata(moduleName).annotationsOfIdentifier(
-                symbol.declaration,
-              ).keepName,
+      const runtime = runtimeEnvironmentOf(this.mode.runtimeProfile ?? "lua53");
+      const result =
+        this.renameCache.get(moduleName) ??
+        assignRenames(
+          ast,
+          resolved,
+          this.identifiersInUse,
+          this.globalRenames,
+          new Set(
+            resolved.symbols.filter(
+              (symbol) =>
+                this.getSourceMetadata(moduleName).annotationsOfIdentifier(
+                  symbol.declaration,
+                ).keepName,
+            ),
           ),
-        ),
-      );
+          {
+            allowLocalNameReuse:
+              !runtime.semantics.debugLocalIntrospection ||
+              this.mode.allowLocalLifetimeChanges === true,
+          },
+        );
       this.renameCache.set(moduleName, result);
       result.usedNames.forEach((name) => this.identifiersInUse.add(name));
     });
@@ -442,6 +452,9 @@ export class Minifier {
         this.mode.effectAwareTransforms !== false &&
         (!runtime.semantics.debugLocalIntrospection ||
           this.mode.allowLocalLifetimeChanges === true);
+      const localNameReuseEnabled =
+        !runtime.semantics.debugLocalIntrospection ||
+        this.mode.allowLocalLifetimeChanges === true;
       const keepNames = new Set(
         resolved.symbols.filter(
           (symbol) =>
@@ -457,14 +470,27 @@ export class Minifier {
             (this.mode.effectAwareLocalHoist !== false ||
               this.mode.effectAwareTableReads !== false)))
       ) {
+        const provisionalAnalysis =
+          this.mode.rename === false ? undefined : optimizerAnalysis();
         const provisionalRenames =
           this.mode.rename === false
             ? NO_RENAME
             : assignRenames(
+                ast,
                 resolved,
                 plannedIdentifiersInUse,
                 this.globalRenames,
                 keepNames,
+                {
+                  allowLocalNameReuse: localNameReuseEnabled,
+                  analysis: provisionalAnalysis
+                    ? {
+                        facts: provisionalAnalysis.facts,
+                        liveness:
+                          provisionalAnalysis.statementDataflow.symbolLiveness,
+                      }
+                    : undefined,
+                },
               );
         passes.run("statement-scheduler", (currentResolve) => {
           const analysis = optimizerAnalysis();
@@ -562,12 +588,21 @@ export class Minifier {
               ).keepName,
           ),
         );
-        assignRenames(
+        // plannedIdentifiersInUse advances in the same link order as renameAll.
+        // Cache this final-generation result so Print does not rebuild the same
+        // facts, CFG, liveness, graph, and binding proof a second time.
+        const finalRename = assignRenames(
+          ast,
           resolved,
           plannedIdentifiersInUse,
           this.globalRenames,
           finalKeepNames,
-        ).usedNames.forEach((name) => plannedIdentifiersInUse.add(name));
+          { allowLocalNameReuse: localNameReuseEnabled },
+        );
+        this.renameCache.set(moduleName, finalRename);
+        finalRename.usedNames.forEach((name) =>
+          plannedIdentifiersInUse.add(name),
+        );
       }
     });
   }

--- a/src/renamer.ts
+++ b/src/renamer.ts
@@ -2,21 +2,21 @@
 // シンボル単位で短縮識別子を割り当てる。printer（ast2lua.ts）は出力時の
 // その場リネームを行わず、このパスが決めた名前を参照するだけになる。
 //
-// 割当は2段階で行う。
-//   1. スロット割当: スコープ木を辿り、各シンボルに整数のスロットを割り当てる。
-//      兄弟スコープ同士（親子関係にないスコープ同士）は生存区間が重ならないため、
-//      同じスロットを再利用できる（圧縮率の向上）。同一スコープ内のシンボル同士・
-//      祖先スコープのシンボルとは必ず異なるスロットになるため、シンボルの生存
-//      スコープ内で名前が衝突することはない。
-//   2. 名前割当: スロットごとの参照回数（頻度）を集計し、頻度の高いスロットから
-//      順に短い名前を割り当てる。頻度の高いシンボルほど短い名前になるため、
-//      同じスロット数でも出力サイズが最小化される。
+// CFG livenessから干渉グラフを作り、同時に生きないlocalへ同じ色を割り当てる。
+// resolverのscope関係による字句衝突辺と、割当名による再Resolve検証を併用し、
+// shadowingやcaptureで参照先が変わらないことを保証する。
 //
 // 予約語・"self"・呼び出し側が指定する予約名（グローバル参照やStormworks APIなど）
 // は、どのシンボルにも割り当てられない。
 import Parser from "luaparse";
-import { Scope, Symbol, ResolveResult } from "./resolver";
+import { Scope, Symbol, ResolveResult, resolveScopes } from "./resolver";
 import { IDENTIFIER_PARTS, isKeyword } from "./ast2lua";
+import { analyzeControlFlow } from "./controlFlow";
+import { analyzeOptimizerFacts, OptimizerFacts } from "./optimizerFacts";
+import {
+  analyzeSymbolLiveness,
+  SymbolLivenessAnalysis,
+} from "./symbolLiveness";
 
 export interface RenameResult {
   // identifierがResolveパスで解決済みのローカルシンボルに対応する場合、
@@ -52,37 +52,18 @@ export function generateCandidate(counter: number): string {
   return id;
 }
 
-/**
- * スコープ木のDFSでシンボルごとにスロット番号を割り当てる。
- * `active`は祖先スコープ（自分を含む）で既に使われているスロットの集合。
- * 兄弟スコープには同じ`active`のコピーが渡されるため、互いの割当は影響しない。
- */
-function assignSlots(
-  scope: Scope,
-  active: ReadonlySet<number>,
-): Map<Symbol, number> {
-  const slotOf = new Map<Symbol, number>();
-  const used = new Set(active);
-
-  scope.symbols.forEach((symbol) => {
-    let slot = 0;
-    while (used.has(slot)) {
-      slot++;
-    }
-    slotOf.set(symbol, slot);
-    used.add(slot);
-  });
-
-  scope.children.forEach((child) => {
-    assignSlots(child, used).forEach((slot, symbol) => {
-      slotOf.set(symbol, slot);
-    });
-  });
-
-  return slotOf;
+export interface RenameOptions {
+  /** Allow same-scope lifetime reuse when local lifetime is not observable. */
+  readonly allowLocalNameReuse?: boolean;
+  /** Reuse the exact optimizer generation already built by the scheduler. */
+  readonly analysis?: {
+    readonly facts: OptimizerFacts;
+    readonly liveness: SymbolLivenessAnalysis;
+  };
 }
 
 export function assignRenames(
+  chunk: Parser.Chunk,
   resolveResult: ResolveResult,
   reserved: ReadonlySet<string>,
   // #8a: プログラム全体を横断して決定されたグローバル識別子の短縮名。
@@ -90,47 +71,42 @@ export function assignRenames(
   // 共有される1つのランタイム束縛に一貫した短縮名を割り当てられる。
   globalRenames?: ReadonlyMap<string, string>,
   keepNames: ReadonlySet<Symbol> = new Set(),
+  options: RenameOptions = {},
 ): RenameResult {
-  const slotOf = assignSlots(resolveResult.chunkScope, new Set());
-
-  // スロットの通算参照回数（宣言自体も1回として数える）を集計する。
-  const weightOfSlot = new Map<number, number>();
-  resolveResult.symbols.forEach((symbol) => {
-    const slot = slotOf.get(symbol);
-    if (slot === undefined) {
-      return;
-    }
-    const weight = symbol.references.length + 1;
-    weightOfSlot.set(slot, (weightOfSlot.get(slot) ?? 0) + weight);
-  });
-
-  const orderedSlots = [...weightOfSlot.keys()].sort(
-    (a, b) => (weightOfSlot.get(b) ?? 0) - (weightOfSlot.get(a) ?? 0),
-  );
-
-  const nameOfSlot = new Map<number, string>();
   const unavailableNames = new Set(reserved);
   keepNames.forEach((symbol) => unavailableNames.add(symbol.name));
-  let counter = 0;
-  orderedSlots.forEach((slot) => {
-    let candidate: string;
-    do {
-      candidate = generateCandidate(counter++);
-    } while (!isAvailable(candidate, unavailableNames));
-    unavailableNames.add(candidate);
-    nameOfSlot.set(slot, candidate);
-  });
+  const variables = resolveResult.symbols.filter(
+    (symbol) =>
+      symbol.kind !== "label" &&
+      symbol.name !== "self" &&
+      !keepNames.has(symbol),
+  );
+  const variableGraph = buildVariableInterference(
+    chunk,
+    resolveResult,
+    variables,
+    options.allowLocalNameReuse === true,
+    options.analysis,
+  );
+  const variableColors = colorGraph(variableGraph);
+  const variableNames = assignColorNames(variableColors, unavailableNames);
 
-  const nameOfSymbol = new Map<Symbol, string>();
-  slotOf.forEach((slot, symbol) => {
-    if (keepNames.has(symbol)) {
-      return;
-    }
-    const name = nameOfSlot.get(slot);
-    if (name !== undefined) {
-      nameOfSymbol.set(symbol, name);
-    }
-  });
+  // Labels have a separate Lua namespace. Color them independently so a label
+  // and a local may share a short spelling, while usedNames still reserves the
+  // spelling against labels from subsequently spliced modules.
+  const labels = resolveResult.symbols.filter(
+    (symbol) =>
+      symbol.kind === "label" &&
+      symbol.name !== "self" &&
+      !keepNames.has(symbol),
+  );
+  const labelNames = assignColorNames(
+    colorGraph(buildLexicalGraph(labels, false)),
+    unavailableNames,
+  );
+  const nameOfSymbol = new Map([...variableNames, ...labelNames]);
+  validateBindings(chunk, resolveResult, nameOfSymbol, globalRenames);
+  const usedNames = new Set(nameOfSymbol.values());
 
   return {
     nameOf: (identifier) => {
@@ -151,6 +127,257 @@ export function assignRenames(
       }
       return undefined;
     },
-    usedNames: new Set(nameOfSlot.values()),
+    usedNames,
   };
+}
+
+type InterferenceGraph = ReadonlyMap<Symbol, ReadonlySet<Symbol>>;
+
+function buildVariableInterference(
+  chunk: Parser.Chunk,
+  resolved: ResolveResult,
+  symbols: readonly Symbol[],
+  allowLocalNameReuse: boolean,
+  analysis: RenameOptions["analysis"],
+): InterferenceGraph {
+  const graph = mutableGraph(symbols);
+  const facts = analysis?.facts ?? analyzeOptimizerFacts(chunk, resolved);
+  const liveness =
+    analysis?.liveness ??
+    analyzeSymbolLiveness(analyzeControlFlow(chunk, resolved), facts);
+  if (facts.generation !== liveness.controlFlow.version)
+    throw new Error("Identifier coloring requires one AST generation");
+
+  liveness.controlFlow.nodes.forEach((node) => {
+    addClique(graph, liveness.liveIn(node));
+    addClique(graph, liveness.liveOut(node));
+    liveness.defs(node).forEach((definition) => {
+      liveness.liveOut(node).forEach((live) => {
+        addEdge(graph, definition, live);
+      });
+    });
+  });
+
+  // Parameters, generic-for variables, and multi-local declarations bind as a
+  // group. Giving two members one spelling would make only the last binding
+  // addressable after reparsing even if one member happens to be unused.
+  const declarationsByOwner = new Map<Parser.Statement, Symbol[]>();
+  symbols.forEach((symbol) => {
+    const declaration = facts
+      .operationsOfSymbol(symbol)
+      .find(
+        (operation) =>
+          operation.kind === "declare" &&
+          operation.origin === symbol.declaration,
+      );
+    if (!declaration) return;
+    const group = declarationsByOwner.get(declaration.owner) ?? [];
+    group.push(symbol);
+    declarationsByOwner.set(declaration.owner, group);
+  });
+  declarationsByOwner.forEach((group) => {
+    addClique(graph, group);
+  });
+
+  // A captured binding can be shadowed inside the closure by any same-scope
+  // declaration whose emitted spelling matches it (notably `local function`).
+  // Extending this lexical interference across the whole declaring scope is
+  // conservative, deterministic, and leaves ordinary non-captured locals free
+  // to reuse names according to liveness.
+  symbols.forEach((symbol) => {
+    const captured = facts
+      .operationsOfSymbol(symbol)
+      .some(
+        (operation) =>
+          "location" in operation && operation.location.kind === "upvalue",
+      );
+    if (!captured) return;
+    symbols.forEach((other) => {
+      if (other.scope === symbol.scope) addEdge(graph, symbol, other);
+    });
+  });
+
+  addLexicalEdges(graph, symbols, allowLocalNameReuse);
+  return graph;
+}
+
+function buildLexicalGraph(
+  symbols: readonly Symbol[],
+  allowSameScopeReuse: boolean,
+): InterferenceGraph {
+  const graph = mutableGraph(symbols);
+  addLexicalEdges(graph, symbols, allowSameScopeReuse);
+  return graph;
+}
+
+function mutableGraph(symbols: readonly Symbol[]): Map<Symbol, Set<Symbol>> {
+  return new Map(symbols.map((symbol) => [symbol, new Set<Symbol>()]));
+}
+
+function addLexicalEdges(
+  graph: Map<Symbol, Set<Symbol>>,
+  symbols: readonly Symbol[],
+  allowSameScopeReuse: boolean,
+): void {
+  for (let left = 0; left < symbols.length; left++) {
+    for (let right = left + 1; right < symbols.length; right++) {
+      const first = symbols[left];
+      const last = symbols[right];
+      if (
+        isAncestor(first.scope, last.scope) ||
+        isAncestor(last.scope, first.scope) ||
+        (!allowSameScopeReuse && first.scope === last.scope)
+      )
+        addEdge(graph, first, last);
+    }
+  }
+}
+
+function isAncestor(ancestor: Scope, descendant: Scope): boolean {
+  if (ancestor === descendant) return false;
+  for (let current = descendant.parent; current; current = current.parent)
+    if (current === ancestor) return true;
+  return false;
+}
+
+function addClique(
+  graph: Map<Symbol, Set<Symbol>>,
+  symbols: ReadonlySet<Symbol> | readonly Symbol[],
+): void {
+  const present = [...symbols].filter((symbol) => graph.has(symbol));
+  for (let left = 0; left < present.length; left++)
+    for (let right = left + 1; right < present.length; right++)
+      addEdge(graph, present[left], present[right]);
+}
+
+function addEdge(
+  graph: Map<Symbol, Set<Symbol>>,
+  first: Symbol,
+  last: Symbol,
+): void {
+  if (first === last || !graph.has(first) || !graph.has(last)) return;
+  graph.get(first)?.add(last);
+  graph.get(last)?.add(first);
+}
+
+/** Deterministic weighted DSATUR coloring. */
+function colorGraph(graph: InterferenceGraph): Map<Symbol, number> {
+  const colors = new Map<Symbol, number>();
+  while (colors.size < graph.size) {
+    const remaining = [...graph.keys()].filter((symbol) => !colors.has(symbol));
+    remaining.sort((left, right) => {
+      const saturationDifference =
+        saturation(graph, colors, right) - saturation(graph, colors, left);
+      if (saturationDifference !== 0) return saturationDifference;
+      const weightDifference = weightOf(right) - weightOf(left);
+      if (weightDifference !== 0) return weightDifference;
+      const degreeDifference =
+        (graph.get(right)?.size ?? 0) - (graph.get(left)?.size ?? 0);
+      return degreeDifference !== 0 ? degreeDifference : left.id - right.id;
+    });
+    const symbol = remaining[0];
+    const unavailable = new Set(
+      [...(graph.get(symbol) ?? [])].flatMap((neighbor) => {
+        const color = colors.get(neighbor);
+        return color === undefined ? [] : [color];
+      }),
+    );
+    let color = 0;
+    while (unavailable.has(color)) color++;
+    colors.set(symbol, color);
+  }
+  return colors;
+}
+
+function saturation(
+  graph: InterferenceGraph,
+  colors: ReadonlyMap<Symbol, number>,
+  symbol: Symbol,
+): number {
+  return new Set(
+    [...(graph.get(symbol) ?? [])].flatMap((neighbor) => {
+      const color = colors.get(neighbor);
+      return color === undefined ? [] : [color];
+    }),
+  ).size;
+}
+
+function weightOf(symbol: Symbol): number {
+  return symbol.references.length + 1;
+}
+
+function assignColorNames(
+  colors: ReadonlyMap<Symbol, number>,
+  reserved: ReadonlySet<string>,
+): Map<Symbol, string> {
+  const unavailable = new Set(reserved);
+  const weightByColor = new Map<number, number>();
+  const firstSymbolByColor = new Map<number, number>();
+  colors.forEach((color, symbol) => {
+    weightByColor.set(
+      color,
+      (weightByColor.get(color) ?? 0) + weightOf(symbol),
+    );
+    firstSymbolByColor.set(
+      color,
+      Math.min(firstSymbolByColor.get(color) ?? symbol.id, symbol.id),
+    );
+  });
+  const orderedColors = [...weightByColor.keys()].sort(
+    (left, right) =>
+      (weightByColor.get(right) ?? 0) - (weightByColor.get(left) ?? 0) ||
+      (firstSymbolByColor.get(left) ?? 0) -
+        (firstSymbolByColor.get(right) ?? 0),
+  );
+  const nameByColor = new Map<number, string>();
+  let counter = 0;
+  orderedColors.forEach((color) => {
+    let candidate: string;
+    do candidate = generateCandidate(counter++);
+    while (!isAvailable(candidate, unavailable));
+    unavailable.add(candidate);
+    nameByColor.set(color, candidate);
+  });
+
+  // Every candidate is an identifier token and keywords are excluded, so the
+  // separator cost around each occurrence is invariant across candidates.
+  // Occurrence count therefore gives the exact candidate-dependent byte cost.
+  const result = new Map<Symbol, string>();
+  colors.forEach((color, symbol) => {
+    const name = nameByColor.get(color);
+    if (name === undefined) throw new Error("Colored symbol has no name");
+    result.set(symbol, name);
+  });
+  return result;
+}
+
+function validateBindings(
+  chunk: Parser.Chunk,
+  original: ResolveResult,
+  names: ReadonlyMap<Symbol, string>,
+  globalRenames: ReadonlyMap<string, string> | undefined,
+): void {
+  const recolored = resolveScopes(chunk, {
+    identifierName: (identifier) => {
+      const symbol = original.symbolOf(identifier);
+      if (symbol) return names.get(symbol) ?? identifier.name;
+      return original.isGlobalReference(identifier)
+        ? (globalRenames?.get(identifier.name) ?? identifier.name)
+        : identifier.name;
+    },
+  });
+  original.symbols.forEach((symbol) => {
+    [symbol.declaration, ...symbol.references].forEach((identifier) => {
+      if (recolored.symbolOf(identifier)?.declaration !== symbol.declaration)
+        throw new Error(
+          `Identifier coloring changed binding for symbol ${String(symbol.id)}`,
+        );
+    });
+  });
+  original.globals.forEach((binding) => {
+    binding.references.forEach((identifier) => {
+      if (!recolored.isGlobalReference(identifier))
+        throw new Error(`Identifier coloring captured global ${binding.name}`);
+    });
+  });
 }

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -50,6 +50,11 @@ export interface ResolveResult {
   scopeOfFunction(fn: Parser.FunctionDeclaration): Scope | undefined;
 }
 
+export interface ResolveOptions {
+  /** Resolve an identifier using its emitted spelling without mutating the AST. */
+  readonly identifierName?: (identifier: Parser.Identifier) => string;
+}
+
 interface MutableScope extends Scope {
   readonly parent: MutableScope | null;
   readonly children: MutableScope[];
@@ -57,13 +62,19 @@ interface MutableScope extends Scope {
   readonly labels: Map<string, Symbol>;
 }
 
-export function resolveScopes(chunk: Parser.Chunk): ResolveResult {
+export function resolveScopes(
+  chunk: Parser.Chunk,
+  options: ResolveOptions = {},
+): ResolveResult {
   let nextSymbolId = 0;
   const allSymbols: Symbol[] = [];
   const globals = new Map<string, GlobalBinding>();
   const identifierSymbols = new WeakMap<Parser.Identifier, Symbol>();
   const globalReferenceNodes = new WeakSet<Parser.Identifier>();
   const functionScopes = new WeakMap<Parser.FunctionDeclaration, Scope>();
+  const identifierName =
+    options.identifierName ??
+    ((identifier: Parser.Identifier) => identifier.name);
 
   function createScope(
     kind: Scope["kind"],
@@ -86,9 +97,10 @@ export function resolveScopes(chunk: Parser.Chunk): ResolveResult {
     node: Parser.Identifier,
     kind: SymbolKind,
   ): Symbol {
+    const name = identifierName(node);
     const symbol: Symbol = {
       id: nextSymbolId++,
-      name: node.name,
+      name,
       kind,
       scope,
       declaration: node,
@@ -96,23 +108,24 @@ export function resolveScopes(chunk: Parser.Chunk): ResolveResult {
     };
     // 同名の再宣言はスコープ内の以後の参照から見た束縛を上書きする（Luaの通常のシャドーイング）
     scope.symbols.push(symbol);
-    scope.bindings.set(node.name, symbol);
+    scope.bindings.set(name, symbol);
     allSymbols.push(symbol);
     identifierSymbols.set(node, symbol);
     return symbol;
   }
 
   function declareLabel(scope: MutableScope, node: Parser.Identifier): Symbol {
+    const name = identifierName(node);
     const symbol: Symbol = {
       id: nextSymbolId++,
-      name: node.name,
+      name,
       kind: "label",
       scope,
       declaration: node,
       references: [],
     };
     scope.symbols.push(symbol);
-    scope.labels.set(node.name, symbol);
+    scope.labels.set(name, symbol);
     allSymbols.push(symbol);
     identifierSymbols.set(node, symbol);
     return symbol;
@@ -146,16 +159,17 @@ export function resolveScopes(chunk: Parser.Chunk): ResolveResult {
     node: Parser.Identifier,
     isWrite = false,
   ) {
-    const symbol = lookupBinding(scope, node.name);
+    const name = identifierName(node);
+    const symbol = lookupBinding(scope, name);
     if (symbol) {
       symbol.references.push(node);
       identifierSymbols.set(node, symbol);
       return;
     }
-    let binding = globals.get(node.name);
+    let binding = globals.get(name);
     if (!binding) {
-      binding = { name: node.name, references: [], writes: [] };
-      globals.set(node.name, binding);
+      binding = { name, references: [], writes: [] };
+      globals.set(name, binding);
     }
     binding.references.push(node);
     if (isWrite) {
@@ -270,7 +284,7 @@ export function resolveScopes(chunk: Parser.Chunk): ResolveResult {
         // hoistLabelsで宣言済みのため、ここでは何もしない
         return;
       case "GotoStatement": {
-        const symbol = lookupLabel(scope, statement.label.name);
+        const symbol = lookupLabel(scope, identifierName(statement.label));
         if (symbol) {
           symbol.references.push(statement.label);
           identifierSymbols.set(statement.label, symbol);

--- a/src/statementDataflow.ts
+++ b/src/statementDataflow.ts
@@ -2,6 +2,10 @@ import Parser from "luaparse";
 import { ControlFlowAnalysis, ControlFlowNode } from "./controlFlow";
 import { Location, OptimizerFacts, OptimizerOperation } from "./optimizerFacts";
 import { GlobalBinding, Symbol } from "./resolver";
+import {
+  analyzeSymbolLiveness,
+  SymbolLivenessAnalysis,
+} from "./symbolLiveness";
 import { ValueFlowAnalysis } from "./valueFlow";
 
 export type DependenceKind =
@@ -25,6 +29,7 @@ export interface StatementDependenceEdge {
 export interface StatementDataflowAnalysis {
   readonly generation: number;
   readonly controlFlow: ControlFlowAnalysis;
+  readonly symbolLiveness: SymbolLivenessAnalysis;
   readonly dependencies: readonly StatementDependenceEdge[];
   liveIn(node: ControlFlowNode): ReadonlySet<Symbol>;
   liveOut(node: ControlFlowNode): ReadonlySet<Symbol>;
@@ -75,10 +80,6 @@ export function analyzeStatementDataflow(
   const controlFlow = valueFlow.controlFlow;
   const symbolIds = new Map<Symbol, number>();
   const globalIds = new Map<GlobalBinding, number>();
-  const directUses = new Map<ControlFlowNode, ReadonlySet<Symbol>>();
-  const directDefs = new Map<ControlFlowNode, ReadonlySet<Symbol>>();
-  const liveIn = new Map<ControlFlowNode, ReadonlySet<Symbol>>();
-  const liveOut = new Map<ControlFlowNode, ReadonlySet<Symbol>>();
   const dependencies: StatementDependenceEdge[] = [];
   const dependenciesByFrom = new WeakMap<
     Parser.Statement,
@@ -184,70 +185,7 @@ export function analyzeStatementDataflow(
     };
   };
 
-  controlFlow.nodes.forEach((node) => {
-    const statement = node.statement;
-    if (!statement) {
-      directUses.set(node, new Set());
-      directDefs.set(node, new Set());
-      return;
-    }
-    const operations = facts.operationsOf(statement);
-    directUses.set(
-      node,
-      new Set(
-        operations.flatMap((operation) => {
-          if (operation.kind !== "read") return [];
-          return symbolOfLocation(operation.location)
-            ? [symbolOfLocation(operation.location) as Symbol]
-            : [];
-        }),
-      ),
-    );
-    directDefs.set(
-      node,
-      new Set(
-        operations.flatMap((operation) => {
-          if (operation.kind !== "write" && operation.kind !== "declare")
-            return [];
-          return symbolOfLocation(operation.location)
-            ? [symbolOfLocation(operation.location) as Symbol]
-            : [];
-        }),
-      ),
-    );
-  });
-
-  controlFlow.units.forEach((unit) => {
-    const unitNodes = controlFlow.nodes.filter((node) => node.unit === unit);
-    unitNodes.forEach((node) => {
-      liveIn.set(node, new Set());
-      liveOut.set(node, new Set());
-    });
-    let changed = true;
-    while (changed) {
-      changed = false;
-      // Node construction is reverse lexical order, which is the natural order for backward liveness.
-      unitNodes.forEach((node) => {
-        const nextOut = new Set<Symbol>();
-        node.successors.forEach((edge) =>
-          liveIn.get(edge.to)?.forEach((symbol) => nextOut.add(symbol)),
-        );
-        const nextIn = new Set(directUses.get(node) ?? []);
-        nextOut.forEach((symbol) => {
-          if (!(directDefs.get(node) ?? new Set()).has(symbol))
-            nextIn.add(symbol);
-        });
-        if (!setsEqual(liveOut.get(node), nextOut)) {
-          liveOut.set(node, nextOut);
-          changed = true;
-        }
-        if (!setsEqual(liveIn.get(node), nextIn)) {
-          liveIn.set(node, nextIn);
-          changed = true;
-        }
-      });
-    }
-  });
+  const liveness = analyzeSymbolLiveness(controlFlow, facts);
 
   const analyzeBody = (body: Parser.Statement[]): void => {
     body.forEach((statement, index) => {
@@ -285,16 +223,17 @@ export function analyzeStatementDataflow(
   return {
     generation: facts.generation,
     controlFlow,
+    symbolLiveness: liveness,
     dependencies,
-    liveIn: (node) => liveIn.get(node) ?? new Set(),
-    liveOut: (node) => liveOut.get(node) ?? new Set(),
+    liveIn: (node) => liveness.liveIn(node),
+    liveOut: (node) => liveness.liveOut(node),
     isLiveBefore: (statement, symbol) => {
       const node = controlFlow.nodeOf(statement);
-      return !!node && (liveIn.get(node)?.has(symbol) ?? false);
+      return !!node && liveness.liveIn(node).has(symbol);
     },
     isLiveAfter: (statement, symbol) => {
       const node = controlFlow.nodeOf(statement);
-      return !!node && (liveOut.get(node)?.has(symbol) ?? false);
+      return !!node && liveness.liveOut(node).has(symbol);
     },
     dependenciesBetween: (first, last) =>
       dependenciesByFrom.get(first)?.get(last) ?? [],
@@ -406,25 +345,6 @@ function deduplicateAccesses(accesses: readonly Access[]): Access[] {
     seen.add(access.identity);
     return true;
   });
-}
-
-function symbolOfLocation(location: Location): Symbol | undefined {
-  return location.kind === "local" ||
-    location.kind === "parameter" ||
-    location.kind === "upvalue"
-    ? location.symbol
-    : undefined;
-}
-
-function setsEqual<T>(
-  left: ReadonlySet<T> | undefined,
-  right: ReadonlySet<T>,
-): boolean {
-  return (
-    !!left &&
-    left.size === right.size &&
-    [...left].every((item) => right.has(item))
-  );
 }
 
 function isExpression(node: Parser.Node): node is Parser.Expression {

--- a/src/symbolLiveness.ts
+++ b/src/symbolLiveness.ts
@@ -1,0 +1,118 @@
+import { ControlFlowAnalysis, ControlFlowNode } from "./controlFlow";
+import { OptimizerFacts, OptimizerOperation } from "./optimizerFacts";
+import { Symbol } from "./resolver";
+
+export interface SymbolLivenessAnalysis {
+  readonly controlFlow: ControlFlowAnalysis;
+  uses(node: ControlFlowNode): ReadonlySet<Symbol>;
+  defs(node: ControlFlowNode): ReadonlySet<Symbol>;
+  liveIn(node: ControlFlowNode): ReadonlySet<Symbol>;
+  liveOut(node: ControlFlowNode): ReadonlySet<Symbol>;
+}
+
+/**
+ * Computes the symbol liveness shared by scheduling and identifier coloring.
+ * Nested functions are independent CFG units; upvalue reads remain uses in the
+ * nested unit, while parameter declarations owned by a function syntax node
+ * must not be mistaken for definitions in its parent's unit.
+ */
+export function analyzeSymbolLiveness(
+  controlFlow: ControlFlowAnalysis,
+  facts: OptimizerFacts,
+): SymbolLivenessAnalysis {
+  const directUses = new Map<ControlFlowNode, ReadonlySet<Symbol>>();
+  const directDefs = new Map<ControlFlowNode, ReadonlySet<Symbol>>();
+  const liveIn = new Map<ControlFlowNode, ReadonlySet<Symbol>>();
+  const liveOut = new Map<ControlFlowNode, ReadonlySet<Symbol>>();
+
+  controlFlow.nodes.forEach((node) => {
+    const operations = node.statement ? facts.operationsOf(node.statement) : [];
+    directUses.set(
+      node,
+      new Set(
+        operations.flatMap((operation) => {
+          if (operation.kind !== "read") return [];
+          const symbol = symbolOf(operation);
+          return symbol ? [symbol] : [];
+        }),
+      ),
+    );
+    directDefs.set(
+      node,
+      new Set(
+        operations.flatMap((operation) => {
+          if (operation.kind !== "write" && operation.kind !== "declare")
+            return [];
+          const symbol = symbolOf(operation);
+          if (!symbol) return [];
+          // Parameter declaration operations are attached to the function
+          // syntax node in its parent unit. Their simultaneous binding is
+          // represented explicitly by the interference builder instead.
+          return operation.kind === "declare" && symbol.kind === "param"
+            ? []
+            : [symbol];
+        }),
+      ),
+    );
+  });
+
+  controlFlow.units.forEach((unit) => {
+    const unitNodes = controlFlow.nodes.filter((node) => node.unit === unit);
+    unitNodes.forEach((node) => {
+      liveIn.set(node, new Set());
+      liveOut.set(node, new Set());
+    });
+    let changed = true;
+    while (changed) {
+      changed = false;
+      // CFG nodes are built in reverse lexical order, which is a useful and
+      // deterministic work-list order for this backward fixed point.
+      unitNodes.forEach((node) => {
+        const nextOut = new Set<Symbol>();
+        node.successors.forEach((edge) =>
+          liveIn.get(edge.to)?.forEach((symbol) => nextOut.add(symbol)),
+        );
+        const nextIn = new Set(directUses.get(node) ?? []);
+        nextOut.forEach((symbol) => {
+          if (!(directDefs.get(node) ?? new Set()).has(symbol))
+            nextIn.add(symbol);
+        });
+        if (!setsEqual(liveOut.get(node), nextOut)) {
+          liveOut.set(node, nextOut);
+          changed = true;
+        }
+        if (!setsEqual(liveIn.get(node), nextIn)) {
+          liveIn.set(node, nextIn);
+          changed = true;
+        }
+      });
+    }
+  });
+
+  return {
+    controlFlow,
+    uses: (node) => directUses.get(node) ?? new Set(),
+    defs: (node) => directDefs.get(node) ?? new Set(),
+    liveIn: (node) => liveIn.get(node) ?? new Set(),
+    liveOut: (node) => liveOut.get(node) ?? new Set(),
+  };
+}
+
+function symbolOf(operation: OptimizerOperation): Symbol | undefined {
+  if (!("location" in operation)) return undefined;
+  const location = operation.location;
+  return location.kind === "local" ||
+    location.kind === "parameter" ||
+    location.kind === "upvalue"
+    ? location.symbol
+    : undefined;
+}
+
+function setsEqual<T>(
+  left: ReadonlySet<T> | undefined,
+  right: ReadonlySet<T>,
+): boolean {
+  if (!left || left.size !== right.size) return false;
+  for (const value of left) if (!right.has(value)) return false;
+  return true;
+}

--- a/test/renamer.integration.test.ts
+++ b/test/renamer.integration.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from "vitest";
+import { SourceMapConsumer } from "source-map";
+import { minifyTemporaryLuaSource } from "./lib/minifierHarness";
+import { runMinifier, WORKING_CASES } from "./lib/helpers";
+
+const SOURCE = `local first = 1
+use(first)
+local second = 2
+use(second)
+`;
+
+const BASE_MODE = {
+  moduleLikeLua: false,
+  mergeLocals: false,
+  effectAwareLocalHoist: false,
+  effectAwareTableReads: false,
+  globalAlias: false,
+  removeUnused: false,
+} as const;
+
+describe("liveness-based identifier coloring", () => {
+  test("reuses a same-scope name and preserves each Source Map origin", async () => {
+    const result = minifyTemporaryLuaSource(SOURCE, {
+      ...BASE_MODE,
+      runtimeProfile: "stormworks",
+    });
+
+    expect(result.code.replaceAll("\n", " ")).toBe(
+      "local a=1 use(a)local a=2 use(a)",
+    );
+    expect(result.map.names).toEqual(
+      expect.arrayContaining(["first", "second"]),
+    );
+    await SourceMapConsumer.with(result.map, null, (consumer) => {
+      const first = consumer.generatedPositionFor({
+        source: "main.lua",
+        line: 1,
+        column: 6,
+      });
+      const second = consumer.generatedPositionFor({
+        source: "main.lua",
+        line: 3,
+        column: 6,
+      });
+      if (
+        first.line === null ||
+        first.column === null ||
+        second.line === null ||
+        second.column === null
+      )
+        throw new Error("renamed declarations must have generated mappings");
+      expect(
+        consumer.originalPositionFor({
+          line: first.line,
+          column: first.column,
+        }).name,
+      ).toBe("first");
+      expect(
+        consumer.originalPositionFor({
+          line: second.line,
+          column: second.column,
+        }).name,
+      ).toBe("second");
+    });
+  });
+
+  test("preserves distinct same-scope names in introspection mode", () => {
+    const preserved = minifyTemporaryLuaSource(SOURCE, {
+      ...BASE_MODE,
+      runtimeProfile: "lua53",
+    });
+    const optedIn = minifyTemporaryLuaSource(SOURCE, {
+      ...BASE_MODE,
+      runtimeProfile: "lua53",
+      allowLocalLifetimeChanges: true,
+    });
+
+    expect(preserved.code.replaceAll("\n", " ")).toBe(
+      "local a=1 use(a)local b=2 use(b)",
+    );
+    expect(optedIn.code.replaceAll("\n", " ")).toBe(
+      "local a=1 use(a)local a=2 use(a)",
+    );
+  });
+
+  test("never lengthens the existing fixture corpus", () => {
+    WORKING_CASES.forEach((fixture) => {
+      const common = {
+        ...fixture,
+        mode: {
+          ...fixture.mode,
+          mergeLocals: false,
+          effectAwareTransforms: false,
+          globalAlias: false,
+          removeUnused: false,
+        },
+      };
+      const colored = runMinifier({
+        ...common,
+        mode: { ...common.mode, runtimeProfile: "stormworks" },
+      }).code;
+      const conservative = runMinifier({
+        ...common,
+        mode: { ...common.mode, runtimeProfile: "lua53" },
+      }).code;
+      expect(Buffer.byteLength(colored), fixture.label).toBeLessThanOrEqual(
+        Buffer.byteLength(conservative),
+      );
+    });
+  });
+});

--- a/test/renamer.test.ts
+++ b/test/renamer.test.ts
@@ -23,7 +23,7 @@ test("sibling scopes (non-overlapping) reuse the same short name", () => {
     end
   `);
   const resolved = resolveScopes(chunk);
-  const result = assignRenames(resolved, new Set());
+  const result = assignRenames(chunk, resolved, new Set());
 
   const firstDecl = (
     (chunk.body[0] as Parser.DoStatement).body[0] as Parser.LocalStatement
@@ -46,12 +46,191 @@ test("symbols live in the same scope never receive the same short name", () => {
     print(a, b, c)
   `);
   const resolved = resolveScopes(chunk);
-  const result = assignRenames(resolved, new Set());
+  const result = assignRenames(chunk, resolved, new Set());
 
   const names = (chunk.body.slice(0, 3) as Parser.LocalStatement[]).map((s) =>
     result.nameOf(s.variables[0]),
   );
   assert.equal(new Set(names).size, 3);
+});
+
+test("same-scope symbols with disjoint liveness reuse one short name", () => {
+  const chunk = parse(`
+    local first = 1
+    print(first)
+    local second = 2
+    print(second)
+  `);
+  const resolved = resolveScopes(chunk);
+  const result = assignRenames(
+    chunk,
+    resolved,
+    new Set(),
+    undefined,
+    new Set(),
+    { allowLocalNameReuse: true },
+  );
+  const first = (chunk.body[0] as Parser.LocalStatement).variables[0];
+  const second = (chunk.body[2] as Parser.LocalStatement).variables[0];
+
+  assert.equal(result.nameOf(first), result.nameOf(second));
+});
+
+test("branch join and loop back-edge keep simultaneously live symbols apart", () => {
+  const chunk = parse(`
+    local branchValue = 0
+    if flag then branchValue = 1 else branchValue = 2 end
+    local loopValue = 0
+    while flag do loopValue = loopValue + branchValue end
+    print(branchValue, loopValue)
+  `);
+  const resolved = resolveScopes(chunk);
+  const result = assignRenames(
+    chunk,
+    resolved,
+    new Set(),
+    undefined,
+    new Set(),
+    { allowLocalNameReuse: true },
+  );
+  const branchValue = (chunk.body[0] as Parser.LocalStatement).variables[0];
+  const loopValue = (chunk.body[2] as Parser.LocalStatement).variables[0];
+
+  assert.notEqual(result.nameOf(branchValue), result.nameOf(loopValue));
+});
+
+test("a captured ancestor never collides with a nested local", () => {
+  const chunk = parse(`
+    local captured = 1
+    do
+      local nested = 2
+      local function read() return captured end
+      print(nested, read())
+    end
+  `);
+  const resolved = resolveScopes(chunk);
+  const result = assignRenames(
+    chunk,
+    resolved,
+    new Set(),
+    undefined,
+    new Set(),
+    { allowLocalNameReuse: true },
+  );
+  const captured = (chunk.body[0] as Parser.LocalStatement).variables[0];
+  const nested = (
+    (chunk.body[1] as Parser.DoStatement).body[0] as Parser.LocalStatement
+  ).variables[0];
+
+  assert.notEqual(result.nameOf(captured), result.nameOf(nested));
+});
+
+test("a captured local never collides with a same-scope function binding", () => {
+  const chunk = parse(`
+    local captured
+    local function reader() return captured end
+    reader()
+  `);
+  const resolved = resolveScopes(chunk);
+  const result = assignRenames(
+    chunk,
+    resolved,
+    new Set(),
+    undefined,
+    new Set(),
+    { allowLocalNameReuse: true },
+  );
+  const captured = (chunk.body[0] as Parser.LocalStatement).variables[0];
+  const reader = (chunk.body[1] as Parser.FunctionDeclaration)
+    .identifier as Parser.Identifier;
+
+  assert.notEqual(result.nameOf(captured), result.nameOf(reader));
+});
+
+test("parameters bound together interfere", () => {
+  const chunk = parse(`
+    local function combine(left, right) return left + right end
+  `);
+  const resolved = resolveScopes(chunk);
+  const result = assignRenames(
+    chunk,
+    resolved,
+    new Set(),
+    undefined,
+    new Set(),
+    { allowLocalNameReuse: true },
+  );
+  const fn = chunk.body[0] as Parser.FunctionDeclaration;
+  const left = fn.parameters[0] as Parser.Identifier;
+  const right = fn.parameters[1] as Parser.Identifier;
+
+  assert.notEqual(result.nameOf(left), result.nameOf(right));
+});
+
+test("generic-for variables bound together interfere", () => {
+  const chunk = parse(`
+    for key, value in pairs(items) do print(key, value) end
+  `);
+  const resolved = resolveScopes(chunk);
+  const result = assignRenames(
+    chunk,
+    resolved,
+    new Set(),
+    undefined,
+    new Set(),
+    { allowLocalNameReuse: true },
+  );
+  const loop = chunk.body[0] as Parser.ForGenericStatement;
+
+  assert.notEqual(
+    result.nameOf(loop.variables[0]),
+    result.nameOf(loop.variables[1]),
+  );
+});
+
+test("return keeps all returned locals mutually live", () => {
+  const chunk = parse(`
+    local first = source()
+    local second = source()
+    return first, second
+  `);
+  const resolved = resolveScopes(chunk);
+  const result = assignRenames(
+    chunk,
+    resolved,
+    new Set(),
+    undefined,
+    new Set(),
+    { allowLocalNameReuse: true },
+  );
+  const first = (chunk.body[0] as Parser.LocalStatement).variables[0];
+  const second = (chunk.body[1] as Parser.LocalStatement).variables[0];
+
+  assert.notEqual(result.nameOf(first), result.nameOf(second));
+});
+
+test("coloring is deterministic", () => {
+  const source = `
+    local first = 1
+    print(first)
+    local second = 2
+    print(second)
+  `;
+  const names = () => {
+    const chunk = parse(source);
+    const resolved = resolveScopes(chunk);
+    const result = assignRenames(
+      chunk,
+      resolved,
+      new Set(),
+      undefined,
+      new Set(),
+      { allowLocalNameReuse: true },
+    );
+    return resolved.symbols.map((symbol) => result.nameOf(symbol.declaration));
+  };
+
+  assert.deepEqual(names(), names());
 });
 
 test("more frequently referenced symbols get shorter names", () => {
@@ -62,7 +241,7 @@ test("more frequently referenced symbols get shorter names", () => {
     print(cold)
   `);
   const resolved = resolveScopes(chunk);
-  const result = assignRenames(resolved, new Set());
+  const result = assignRenames(chunk, resolved, new Set());
 
   const hotDecl = (chunk.body[0] as Parser.LocalStatement).variables[0];
   const coldDecl = (chunk.body[1] as Parser.LocalStatement).variables[0];
@@ -82,7 +261,7 @@ test("reserved names (globals/keywords) are never assigned to a symbol", () => {
   `);
   const resolved = resolveScopes(chunk);
   // "a" は本来最初に割り当てられるはずの名前。予約済みとして渡すと避けられる。
-  const result = assignRenames(resolved, new Set(["a"]));
+  const result = assignRenames(chunk, resolved, new Set(["a"]));
 
   const decl = (chunk.body[0] as Parser.LocalStatement).variables[0];
   assert.notEqual(result.nameOf(decl), "a");
@@ -95,7 +274,7 @@ test("self is never renamed and never assigned to another symbol", () => {
     end
   `);
   const resolved = resolveScopes(chunk);
-  const result = assignRenames(resolved, new Set());
+  const result = assignRenames(chunk, resolved, new Set());
 
   const fnDecl = chunk.body[0] as Parser.FunctionDeclaration;
   const selfParam = fnDecl.parameters[0] as Parser.Identifier;
@@ -115,7 +294,7 @@ test("usedNames reflects exactly the short names handed out", () => {
     print(x)
   `);
   const resolved = resolveScopes(chunk);
-  const result = assignRenames(resolved, new Set());
+  const result = assignRenames(chunk, resolved, new Set());
 
   const xDecl = (chunk.body[0] as Parser.LocalStatement).variables[0];
   const yDecl = (
@@ -136,6 +315,7 @@ test("globalRenames applies to genuine global references (#8a)", () => {
   `);
   const resolved = resolveScopes(chunk);
   const result = assignRenames(
+    chunk,
     resolved,
     new Set(),
     new Map([["counter", "g"]]),
@@ -155,6 +335,7 @@ test("globalRenames never renames a field name that happens to share a global's 
   `);
   const resolved = resolveScopes(chunk);
   const result = assignRenames(
+    chunk,
     resolved,
     new Set(),
     new Map([["counter", "g"]]),


### PR DESCRIPTION
Closes #75

## 概要
- 共通CFG livenessからlocal・parameter・for変数の干渉グラフを構築し、決定論的なweighted DSATURで短名を割り当てます
- Stormworksでは同一scope内の非干渉symbolへ名前を再利用し、Lua 5.3ではlocal introspectionを保つ既定動作を維持します
- capture・shadowing・同時宣言・祖先/子scopeを保護し、割当後に再Resolveして全参照のbinding identityを検証します
- 旧scope DFS slot allocatorは互換層を残さず撤去しました
- 最終rename解析をキャッシュし、facts/CFG/liveness/graph/binding proofの構造的な重複実行を除去しました

範囲外判断はIssueコメントに記録済みです: https://github.com/nona-takahara/storm-lua-minify/issues/75#issuecomment-5406203484

## 検証
- `pnpm test`: 41 files / 380 tests passed
- `pnpm run format:check`
- `pnpm lint`
- `pnpm build`
- `pnpm verify:lua-budget`: 150 active locals、49/50 accepted、51 rejected
- `pnpm verify:effect-semantics`: Lua 5.3の4 fixturesが完全一致
- `pnpm report:optimizer`: 15 accepted / 13 rejected / 43 estimated bytes

## n-tracs（fixture `0b0d3c0`、baseline `806692c`）
- default: 90,542 -> 90,540 bytes (-2)
- all opt-ins: 90,147 -> 90,147 bytes (同値)
- Lua 5.3 syntax検証およびexported names 10件を確認
- Windows Node、warm-up後5回のmedian: default +26.8%、all opt-ins +10.1%

時間増加は必要なCFG/liveness・干渉構築・binding proofによるものです。構造的な重複解析は除去し、出力byteを悪化させないことをfixture corpusでも検証しています。