### PR TITLE
関数summaryを使ったinlining・parameter pruning・関数DCEを実装する

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ CLIはStormworks向けツールとして、`--runtime-profile stormworks`を既�
 
 ### 関数rewrite
 
-解決可能なlocal関数について、末尾の未使用parameter削除、single-use関数のinline、到達不能なlocal関数の削除を共通call graph・function summary上で行います。実引数は元の順序と回数で評価し、複数戻り値と末尾展開はLuaの代入・return規則を保ちます。再帰、escape、複数call、vararg、未知のcall target、証明できないupvalue/closureは保守的に拒否します。
+解決可能なlocal関数について、末尾の未使用parameter削除、single-use関数のinline、到達不能なlocal関数の削除を共通call graph・function summary上で行います。inlineで複製するparameter・local・labelはResolveのsymbol単位でalpha conversionし、呼び出し側の同名bindingによるcaptureを防ぎます。実引数は元の順序と回数で評価し、複数戻り値と末尾展開はLuaの代入・return規則を保ちます。再帰、escape、複数call、vararg、未知のcall target、証明できないupvalue/closureは保守的に拒否します。
 
 関数inlineはstack frameやparameter数をdebug APIから観測できるため、`stormworks` profileでは既定で有効、`lua53` profileでは`--allow-local-lifetime-changes`を明示した場合だけ有効です。関数rewriteあり／なしはschedulerとは別の隔離された`Minifier`で最終Rename／Printまで比較し、関数rewrite単独で出力が厳密に短くなる場合だけ採用します。Source Mapは、inlineした本体を元の関数本体へ、埋め込んだ実引数を元のcall siteへ対応付けます。
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ CLIはStormworks向けツールとして、`--runtime-profile stormworks`を既�
 
 2段目はlocalの生存期間を早めるため、`debug.getlocal`等を持つ純Luaでは既定で無効です。3段目は実際に読む値が変わり得ます。出力サイズを優先し、その違いを受け入れられるコードでだけ指定してください。
 
+### 関数rewrite
+
+解決可能なlocal関数について、末尾の未使用parameter削除、single-use関数のinline、到達不能なlocal関数の削除を共通call graph・function summary上で行います。実引数は元の順序と回数で評価し、複数戻り値と末尾展開はLuaの代入・return規則を保ちます。再帰、escape、複数call、vararg、未知のcall target、証明できないupvalue/closureは保守的に拒否します。
+
+関数inlineはstack frameやparameter数をdebug APIから観測できるため、`stormworks` profileでは既定で有効、`lua53` profileでは`--allow-local-lifetime-changes`を明示した場合だけ有効です。関数rewriteあり／なしはschedulerとは別の隔離された`Minifier`で最終Rename／Printまで比較し、関数rewrite単独で出力が厳密に短くなる場合だけ採用します。Source Mapは、inlineした本体を元の関数本体へ、埋め込んだ実引数を元のcall siteへ対応付けます。
+
 # Source Map
 
 このツールは、ミニファイ後のコードと合わせて [Source Map](https://tc39.es/source-map/) (`.lua.map`) を出力します。

--- a/scripts/verify-effect-semantics.cjs
+++ b/scripts/verify-effect-semantics.cjs
@@ -41,6 +41,28 @@ local function values() print("values") return 1,2,3 end
 local a,b=values()
 print(a,b)
 `,
+  `
+local log={}
+local function make(value) log[#log+1]=value return value end
+local function publish(first,second) print(first,second,table.concat(log,",")) end
+publish(make("first"),make("second"))
+`,
+  `
+local function pair(value)
+  local next=value+1
+  if value<0 then return value,next end
+  return next,value
+end
+print(pair(4))
+print(pair(-2))
+`,
+  `
+local function run(first,second)
+  local sum=first+second
+  print(sum)
+end
+run((function() print("first") return 1 end)(),(function() print("second") return 2 end)())
+`,
 ];
 
 const directory = fs.mkdtempSync(

--- a/src/functionRewrites.ts
+++ b/src/functionRewrites.ts
@@ -1,9 +1,10 @@
 import Parser from "luaparse";
 import { CallGraphAnalysis } from "./callGraph";
-import { walkExpression } from "./astWalk";
+import { walkExpression, walkStatement } from "./astWalk";
 import { InterproceduralAnalysis } from "./interproceduralAnalysis";
-import { ResolveResult } from "./resolver";
+import { ResolveResult, Scope } from "./resolver";
 import { SourceMetadata } from "./sourceMetadata";
+import { copyNodeOrigin } from "./generatedNode";
 
 export interface FunctionRewriteResult {
   readonly changed: boolean;
@@ -18,6 +19,10 @@ export interface InlineRewriteResult {
 export interface StatementInlineRewriteResult {
   readonly changed: boolean;
   readonly inlinedFunctions: number;
+}
+
+export interface BoundStatementInlineOptions {
+  readonly maxIntroducedLocalsAt: (statement: Parser.Statement) => number;
 }
 
 type PrimitiveLiteral =
@@ -385,6 +390,52 @@ function isClosedInlineStatement(
   }
 }
 
+function hasFunctionScopeAncestor(
+  symbolScope: Scope,
+  functionScope: Scope,
+): boolean {
+  for (let scope: Scope | null = symbolScope; scope; scope = scope.parent) {
+    if (scope === functionScope) return true;
+  }
+  return false;
+}
+
+function bodyUsesOnlyOwnedBindings(
+  body: readonly Parser.Statement[],
+  resolved: ResolveResult,
+  functionScope: Scope,
+): boolean {
+  let safe = true;
+  const visitBlock = (statements: readonly Parser.Statement[]): void => {
+    statements.forEach((statement) => {
+      if (statement.type === "FunctionDeclaration") {
+        safe = false;
+        return;
+      }
+      if (statement.type === "ReturnStatement") {
+        safe = false;
+        return;
+      }
+      walkStatementForOwnedBindings(statement);
+    });
+  };
+  const walkStatementForOwnedBindings = (statement: Parser.Statement): void => {
+    walkStatement(statement, {
+      onIdentifierReference: (identifier) => {
+        const symbol = resolved.symbolOf(identifier);
+        if (symbol && !hasFunctionScopeAncestor(symbol.scope, functionScope))
+          safe = false;
+      },
+      onFunction: () => {
+        safe = false;
+      },
+      onBlock: visitBlock,
+    });
+  };
+  visitBlock(body);
+  return safe;
+}
+
 /** Inline a straight-line, closed function body at a statement call site. */
 export function inlineClosedStatementFunctions(
   chunk: Parser.Chunk,
@@ -440,6 +491,92 @@ export function inlineClosedStatementFunctions(
     metadata.replaceStatement(site.owner, replacements);
     executable.forEach((source, index) => {
       metadata.transferStatements([source], replacements[index]);
+    });
+    inlinedFunctions++;
+  });
+
+  return { changed: inlinedFunctions > 0, inlinedFunctions };
+}
+
+/**
+ * Inline a non-returning statement function behind a lexical block and a
+ * parameter-binding local. The binding statement is the semantic boundary:
+ * arbitrary actuals keep Lua's original left-to-right evaluation and tuple
+ * adjustment before the copied body starts.
+ */
+export function inlineBoundStatementFunctions(
+  chunk: Parser.Chunk,
+  analysis: InterproceduralAnalysis,
+  resolved: ResolveResult,
+  metadata: SourceMetadata,
+  options: BoundStatementInlineOptions,
+): StatementInlineRewriteResult {
+  let inlinedFunctions = 0;
+
+  analysis.callGraph.functions.forEach((callable) => {
+    const declaration = callable.declaration;
+    const symbol = callable.symbol;
+    const functionScope = resolved.scopeOfFunction(declaration);
+    if (
+      !symbol ||
+      !functionScope ||
+      !declaration.isLocal ||
+      declaration.parameters.length === 0 ||
+      declaration.parameters.some(
+        (parameter) => parameter.type !== "Identifier",
+      ) ||
+      symbol.references.length !== 1 ||
+      metadata.annotationsOf(declaration).keep
+    )
+      return;
+
+    const executable = [...declaration.body];
+    const tail = executable.at(-1);
+    if (tail?.type === "ReturnStatement" && tail.arguments.length === 0)
+      executable.pop();
+    if (
+      executable.length === 0 ||
+      executable.some((statement) => metadata.annotationsOf(statement).keep) ||
+      !bodyUsesOnlyOwnedBindings(executable, resolved, functionScope)
+    )
+      return;
+
+    const site = analysis.callGraph.calls.find(
+      (candidate) =>
+        candidate.owner.type === "CallStatement" &&
+        candidate.owner.expression === candidate.call &&
+        !candidate.hasUnknownTarget &&
+        candidate.targets.size === 1 &&
+        candidate.targets.has(callable) &&
+        candidate.call.type === "CallExpression" &&
+        candidate.call.base === symbol.references[0],
+    );
+    if (!site || site.call.type !== "CallExpression") return;
+    if (
+      declaration.parameters.length > options.maxIntroducedLocalsAt(site.owner)
+    )
+      return;
+
+    const binding: Parser.LocalStatement = {
+      type: "LocalStatement",
+      variables: declaration.parameters.map((parameter) =>
+        structuredClone(parameter as Parser.Identifier),
+      ),
+      init: site.call.arguments.map((argument) => structuredClone(argument)),
+    };
+    copyNodeOrigin(binding, site.owner);
+    const copiedBody = executable.map((statement) =>
+      structuredClone(statement),
+    );
+    const replacement: Parser.DoStatement = {
+      type: "DoStatement",
+      body: [binding, ...copiedBody],
+    };
+    copyNodeOrigin(replacement, site.owner);
+    if (!replaceStatement(chunk.body, site.owner, [replacement])) return;
+    metadata.replaceStatement(site.owner, [replacement]);
+    executable.forEach((source, index) => {
+      metadata.transferStatements([source], copiedBody[index]);
     });
     inlinedFunctions++;
   });

--- a/src/functionRewrites.ts
+++ b/src/functionRewrites.ts
@@ -15,6 +15,11 @@ export interface InlineRewriteResult {
   readonly inlinedFunctions: number;
 }
 
+export interface StatementInlineRewriteResult {
+  readonly changed: boolean;
+  readonly inlinedFunctions: number;
+}
+
 /**
  * Remove only the trailing, identifier parameters proven unused by Resolve.
  *
@@ -129,6 +134,122 @@ export function inlineClosedSingleUseFunctions(
     // structuredClone retains loc/range on every copied node, so the inlined
     // expression maps to the function body/return origin rather than call-site text.
     overwriteExpression(site.call, structuredClone(expression));
+    inlinedFunctions++;
+  });
+
+  return { changed: inlinedFunctions > 0, inlinedFunctions };
+}
+
+function statementChildren(statement: Parser.Statement): Parser.Statement[][] {
+  switch (statement.type) {
+    case "DoStatement":
+    case "WhileStatement":
+    case "RepeatStatement":
+    case "FunctionDeclaration":
+    case "ForNumericStatement":
+    case "ForGenericStatement":
+      return [statement.body];
+    case "IfStatement":
+      return statement.clauses.map((clause) => clause.body);
+    default:
+      return [];
+  }
+}
+
+function replaceStatement(
+  body: Parser.Statement[],
+  target: Parser.Statement,
+  replacements: Parser.Statement[],
+): boolean {
+  const index = body.indexOf(target);
+  if (index >= 0) {
+    body.splice(index, 1, ...replacements);
+    return true;
+  }
+  return body.some((statement) =>
+    statementChildren(statement).some((child) =>
+      replaceStatement(child, target, replacements),
+    ),
+  );
+}
+
+function isClosedInlineStatement(
+  statement: Parser.Statement,
+  resolved: ResolveResult,
+): boolean {
+  let closed = true;
+  const inspect = (expression: Parser.Expression) => {
+    if (!isClosedInlineExpression(expression, resolved)) closed = false;
+  };
+  switch (statement.type) {
+    case "AssignmentStatement":
+      statement.variables.forEach(inspect);
+      statement.init.forEach(inspect);
+      return closed;
+    case "CallStatement":
+      inspect(statement.expression);
+      return closed;
+    default:
+      return false;
+  }
+}
+
+/** Inline a straight-line, closed function body at a statement call site. */
+export function inlineClosedStatementFunctions(
+  chunk: Parser.Chunk,
+  analysis: InterproceduralAnalysis,
+  resolved: ResolveResult,
+  metadata: SourceMetadata,
+): StatementInlineRewriteResult {
+  let inlinedFunctions = 0;
+
+  analysis.callGraph.functions.forEach((callable) => {
+    const declaration = callable.declaration;
+    const symbol = callable.symbol;
+    if (
+      !symbol ||
+      !declaration.isLocal ||
+      declaration.parameters.length !== 0 ||
+      symbol.references.length !== 1 ||
+      metadata.annotationsOf(declaration).keep
+    )
+      return;
+
+    const executable = [...declaration.body];
+    const tail = executable.at(-1);
+    if (tail?.type === "ReturnStatement" && tail.arguments.length === 0)
+      executable.pop();
+    if (
+      executable.length === 0 ||
+      executable.some(
+        (statement) =>
+          metadata.annotationsOf(statement).keep ||
+          !isClosedInlineStatement(statement, resolved),
+      )
+    )
+      return;
+
+    const site = analysis.callGraph.calls.find(
+      (candidate) =>
+        candidate.owner.type === "CallStatement" &&
+        candidate.owner.expression === candidate.call &&
+        !candidate.hasUnknownTarget &&
+        candidate.targets.size === 1 &&
+        candidate.targets.has(callable) &&
+        candidate.call.type === "CallExpression" &&
+        candidate.call.arguments.length === 0 &&
+        candidate.call.base === symbol.references[0],
+    );
+    if (!site) return;
+
+    const replacements = executable.map((statement) =>
+      structuredClone(statement),
+    );
+    if (!replaceStatement(chunk.body, site.owner, replacements)) return;
+    metadata.replaceStatement(site.owner, replacements);
+    executable.forEach((source, index) => {
+      metadata.transferStatements([source], replacements[index]);
+    });
     inlinedFunctions++;
   });
 

--- a/src/functionRewrites.ts
+++ b/src/functionRewrites.ts
@@ -62,9 +62,7 @@ export function pruneTrailingUnusedParameters(
 
     if (retained === declaration.parameters.length) return;
     prunedParameters += declaration.parameters.length - retained;
-    declaration.parameters = declaration.parameters.slice(0, retained) as (
-      Parser.Identifier | Parser.VarargLiteral
-    )[];
+    declaration.parameters = declaration.parameters.slice(0, retained);
   });
 
   return {
@@ -77,9 +75,8 @@ function overwriteExpression(
   target: Parser.Expression,
   replacement: Parser.Expression,
 ): void {
-  Object.keys(target).forEach((key) => {
-    delete (target as unknown as Record<string, unknown>)[key];
-  });
+  // Visitors dispatch exclusively on `type`; fields from the former node are
+  // inert after this assignment and do not need an unsafe dynamic deletion.
   Object.assign(target, replacement);
 }
 
@@ -96,7 +93,7 @@ function isClosedInlineExpression(
       closed = false;
     },
   });
-  return closed && expression.type !== "VarargLiteral";
+  return closed;
 }
 
 function primitiveLiteral(
@@ -154,9 +151,9 @@ function substituteParameters(
       case "CallExpression": {
         const call = copied as Parser.CallExpression;
         substitute(original.base, call.base);
-        original.arguments.forEach((argument, index) =>
-          substitute(argument, call.arguments[index]),
-        );
+        original.arguments.forEach((argument, index) => {
+          substitute(argument, call.arguments[index]);
+        });
         return;
       }
       case "TableCallExpression": {
@@ -216,7 +213,7 @@ function onlyParametersOrGlobals(
       safe = false;
     },
   });
-  return safe && expression.type !== "VarargLiteral";
+  return safe;
 }
 
 /**

--- a/src/functionRewrites.ts
+++ b/src/functionRewrites.ts
@@ -2,7 +2,7 @@ import Parser from "luaparse";
 import { CallGraphAnalysis } from "./callGraph";
 import { walkExpression, walkStatement } from "./astWalk";
 import { InterproceduralAnalysis } from "./interproceduralAnalysis";
-import { ResolveResult, Scope } from "./resolver";
+import { ResolveResult, Scope, Symbol } from "./resolver";
 import { SourceMetadata } from "./sourceMetadata";
 import { copyNodeOrigin } from "./generatedNode";
 
@@ -445,6 +445,74 @@ function ownedLocalCount(
   ).length;
 }
 
+/**
+ * Rename copied callee-owned bindings by resolved symbol identity. This keeps
+ * declarations and references paired even when the call site has same-spelled
+ * locals, and avoids treating field names as lexical bindings.
+ */
+function alphaConvertOwnedCopies(
+  originals: readonly unknown[],
+  copies: readonly unknown[],
+  resolved: ResolveResult,
+  functionScope: Scope,
+): void {
+  const owned = new Set(
+    resolved.symbols.filter((symbol) =>
+      hasFunctionScopeAncestor(symbol.scope, functionScope),
+    ),
+  );
+  const unavailable = new Set([
+    ...resolved.symbols.map((symbol) => symbol.name),
+    ...resolved.globals.keys(),
+  ]);
+  const replacementNames = new Map<Symbol, string>();
+  let nextName = 0;
+
+  const nameOf = (symbol: Symbol): string => {
+    const existing = replacementNames.get(symbol);
+    if (existing !== undefined) return existing;
+    let candidate: string;
+    do {
+      candidate = `__stormInline${String(nextName++)}`;
+    } while (unavailable.has(candidate));
+    unavailable.add(candidate);
+    replacementNames.set(symbol, candidate);
+    return candidate;
+  };
+
+  const visitPair = (original: unknown, copy: unknown): void => {
+    if (
+      !original ||
+      !copy ||
+      typeof original !== "object" ||
+      typeof copy !== "object"
+    )
+      return;
+    if (Array.isArray(original)) {
+      if (!Array.isArray(copy)) return;
+      original.forEach((value, index) => {
+        visitPair(value, copy[index]);
+      });
+      return;
+    }
+    if ((original as Parser.Node).type === "Identifier") {
+      if ((copy as Parser.Node).type !== "Identifier") return;
+      const symbol = resolved.symbolOf(original as Parser.Identifier);
+      if (symbol && owned.has(symbol))
+        (copy as Parser.Identifier).name = nameOf(symbol);
+      return;
+    }
+    Object.keys(original).forEach((key) => {
+      visitPair(
+        (original as Record<string, unknown>)[key],
+        (copy as Record<string, unknown>)[key],
+      );
+    });
+  };
+
+  visitPair(originals, copies);
+}
+
 /** Inline a straight-line, closed function body at a statement call site. */
 export function inlineClosedStatementFunctions(
   chunk: Parser.Chunk,
@@ -577,6 +645,12 @@ export function inlineBoundStatementFunctions(
     const copiedBody = executable.map((statement) =>
       structuredClone(statement),
     );
+    alphaConvertOwnedCopies(
+      [...declaration.parameters, ...executable],
+      [...binding.variables, ...copiedBody],
+      resolved,
+      functionScope,
+    );
     const replacement: Parser.DoStatement = {
       type: "DoStatement",
       body: [binding, ...copiedBody],
@@ -649,12 +723,14 @@ export function inlineTailCallFunctions(
       return;
 
     const body: Parser.Statement[] = [];
+    let copiedParameters: Parser.Identifier[] = [];
     if (declaration.parameters.length > 0) {
+      copiedParameters = declaration.parameters.map((parameter) =>
+        structuredClone(parameter as Parser.Identifier),
+      );
       const binding: Parser.LocalStatement = {
         type: "LocalStatement",
-        variables: declaration.parameters.map((parameter) =>
-          structuredClone(parameter as Parser.Identifier),
-        ),
+        variables: copiedParameters,
         init: site.call.arguments.map((argument) => structuredClone(argument)),
       };
       copyNodeOrigin(binding, site.owner);
@@ -662,6 +738,12 @@ export function inlineTailCallFunctions(
     }
     const copiedBody = declaration.body.map((statement) =>
       structuredClone(statement),
+    );
+    alphaConvertOwnedCopies(
+      [...declaration.parameters, ...declaration.body],
+      [...copiedParameters, ...copiedBody],
+      resolved,
+      functionScope,
     );
     body.push(...copiedBody);
     if (declaration.body.at(-1)?.type !== "ReturnStatement") {

--- a/src/functionRewrites.ts
+++ b/src/functionRewrites.ts
@@ -1,0 +1,50 @@
+import Parser from "luaparse";
+import { CallGraphAnalysis } from "./callGraph";
+import { SourceMetadata } from "./sourceMetadata";
+
+export interface FunctionRewriteResult {
+  readonly changed: boolean;
+  readonly prunedParameters: number;
+}
+
+/**
+ * Remove only the trailing, identifier parameters proven unused by Resolve.
+ *
+ * Call arguments deliberately remain untouched: Lua evaluates surplus actuals in
+ * their original order and then discards them, which preserves their effects,
+ * errors, and multiple-value adjustment. A vararg tail is therefore a hard
+ * boundary rather than something this rewrite tries to reason around.
+ */
+export function pruneTrailingUnusedParameters(
+  callGraph: CallGraphAnalysis,
+  metadata: SourceMetadata,
+): FunctionRewriteResult {
+  let prunedParameters = 0;
+
+  callGraph.functions.forEach((callable) => {
+    const declaration = callable.declaration;
+    if (metadata.annotationsOf(declaration).keep) return;
+
+    let retained = declaration.parameters.length;
+    while (retained > 0) {
+      const parameter = declaration.parameters[retained - 1];
+      if (parameter.type !== "Identifier") break;
+      const symbol = callable.parameters.find(
+        (candidate) => candidate.declaration === parameter,
+      );
+      if (!symbol || symbol.references.length > 0) break;
+      retained--;
+    }
+
+    if (retained === declaration.parameters.length) return;
+    prunedParameters += declaration.parameters.length - retained;
+    declaration.parameters = declaration.parameters.slice(0, retained) as (
+      Parser.Identifier | Parser.VarargLiteral
+    )[];
+  });
+
+  return {
+    changed: prunedParameters > 0,
+    prunedParameters,
+  };
+}

--- a/src/functionRewrites.ts
+++ b/src/functionRewrites.ts
@@ -1,10 +1,18 @@
 import Parser from "luaparse";
 import { CallGraphAnalysis } from "./callGraph";
+import { walkExpression } from "./astWalk";
+import { InterproceduralAnalysis } from "./interproceduralAnalysis";
+import { ResolveResult } from "./resolver";
 import { SourceMetadata } from "./sourceMetadata";
 
 export interface FunctionRewriteResult {
   readonly changed: boolean;
   readonly prunedParameters: number;
+}
+
+export interface InlineRewriteResult {
+  readonly changed: boolean;
+  readonly inlinedFunctions: number;
 }
 
 /**
@@ -47,4 +55,82 @@ export function pruneTrailingUnusedParameters(
     changed: prunedParameters > 0,
     prunedParameters,
   };
+}
+
+function overwriteExpression(
+  target: Parser.Expression,
+  replacement: Parser.Expression,
+): void {
+  Object.keys(target).forEach((key) => {
+    delete (target as unknown as Record<string, unknown>)[key];
+  });
+  Object.assign(target, replacement);
+}
+
+function isClosedInlineExpression(
+  expression: Parser.Expression,
+  resolved: ResolveResult,
+): boolean {
+  let closed = true;
+  walkExpression(expression, {
+    onIdentifierReference: (identifier) => {
+      if (resolved.symbolOf(identifier)) closed = false;
+    },
+    onFunction: () => {
+      closed = false;
+    },
+  });
+  return closed && expression.type !== "VarargLiteral";
+}
+
+/**
+ * Inline the first deliberately narrow class whose binding proof is complete:
+ * a zero-argument, single-use local function returning one closed expression.
+ * Closed means every identifier is global; local/upvalue references wait for
+ * symbol-level alpha conversion instead of being guessed from their spelling.
+ */
+export function inlineClosedSingleUseFunctions(
+  analysis: InterproceduralAnalysis,
+  resolved: ResolveResult,
+  metadata: SourceMetadata,
+): InlineRewriteResult {
+  let inlinedFunctions = 0;
+
+  analysis.callGraph.functions.forEach((callable) => {
+    const declaration = callable.declaration;
+    const symbol = callable.symbol;
+    if (
+      !symbol ||
+      !declaration.isLocal ||
+      declaration.parameters.length !== 0 ||
+      declaration.body.length !== 1 ||
+      symbol.references.length !== 1 ||
+      metadata.annotationsOf(declaration).keep
+    )
+      return;
+
+    const returned = declaration.body[0];
+    if (returned.type !== "ReturnStatement" || returned.arguments.length !== 1)
+      return;
+    const expression = returned.arguments[0];
+    if (!isClosedInlineExpression(expression, resolved)) return;
+
+    const site = analysis.callGraph.calls.find(
+      (candidate) =>
+        !candidate.hasUnknownTarget &&
+        candidate.targets.size === 1 &&
+        candidate.targets.has(callable) &&
+        candidate.call.type === "CallExpression" &&
+        candidate.call.arguments.length === 0 &&
+        candidate.call.base === symbol.references[0],
+    );
+    if (!site) return;
+
+    // structuredClone retains loc/range on every copied node, so the inlined
+    // expression maps to the function body/return origin rather than call-site text.
+    overwriteExpression(site.call, structuredClone(expression));
+    inlinedFunctions++;
+  });
+
+  return { changed: inlinedFunctions > 0, inlinedFunctions };
 }

--- a/src/functionRewrites.ts
+++ b/src/functionRewrites.ts
@@ -404,6 +404,7 @@ function bodyUsesOnlyOwnedBindings(
   body: readonly Parser.Statement[],
   resolved: ResolveResult,
   functionScope: Scope,
+  allowReturns = false,
 ): boolean {
   let safe = true;
   const visitBlock = (statements: readonly Parser.Statement[]): void => {
@@ -412,7 +413,7 @@ function bodyUsesOnlyOwnedBindings(
         safe = false;
         return;
       }
-      if (statement.type === "ReturnStatement") {
+      if (statement.type === "ReturnStatement" && !allowReturns) {
         safe = false;
         return;
       }
@@ -434,6 +435,17 @@ function bodyUsesOnlyOwnedBindings(
   };
   visitBlock(body);
   return safe;
+}
+
+function ownedLocalCount(
+  resolved: ResolveResult,
+  functionScope: Scope,
+): number {
+  return resolved.symbols.filter(
+    (symbol) =>
+      symbol.kind !== "label" &&
+      hasFunctionScopeAncestor(symbol.scope, functionScope),
+  ).length;
 }
 
 /** Inline a straight-line, closed function body at a statement call site. */
@@ -576,6 +588,98 @@ export function inlineBoundStatementFunctions(
     if (!replaceStatement(chunk.body, site.owner, [replacement])) return;
     metadata.replaceStatement(site.owner, [replacement]);
     executable.forEach((source, index) => {
+      metadata.transferStatements([source], copiedBody[index]);
+    });
+    inlinedFunctions++;
+  });
+
+  return { changed: inlinedFunctions > 0, inlinedFunctions };
+}
+
+/**
+ * Inline a function into `return f(...)`. Every copied callee return now exits
+ * the caller, which is equivalent specifically because the call occupied the
+ * caller's entire return tuple. A synthetic empty return preserves fallthrough.
+ */
+export function inlineTailCallFunctions(
+  chunk: Parser.Chunk,
+  analysis: InterproceduralAnalysis,
+  resolved: ResolveResult,
+  metadata: SourceMetadata,
+  options: BoundStatementInlineOptions,
+): StatementInlineRewriteResult {
+  let inlinedFunctions = 0;
+
+  analysis.callGraph.functions.forEach((callable) => {
+    const declaration = callable.declaration;
+    const symbol = callable.symbol;
+    const functionScope = resolved.scopeOfFunction(declaration);
+    if (
+      !symbol ||
+      !functionScope ||
+      !declaration.isLocal ||
+      declaration.parameters.some(
+        (parameter) => parameter.type !== "Identifier",
+      ) ||
+      declaration.body.length === 0 ||
+      symbol.references.length !== 1 ||
+      metadata.annotationsOf(declaration).keep ||
+      !bodyUsesOnlyOwnedBindings(
+        declaration.body,
+        resolved,
+        functionScope,
+        true,
+      )
+    )
+      return;
+
+    const site = analysis.callGraph.calls.find(
+      (candidate) =>
+        candidate.owner.type === "ReturnStatement" &&
+        candidate.owner.arguments.length === 1 &&
+        candidate.owner.arguments[0] === candidate.call &&
+        !candidate.hasUnknownTarget &&
+        candidate.targets.size === 1 &&
+        candidate.targets.has(callable) &&
+        candidate.call.type === "CallExpression" &&
+        candidate.call.base === symbol.references[0],
+    );
+    if (!site || site.call.type !== "CallExpression") return;
+    if (
+      ownedLocalCount(resolved, functionScope) >
+      options.maxIntroducedLocalsAt(site.owner)
+    )
+      return;
+
+    const body: Parser.Statement[] = [];
+    if (declaration.parameters.length > 0) {
+      const binding: Parser.LocalStatement = {
+        type: "LocalStatement",
+        variables: declaration.parameters.map((parameter) =>
+          structuredClone(parameter as Parser.Identifier),
+        ),
+        init: site.call.arguments.map((argument) => structuredClone(argument)),
+      };
+      copyNodeOrigin(binding, site.owner);
+      body.push(binding);
+    }
+    const copiedBody = declaration.body.map((statement) =>
+      structuredClone(statement),
+    );
+    body.push(...copiedBody);
+    if (declaration.body.at(-1)?.type !== "ReturnStatement") {
+      const fallthrough: Parser.ReturnStatement = {
+        type: "ReturnStatement",
+        arguments: [],
+      };
+      copyNodeOrigin(fallthrough, site.owner);
+      body.push(fallthrough);
+    }
+    const replacement: Parser.DoStatement = { type: "DoStatement", body };
+    copyNodeOrigin(replacement, site.owner);
+    if (!replaceStatement(chunk.body, site.owner, [replacement])) return;
+    metadata.replaceStatement(site.owner, [replacement]);
+    declaration.body.forEach((source, index) => {
       metadata.transferStatements([source], copiedBody[index]);
     });
     inlinedFunctions++;

--- a/src/functionRewrites.ts
+++ b/src/functionRewrites.ts
@@ -20,6 +20,12 @@ export interface StatementInlineRewriteResult {
   readonly inlinedFunctions: number;
 }
 
+type PrimitiveLiteral =
+  | Parser.StringLiteral
+  | Parser.NumericLiteral
+  | Parser.BooleanLiteral
+  | Parser.NilLiteral;
+
 /**
  * Remove only the trailing, identifier parameters proven unused by Resolve.
  *
@@ -88,6 +94,126 @@ function isClosedInlineExpression(
   return closed && expression.type !== "VarargLiteral";
 }
 
+function primitiveLiteral(
+  expression: Parser.Expression | undefined,
+): PrimitiveLiteral | undefined {
+  if (!expression) return { type: "NilLiteral", value: null, raw: "nil" };
+  switch (expression.type) {
+    case "StringLiteral":
+    case "NumericLiteral":
+    case "BooleanLiteral":
+    case "NilLiteral":
+      return expression;
+    default:
+      return undefined;
+  }
+}
+
+function substituteParameters(
+  expression: Parser.Expression,
+  replacements: ReadonlyMap<string, PrimitiveLiteral>,
+): Parser.Expression {
+  const clone = structuredClone(expression);
+  const substitute = (
+    original: Parser.Expression,
+    copied: Parser.Expression,
+  ): void => {
+    if (original.type !== copied.type)
+      throw new Error("Cloned expression changed node type");
+    switch (original.type) {
+      case "Identifier": {
+        const replacement = replacements.get(original.name);
+        if (replacement)
+          overwriteExpression(copied, structuredClone(replacement));
+        return;
+      }
+      case "StringLiteral":
+      case "NumericLiteral":
+      case "BooleanLiteral":
+      case "NilLiteral":
+      case "VarargLiteral":
+        return;
+      case "LogicalExpression":
+      case "BinaryExpression": {
+        const binary = copied as Parser.BinaryExpression;
+        substitute(original.left, binary.left);
+        substitute(original.right, binary.right);
+        return;
+      }
+      case "UnaryExpression":
+        substitute(
+          original.argument,
+          (copied as Parser.UnaryExpression).argument,
+        );
+        return;
+      case "CallExpression": {
+        const call = copied as Parser.CallExpression;
+        substitute(original.base, call.base);
+        original.arguments.forEach((argument, index) =>
+          substitute(argument, call.arguments[index]),
+        );
+        return;
+      }
+      case "TableCallExpression": {
+        const call = copied as Parser.TableCallExpression;
+        substitute(original.base, call.base);
+        substitute(original.arguments, call.arguments);
+        return;
+      }
+      case "StringCallExpression": {
+        const call = copied as Parser.StringCallExpression;
+        substitute(original.base, call.base);
+        substitute(original.argument, call.argument);
+        return;
+      }
+      case "IndexExpression": {
+        const index = copied as Parser.IndexExpression;
+        substitute(original.base, index.base);
+        substitute(original.index, index.index);
+        return;
+      }
+      case "MemberExpression":
+        substitute(original.base, (copied as Parser.MemberExpression).base);
+        return;
+      case "TableConstructorExpression": {
+        const table = copied as Parser.TableConstructorExpression;
+        original.fields.forEach((field, index) => {
+          const copiedField = table.fields[index];
+          if (field.type === "TableKey") {
+            if (copiedField.type !== "TableKey")
+              throw new Error("Cloned table field changed node type");
+            substitute(field.key, copiedField.key);
+          }
+          substitute(field.value, copiedField.value);
+        });
+        return;
+      }
+      case "FunctionDeclaration":
+        throw new Error("Nested functions are not substitutable");
+    }
+  };
+  substitute(expression, clone);
+  return clone;
+}
+
+function onlyParametersOrGlobals(
+  expression: Parser.Expression,
+  resolved: ResolveResult,
+  parameterNames: ReadonlySet<string>,
+): boolean {
+  let safe = true;
+  walkExpression(expression, {
+    onIdentifierReference: (identifier) => {
+      const symbol = resolved.symbolOf(identifier);
+      if (symbol && !parameterNames.has(symbol.name)) safe = false;
+    },
+    onFunction: () => {
+      safe = false;
+    },
+  });
+  return safe && expression.type !== "VarargLiteral";
+}
+
 /**
  * Inline the first deliberately narrow class whose binding proof is complete:
  * a zero-argument, single-use local function returning one closed expression.
@@ -134,6 +260,71 @@ export function inlineClosedSingleUseFunctions(
     // structuredClone retains loc/range on every copied node, so the inlined
     // expression maps to the function body/return origin rather than call-site text.
     overwriteExpression(site.call, structuredClone(expression));
+    inlinedFunctions++;
+  });
+
+  return { changed: inlinedFunctions > 0, inlinedFunctions };
+}
+
+/** Inline a single-return function when every actual is an immutable literal. */
+export function inlineLiteralArgumentFunctions(
+  analysis: InterproceduralAnalysis,
+  resolved: ResolveResult,
+  metadata: SourceMetadata,
+): InlineRewriteResult {
+  let inlinedFunctions = 0;
+
+  analysis.callGraph.functions.forEach((callable) => {
+    const declaration = callable.declaration;
+    const symbol = callable.symbol;
+    if (
+      !symbol ||
+      !declaration.isLocal ||
+      declaration.parameters.length === 0 ||
+      declaration.parameters.some(
+        (parameter) => parameter.type !== "Identifier",
+      ) ||
+      declaration.body.length !== 1 ||
+      symbol.references.length !== 1 ||
+      metadata.annotationsOf(declaration).keep
+    )
+      return;
+    const returned = declaration.body[0];
+    if (returned.type !== "ReturnStatement" || returned.arguments.length !== 1)
+      return;
+
+    const site = analysis.callGraph.calls.find(
+      (candidate) =>
+        !candidate.hasUnknownTarget &&
+        candidate.targets.size === 1 &&
+        candidate.targets.has(callable) &&
+        candidate.call.type === "CallExpression" &&
+        candidate.call.arguments.length <= declaration.parameters.length &&
+        candidate.call.base === symbol.references[0],
+    );
+    if (!site || site.call.type !== "CallExpression") return;
+
+    const replacements = new Map<string, PrimitiveLiteral>();
+    for (let index = 0; index < declaration.parameters.length; index++) {
+      const parameter = declaration.parameters[index];
+      if (parameter.type !== "Identifier") return;
+      const actual = primitiveLiteral(site.call.arguments[index]);
+      if (!actual) return;
+      replacements.set(parameter.name, actual);
+    }
+    if (
+      !onlyParametersOrGlobals(
+        returned.arguments[0],
+        resolved,
+        new Set(replacements.keys()),
+      )
+    )
+      return;
+
+    overwriteExpression(
+      site.call,
+      substituteParameters(returned.arguments[0], replacements),
+    );
     inlinedFunctions++;
   });
 

--- a/src/minifier.ts
+++ b/src/minifier.ts
@@ -99,6 +99,10 @@ const NO_RENAME: RenameResult = {
   usedNames: new Set(),
 };
 
+function sourceRangeOf(node: object): [number, number] | undefined {
+  return (node as { range?: [number, number] }).range;
+}
+
 function copyMap<K, V>(source: ReadonlyMap<K, V>, target: Map<K, V>): void {
   target.clear();
   source.forEach((value, key) => target.set(key, value));
@@ -245,6 +249,72 @@ export class Minifier {
       const resolved = this.moduleResolve.get(moduleName);
       if (!ast || !resolved) throw new Error(moduleName + " is not found");
       const passes = new PassOrchestrator(ast, resolved);
+      const runtimeProfile = this.mode.runtimeProfile ?? "lua53";
+      const moduleRange =
+        sourceRangeOf(ast) ??
+        ([0, this.moduleSourceText.get(moduleName)?.length ?? 0] as const);
+      const recordAccepted = (pass: string, count: number) => {
+        if (count === 0) return;
+        this.diagnosticCollector?.record({
+          pass,
+          moduleName,
+          runtimeProfile,
+          decision: "accepted",
+          reason: "function-rewrite-applied",
+          candidateSize: count,
+          sourceRange: moduleRange,
+        });
+      };
+      const initialAnalysis = passes.analysis(
+        OPTIMIZER_ANALYSIS_CACHE_KEY,
+        analyzeOptimizerAtGeneration,
+      );
+      const recursive = new Set(
+        initialAnalysis.callGraph.sccs
+          .filter((scc) => scc.recursive)
+          .flatMap((scc) => scc.functions),
+      );
+      initialAnalysis.interprocedural.diagnostics.forEach((diagnostic) =>
+        this.diagnosticCollector?.record({
+          pass: "interprocedural-summary",
+          moduleName,
+          runtimeProfile,
+          decision:
+            diagnostic.reason === "unknown-call-target"
+              ? "rejected"
+              : "accepted",
+          reason: diagnostic.reason,
+          candidateSize: 1,
+          sourceRange: diagnostic.sourceRange ?? moduleRange,
+        }),
+      );
+      initialAnalysis.callGraph.functions.forEach((callable) => {
+        if (!callable.symbol || !callable.declaration.isLocal) return;
+        const calls = initialAnalysis.callGraph.calls.filter((call) =>
+          call.targets.has(callable),
+        ).length;
+        const reason = recursive.has(callable)
+          ? "recursive-function"
+          : callable.declaration.parameters.some(
+                (parameter) => parameter.type === "VarargLiteral",
+              )
+            ? "vararg-function"
+            : callable.symbol.references.length > calls
+              ? "function-escape"
+              : calls > 1
+                ? "multiple-call-sites"
+                : undefined;
+        if (!reason) return;
+        this.diagnosticCollector?.record({
+          pass: "function-rewrite",
+          moduleName,
+          runtimeProfile,
+          decision: "rejected",
+          reason,
+          candidateSize: 1,
+          sourceRange: sourceRangeOf(callable.declaration),
+        });
+      });
       passes.run("prune-trailing-unused-parameters", () => {
         const analysis = passes.analysis(
           OPTIMIZER_ANALYSIS_CACHE_KEY,
@@ -253,6 +323,10 @@ export class Minifier {
         const result = pruneTrailingUnusedParameters(
           analysis.interprocedural.callGraph,
           this.getSourceMetadata(moduleName),
+        );
+        recordAccepted(
+          "prune-trailing-unused-parameters",
+          result.prunedParameters,
         );
         return {
           changed: result.changed,
@@ -269,6 +343,10 @@ export class Minifier {
           currentResolve,
           this.getSourceMetadata(moduleName),
         );
+        recordAccepted(
+          "inline-closed-single-use-functions",
+          result.inlinedFunctions,
+        );
         return {
           changed: result.changed,
           invalidatesResolve: result.changed,
@@ -283,6 +361,10 @@ export class Minifier {
           analysis.interprocedural,
           currentResolve,
           this.getSourceMetadata(moduleName),
+        );
+        recordAccepted(
+          "inline-literal-argument-functions",
+          result.inlinedFunctions,
         );
         return {
           changed: result.changed,
@@ -317,6 +399,7 @@ export class Minifier {
             },
           },
         );
+        recordAccepted("inline-tail-call-functions", result.inlinedFunctions);
         return {
           changed: result.changed,
           invalidatesResolve: result.changed,
@@ -332,6 +415,10 @@ export class Minifier {
           analysis.interprocedural,
           currentResolve,
           this.getSourceMetadata(moduleName),
+        );
+        recordAccepted(
+          "inline-closed-statement-functions",
+          result.inlinedFunctions,
         );
         return {
           changed: result.changed,
@@ -364,6 +451,10 @@ export class Minifier {
               );
             },
           },
+        );
+        recordAccepted(
+          "inline-bound-statement-functions",
+          result.inlinedFunctions,
         );
         return {
           changed: result.changed,
@@ -882,6 +973,16 @@ export class Minifier {
           currentResolve,
           metadata,
           facts,
+          (statement) =>
+            this.diagnosticCollector?.record({
+              pass: "function-dce",
+              moduleName,
+              runtimeProfile: this.mode.runtimeProfile ?? "lua53",
+              decision: "accepted",
+              reason: "unused-function",
+              candidateSize: 1,
+              sourceRange: sourceRangeOf(statement),
+            }),
         );
         return { changed, invalidatesResolve: changed };
       });

--- a/src/minifier.ts
+++ b/src/minifier.ts
@@ -38,6 +38,7 @@ import {
 } from "./optimizerAnalysis";
 import { propagateInterproceduralConstants } from "./interproceduralConstants";
 import {
+  inlineClosedStatementFunctions,
   inlineClosedSingleUseFunctions,
   pruneTrailingUnusedParameters,
 } from "./functionRewrites";
@@ -260,6 +261,22 @@ export class Minifier {
           analyzeOptimizerAtGeneration,
         );
         const result = inlineClosedSingleUseFunctions(
+          analysis.interprocedural,
+          currentResolve,
+          this.getSourceMetadata(moduleName),
+        );
+        return {
+          changed: result.changed,
+          invalidatesResolve: result.changed,
+        };
+      });
+      passes.run("inline-closed-statement-functions", (currentResolve) => {
+        const analysis = passes.analysis(
+          OPTIMIZER_ANALYSIS_CACHE_KEY,
+          analyzeOptimizerAtGeneration,
+        );
+        const result = inlineClosedStatementFunctions(
+          ast,
           analysis.interprocedural,
           currentResolve,
           this.getSourceMetadata(moduleName),

--- a/src/minifier.ts
+++ b/src/minifier.ts
@@ -38,6 +38,7 @@ import {
 } from "./optimizerAnalysis";
 import { propagateInterproceduralConstants } from "./interproceduralConstants";
 import {
+  inlineBoundStatementFunctions,
   inlineClosedStatementFunctions,
   inlineClosedSingleUseFunctions,
   inlineLiteralArgumentFunctions,
@@ -297,6 +298,38 @@ export class Minifier {
           analysis.interprocedural,
           currentResolve,
           this.getSourceMetadata(moduleName),
+        );
+        return {
+          changed: result.changed,
+          invalidatesResolve: result.changed,
+        };
+      });
+      passes.run("inline-bound-statement-functions", (currentResolve) => {
+        const analysis = passes.analysis(
+          OPTIMIZER_ANALYSIS_CACHE_KEY,
+          analyzeOptimizerAtGeneration,
+        );
+        const localResources = analyzeLocalResourceUsage(ast);
+        const result = inlineBoundStatementFunctions(
+          ast,
+          analysis.interprocedural,
+          currentResolve,
+          this.getSourceMetadata(moduleName),
+          {
+            maxIntroducedLocalsAt: (statement) => {
+              const active = localResources.activeLocalsBefore(statement);
+              if (active === undefined) return 0;
+              return Math.max(
+                0,
+                Math.min(
+                  runtimeEnvironmentOf(this.mode.runtimeProfile ?? "lua53")
+                    .resources.maxActiveLocalsPerFunction - active,
+                  runtimeEnvironmentOf(this.mode.runtimeProfile ?? "lua53")
+                    .resources.maxRegistersPerFunction - active,
+                ),
+              );
+            },
+          },
         );
         return {
           changed: result.changed,

--- a/src/minifier.ts
+++ b/src/minifier.ts
@@ -130,14 +130,17 @@ export class Minifier {
   private readonly moduleMetadata = new Map<string, SourceMetadata>();
   private readonly diagnosticCollector?: OptimizationDiagnosticCollector;
   private readonly schedulerVariant?: "baseline" | "trial";
+  private readonly functionRewriteVariant?: "baseline" | "trial";
 
   constructor(
     entryFilePath: string,
     luaParseSettings: Partial<Options>,
     mode: MinifierMode,
     schedulerVariant?: "baseline" | "trial",
+    functionRewriteVariant?: "baseline" | "trial",
   ) {
     this.schedulerVariant = schedulerVariant;
+    this.functionRewriteVariant = functionRewriteVariant;
     this.entryFilePath = entryFilePath;
     this.identifiersInUse = new Set<string>();
     this.moduleSourceText = new Map<string, string>();
@@ -166,6 +169,12 @@ export class Minifier {
 
   parse(): SourceNode {
     if (
+      this.functionRewriteVariant === undefined &&
+      this.functionRewritesEnabled()
+    ) {
+      return this.parseWithFunctionRewriteSelection();
+    }
+    if (
       this.schedulerVariant === undefined &&
       this.requiresSchedulerSelection()
     ) {
@@ -174,12 +183,57 @@ export class Minifier {
     return this.parseOnce();
   }
 
+  private parseWithFunctionRewriteSelection(): SourceNode {
+    const baselineMinifier = new Minifier(
+      this.entryFilePath,
+      this.luaParseSettings,
+      this.mode,
+      undefined,
+      "baseline",
+    );
+    const baseline = baselineMinifier.parse();
+    const baselineBytes = new TextEncoder().encode(baseline.toString()).length;
+    let trialMinifier: Minifier;
+    let trial: SourceNode;
+    try {
+      trialMinifier = new Minifier(
+        this.entryFilePath,
+        this.luaParseSettings,
+        this.mode,
+        undefined,
+        "trial",
+      );
+      trial = trialMinifier.parse();
+    } catch {
+      this.copyDiagnosticsFrom(baselineMinifier);
+      this.recordFinalFunctionRewriteDecision("rejected", "trial-failed");
+      return this.adoptVariant(baselineMinifier, baseline);
+    }
+    const trialBytes = new TextEncoder().encode(trial.toString()).length;
+    if (trialBytes >= baselineBytes) {
+      this.copyDiagnosticsFrom(trialMinifier);
+      this.recordFinalFunctionRewriteDecision(
+        "rejected",
+        "final-output-not-shorter",
+      );
+      return this.adoptVariant(baselineMinifier, baseline);
+    }
+    this.copyDiagnosticsFrom(trialMinifier);
+    this.recordFinalFunctionRewriteDecision(
+      "accepted",
+      "final-output-shorter",
+      baselineBytes - trialBytes,
+    );
+    return this.adoptVariant(trialMinifier, trial);
+  }
+
   private parseWithSchedulerSelection(): SourceNode {
     const baselineMinifier = new Minifier(
       this.entryFilePath,
       this.luaParseSettings,
       this.mode,
       "baseline",
+      this.functionRewriteVariant,
     );
     const baseline = baselineMinifier.parseOnce();
     const baselineBytes = new TextEncoder().encode(baseline.toString()).length;
@@ -191,6 +245,7 @@ export class Minifier {
         this.luaParseSettings,
         this.mode,
         "trial",
+        this.functionRewriteVariant,
       );
       trial = trialMinifier.parseOnce();
     } catch {
@@ -241,7 +296,10 @@ export class Minifier {
 
   /** Function-summary consumers run before scheduling and final rename/print. */
   private rewriteFunctionsAll(): void {
-    if (this.schedulerVariant === "baseline" || !this.functionRewritesEnabled())
+    if (
+      this.functionRewriteVariant === "baseline" ||
+      !this.functionRewritesEnabled()
+    )
       return;
 
     this.linkOrder.forEach((moduleName) => {
@@ -466,7 +524,6 @@ export class Minifier {
   }
 
   private requiresSchedulerSelection(): boolean {
-    if (this.functionRewritesEnabled()) return true;
     if (this.mode.mergeLocals !== false) return true;
     if (this.mode.effectAwareTransforms === false) return false;
     const runtime = runtimeEnvironmentOf(this.mode.runtimeProfile ?? "lua53");
@@ -519,6 +576,24 @@ export class Minifier {
   ): void {
     this.diagnosticCollector?.record({
       pass: "statement-scheduler-final-cost",
+      decision,
+      reason,
+      candidateSize: 1,
+      estimatedByteSavings: byteSavings,
+      runtimeProfile: this.mode.runtimeProfile ?? "lua53",
+      moduleName: this.entryModule,
+      sourceRange: [0, fs.readFileSync(this.entryFilePath, "utf8").length],
+    });
+  }
+
+  private recordFinalFunctionRewriteDecision(
+    decision: "accepted" | "rejected",
+    reason:
+      "final-output-shorter" | "final-output-not-shorter" | "trial-failed",
+    byteSavings?: number,
+  ): void {
+    this.diagnosticCollector?.record({
+      pass: "function-rewrite-final-cost",
       decision,
       reason,
       candidateSize: 1,

--- a/src/minifier.ts
+++ b/src/minifier.ts
@@ -37,7 +37,10 @@ import {
   OPTIMIZER_ANALYSIS_CACHE_KEY,
 } from "./optimizerAnalysis";
 import { propagateInterproceduralConstants } from "./interproceduralConstants";
-import { pruneTrailingUnusedParameters } from "./functionRewrites";
+import {
+  inlineClosedSingleUseFunctions,
+  pruneTrailingUnusedParameters,
+} from "./functionRewrites";
 
 export type { RuntimeProfile } from "./runtimeEnvironment";
 
@@ -244,6 +247,21 @@ export class Minifier {
         );
         const result = pruneTrailingUnusedParameters(
           analysis.interprocedural.callGraph,
+          this.getSourceMetadata(moduleName),
+        );
+        return {
+          changed: result.changed,
+          invalidatesResolve: result.changed,
+        };
+      });
+      passes.run("inline-closed-single-use-functions", (currentResolve) => {
+        const analysis = passes.analysis(
+          OPTIMIZER_ANALYSIS_CACHE_KEY,
+          analyzeOptimizerAtGeneration,
+        );
+        const result = inlineClosedSingleUseFunctions(
+          analysis.interprocedural,
+          currentResolve,
           this.getSourceMetadata(moduleName),
         );
         return {

--- a/src/minifier.ts
+++ b/src/minifier.ts
@@ -37,6 +37,7 @@ import {
   OPTIMIZER_ANALYSIS_CACHE_KEY,
 } from "./optimizerAnalysis";
 import { propagateInterproceduralConstants } from "./interproceduralConstants";
+import { pruneTrailingUnusedParameters } from "./functionRewrites";
 
 export type { RuntimeProfile } from "./runtimeEnvironment";
 
@@ -205,6 +206,8 @@ export class Minifier {
     this.link();
     this.foldConstantsAll();
     this.removeUnusedAll();
+    this.rewriteFunctionsAll();
+    this.removeUnusedAll();
     this.rebuildIdentifiersInUse();
     this.computeGlobalRenames();
     this.transformAll();
@@ -224,7 +227,36 @@ export class Minifier {
     return result;
   }
 
+  /** Function-summary consumers run before scheduling and final rename/print. */
+  private rewriteFunctionsAll(): void {
+    if (this.schedulerVariant === "baseline" || !this.functionRewritesEnabled())
+      return;
+
+    this.linkOrder.forEach((moduleName) => {
+      const ast = this.moduleAST.get(moduleName);
+      const resolved = this.moduleResolve.get(moduleName);
+      if (!ast || !resolved) throw new Error(moduleName + " is not found");
+      const passes = new PassOrchestrator(ast, resolved);
+      passes.run("prune-trailing-unused-parameters", () => {
+        const analysis = passes.analysis(
+          OPTIMIZER_ANALYSIS_CACHE_KEY,
+          analyzeOptimizerAtGeneration,
+        );
+        const result = pruneTrailingUnusedParameters(
+          analysis.interprocedural.callGraph,
+          this.getSourceMetadata(moduleName),
+        );
+        return {
+          changed: result.changed,
+          invalidatesResolve: result.changed,
+        };
+      });
+      this.moduleResolve.set(moduleName, passes.resolved);
+    });
+  }
+
   private requiresSchedulerSelection(): boolean {
+    if (this.functionRewritesEnabled()) return true;
     if (this.mode.mergeLocals !== false) return true;
     if (this.mode.effectAwareTransforms === false) return false;
     const runtime = runtimeEnvironmentOf(this.mode.runtimeProfile ?? "lua53");
@@ -235,6 +267,15 @@ export class Minifier {
       lifetimeAllowed &&
       (this.mode.effectAwareLocalHoist !== false ||
         this.mode.effectAwareTableReads !== false)
+    );
+  }
+
+  private functionRewritesEnabled(): boolean {
+    if (this.mode.effectAwareTransforms === false) return false;
+    const runtime = runtimeEnvironmentOf(this.mode.runtimeProfile ?? "lua53");
+    return (
+      !runtime.semantics.debugLocalIntrospection ||
+      this.mode.allowLocalLifetimeChanges === true
     );
   }
 

--- a/src/minifier.ts
+++ b/src/minifier.ts
@@ -42,6 +42,7 @@ import {
   inlineClosedStatementFunctions,
   inlineClosedSingleUseFunctions,
   inlineLiteralArgumentFunctions,
+  inlineTailCallFunctions,
   pruneTrailingUnusedParameters,
 } from "./functionRewrites";
 
@@ -282,6 +283,39 @@ export class Minifier {
           analysis.interprocedural,
           currentResolve,
           this.getSourceMetadata(moduleName),
+        );
+        return {
+          changed: result.changed,
+          invalidatesResolve: result.changed,
+        };
+      });
+      passes.run("inline-tail-call-functions", (currentResolve) => {
+        const analysis = passes.analysis(
+          OPTIMIZER_ANALYSIS_CACHE_KEY,
+          analyzeOptimizerAtGeneration,
+        );
+        const localResources = analyzeLocalResourceUsage(ast);
+        const runtime = runtimeEnvironmentOf(
+          this.mode.runtimeProfile ?? "lua53",
+        );
+        const result = inlineTailCallFunctions(
+          ast,
+          analysis.interprocedural,
+          currentResolve,
+          this.getSourceMetadata(moduleName),
+          {
+            maxIntroducedLocalsAt: (statement) => {
+              const active = localResources.activeLocalsBefore(statement);
+              if (active === undefined) return 0;
+              return Math.max(
+                0,
+                Math.min(
+                  runtime.resources.maxActiveLocalsPerFunction - active,
+                  runtime.resources.maxRegistersPerFunction - active,
+                ),
+              );
+            },
+          },
         );
         return {
           changed: result.changed,

--- a/src/minifier.ts
+++ b/src/minifier.ts
@@ -40,6 +40,7 @@ import { propagateInterproceduralConstants } from "./interproceduralConstants";
 import {
   inlineClosedStatementFunctions,
   inlineClosedSingleUseFunctions,
+  inlineLiteralArgumentFunctions,
   pruneTrailingUnusedParameters,
 } from "./functionRewrites";
 
@@ -211,6 +212,7 @@ export class Minifier {
     this.foldConstantsAll();
     this.removeUnusedAll();
     this.rewriteFunctionsAll();
+    this.foldConstantsAll();
     this.removeUnusedAll();
     this.rebuildIdentifiersInUse();
     this.computeGlobalRenames();
@@ -261,6 +263,21 @@ export class Minifier {
           analyzeOptimizerAtGeneration,
         );
         const result = inlineClosedSingleUseFunctions(
+          analysis.interprocedural,
+          currentResolve,
+          this.getSourceMetadata(moduleName),
+        );
+        return {
+          changed: result.changed,
+          invalidatesResolve: result.changed,
+        };
+      });
+      passes.run("inline-literal-argument-functions", (currentResolve) => {
+        const analysis = passes.analysis(
+          OPTIMIZER_ANALYSIS_CACHE_KEY,
+          analyzeOptimizerAtGeneration,
+        );
+        const result = inlineLiteralArgumentFunctions(
           analysis.interprocedural,
           currentResolve,
           this.getSourceMetadata(moduleName),

--- a/src/optimizerDiagnostics.ts
+++ b/src/optimizerDiagnostics.ts
@@ -41,7 +41,13 @@ export type OptimizationDiagnosticReason =
   | "recursive-scc-converged"
   | "parameter-field-effect"
   | "parameter-escape"
-  | "external-contract-used";
+  | "external-contract-used"
+  | "function-rewrite-applied"
+  | "multiple-call-sites"
+  | "function-escape"
+  | "recursive-function"
+  | "vararg-function"
+  | "unused-function";
 
 export interface OptimizationDiagnostic {
   readonly pass: string;

--- a/src/removeUnused.ts
+++ b/src/removeUnused.ts
@@ -69,11 +69,19 @@ function removeFromBlock(
   resolved: ResolveResult,
   metadata: SourceMetadata,
   facts: OptimizerFacts,
+  onRemoveLocalFunction?: (statement: Parser.FunctionDeclaration) => void,
 ): boolean {
   let changed = false;
   body.forEach((statement) => {
     nestedBodies(statement).forEach((nested) => {
-      changed = removeFromBlock(nested, resolved, metadata, facts) || changed;
+      changed =
+        removeFromBlock(
+          nested,
+          resolved,
+          metadata,
+          facts,
+          onRemoveLocalFunction,
+        ) || changed;
     });
   });
 
@@ -87,6 +95,7 @@ function removeFromBlock(
     ) {
       const symbol = resolved.symbolOf(statement.identifier);
       if (symbol && !hasExternalReference(statement, symbol.references)) {
+        onRemoveLocalFunction?.(statement);
         changed = true;
         replacements.set(statement, []);
         return;
@@ -188,6 +197,13 @@ export function removeUnusedLocals(
   resolved: ResolveResult,
   metadata: SourceMetadata,
   facts: OptimizerFacts,
+  onRemoveLocalFunction?: (statement: Parser.FunctionDeclaration) => void,
 ): boolean {
-  return removeFromBlock(chunk.body, resolved, metadata, facts);
+  return removeFromBlock(
+    chunk.body,
+    resolved,
+    metadata,
+    facts,
+    onRemoveLocalFunction,
+  );
 }

--- a/test/functionRewrites.integration.test.ts
+++ b/test/functionRewrites.integration.test.ts
@@ -72,4 +72,18 @@ return first(1,sideEffect())
     expect(optimized).toContain("first()globalValue=second()");
     expect(optimized).not.toContain("function");
   });
+
+  test("specializes literal arguments before later optimization", () => {
+    const source =
+      "local function add(value,amount)return value+amount end return add(40,2)";
+    const optimized = minifyTemporaryLuaSource(source, {
+      moduleLikeLua: false,
+      runtimeProfile: "stormworks",
+      mergeLocals: false,
+      foldConstants: true,
+    }).code;
+
+    expect(optimized).not.toContain("function");
+    expect(optimized).toContain("42");
+  });
 });

--- a/test/functionRewrites.integration.test.ts
+++ b/test/functionRewrites.integration.test.ts
@@ -116,4 +116,51 @@ return first(1,sideEffect())
     expect(optimized).toContain("return");
     expect(optimized).toContain("make()");
   });
+
+  test("deletes unreachable local functions through the shared unused pass", () => {
+    const source = "local function unreachable() publish() end return 1";
+    const result = minifyTemporaryLuaSource(source, {
+      moduleLikeLua: false,
+      runtimeProfile: "stormworks",
+      collectOptimizationDiagnostics: true,
+    });
+
+    expect(result.code).not.toContain("function");
+    expect(result.minifier.optimizationDiagnostics).toContainEqual(
+      expect.objectContaining({
+        pass: "function-dce",
+        decision: "accepted",
+        reason: "unused-function",
+      }),
+    );
+  });
+
+  test("reports recursive, escaping, multi-use, and vararg rejection reasons", () => {
+    const source = `
+local function recursive(value) if value then return recursive(false) end end
+local function escaping(value) return value end
+consume(escaping)
+local function shared(value) return value end
+publish(shared(1),shared(2))
+local function variadic(...) return ... end
+return recursive(true),variadic(1)
+`;
+    const result = minifyTemporaryLuaSource(source, {
+      moduleLikeLua: false,
+      runtimeProfile: "stormworks",
+      collectOptimizationDiagnostics: true,
+    });
+    const reasons = result.minifier.optimizationDiagnostics
+      .filter((diagnostic) => diagnostic.pass === "function-rewrite")
+      .map((diagnostic) => diagnostic.reason);
+
+    expect(reasons).toEqual(
+      expect.arrayContaining([
+        "recursive-function",
+        "function-escape",
+        "multiple-call-sites",
+        "vararg-function",
+      ]),
+    );
+  });
 });

--- a/test/functionRewrites.integration.test.ts
+++ b/test/functionRewrites.integration.test.ts
@@ -46,4 +46,17 @@ return first(1,sideEffect())
 
     expect(allowed.length).toBeLessThan(preserved.length);
   });
+
+  test("inlines a closed single-use function and removes its declaration", () => {
+    const source =
+      "local function compute()return external()+1 end return compute()";
+    const optimized = minifyTemporaryLuaSource(source, {
+      moduleLikeLua: false,
+      runtimeProfile: "stormworks",
+      mergeLocals: false,
+    }).code;
+
+    expect(optimized).toContain("external()+1");
+    expect(optimized).not.toContain("function");
+  });
 });

--- a/test/functionRewrites.integration.test.ts
+++ b/test/functionRewrites.integration.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "vitest";
+import { SourceMapConsumer } from "source-map";
 import { minifyTemporaryLuaSource } from "./lib/minifierHarness";
 
 describe("function rewrites integration", () => {
@@ -162,5 +163,33 @@ return recursive(true),variadic(1)
         "vararg-function",
       ]),
     );
+  });
+
+  test("maps an inlined expression to its function-body origin", async () => {
+    const source = [
+      "local function compute()",
+      "  return external()+1",
+      "end",
+      "return compute()",
+    ].join("\n");
+    const result = minifyTemporaryLuaSource(source, {
+      moduleLikeLua: false,
+      runtimeProfile: "stormworks",
+      mergeLocals: false,
+    });
+    const offset = result.code.indexOf("external");
+    expect(offset).toBeGreaterThanOrEqual(0);
+    const before = result.code.slice(0, offset).split("\n");
+    const generated = {
+      line: before.length,
+      column: before.at(-1)?.length ?? 0,
+    };
+
+    await SourceMapConsumer.with(result.map, null, (consumer) => {
+      const origin = consumer.originalPositionFor(generated);
+      expect(origin.source).toBe("main.lua");
+      expect(origin.line).toBe(2);
+      expect(origin.name).toBe("external");
+    });
   });
 });

--- a/test/functionRewrites.integration.test.ts
+++ b/test/functionRewrites.integration.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "vitest";
+import { minifyTemporaryLuaSource } from "./lib/minifierHarness";
+
+describe("function rewrites integration", () => {
+  test("prunes a trailing unused parameter but leaves surplus actual evaluation", () => {
+    const source = `
+local function first(value,unused) return value end
+return first(1,sideEffect())
+`;
+    const optimized = minifyTemporaryLuaSource(source, {
+      moduleLikeLua: false,
+      runtimeProfile: "stormworks",
+      mergeLocals: false,
+    }).code;
+    const baseline = minifyTemporaryLuaSource(source, {
+      moduleLikeLua: false,
+      runtimeProfile: "stormworks",
+      mergeLocals: false,
+      effectAwareTransforms: false,
+    }).code;
+
+    expect(optimized).toContain("sideEffect()");
+    expect(Buffer.byteLength(optimized)).toBeLessThan(
+      Buffer.byteLength(baseline),
+    );
+  });
+
+  test("preserves parameter declarations under Lua debug introspection", () => {
+    const source =
+      "local function first(value,unused)return value end return first(1,2)";
+    const preserved = minifyTemporaryLuaSource(source, {
+      moduleLikeLua: false,
+      runtimeProfile: "lua53",
+      mergeLocals: false,
+      effectAwareLocalHoist: false,
+      effectAwareTableReads: false,
+    }).code;
+    const allowed = minifyTemporaryLuaSource(source, {
+      moduleLikeLua: false,
+      runtimeProfile: "lua53",
+      allowLocalLifetimeChanges: true,
+      mergeLocals: false,
+      effectAwareLocalHoist: false,
+      effectAwareTableReads: false,
+    }).code;
+
+    expect(allowed.length).toBeLessThan(preserved.length);
+  });
+});

--- a/test/functionRewrites.integration.test.ts
+++ b/test/functionRewrites.integration.test.ts
@@ -59,4 +59,17 @@ return first(1,sideEffect())
     expect(optimized).toContain("external()+1");
     expect(optimized).not.toContain("function");
   });
+
+  test("splices a multi-statement closed body and removes the call frame", () => {
+    const source =
+      "local function run() first() globalValue=second() end run()";
+    const optimized = minifyTemporaryLuaSource(source, {
+      moduleLikeLua: false,
+      runtimeProfile: "stormworks",
+      mergeLocals: false,
+    }).code;
+
+    expect(optimized).toContain("first()globalValue=second()");
+    expect(optimized).not.toContain("function");
+  });
 });

--- a/test/functionRewrites.integration.test.ts
+++ b/test/functionRewrites.integration.test.ts
@@ -102,4 +102,18 @@ return first(1,sideEffect())
     expect(optimized).not.toContain("function");
     expect(optimized).toContain("publish");
   });
+
+  test("preserves a multi-statement return tuple in tail position", () => {
+    const source =
+      "local function pair(value)local next=value+1 if flag then return value,next end return next,value end return pair(make())";
+    const optimized = minifyTemporaryLuaSource(source, {
+      moduleLikeLua: false,
+      runtimeProfile: "stormworks",
+      mergeLocals: false,
+    }).code;
+
+    expect(optimized).not.toContain("function");
+    expect(optimized).toContain("return");
+    expect(optimized).toContain("make()");
+  });
 });

--- a/test/functionRewrites.integration.test.ts
+++ b/test/functionRewrites.integration.test.ts
@@ -86,4 +86,20 @@ return first(1,sideEffect())
     expect(optimized).not.toContain("function");
     expect(optimized).toContain("42");
   });
+
+  test("preserves arbitrary actual evaluation through a parameter binding", () => {
+    const source =
+      "local function run(first,second)local sum=first+second publish(sum)end run(makeFirst(),makeSecond())";
+    const optimized = minifyTemporaryLuaSource(source, {
+      moduleLikeLua: false,
+      runtimeProfile: "stormworks",
+      mergeLocals: false,
+    }).code;
+
+    expect(optimized.indexOf("makeFirst()")).toBeLessThan(
+      optimized.indexOf("makeSecond()"),
+    );
+    expect(optimized).not.toContain("function");
+    expect(optimized).toContain("publish");
+  });
 });

--- a/test/functionRewrites.integration.test.ts
+++ b/test/functionRewrites.integration.test.ts
@@ -192,4 +192,22 @@ return recursive(true),variadic(1)
       expect(origin.name).toBe("external");
     });
   });
+
+  test("gates function rewrites separately at final output", () => {
+    const result = minifyTemporaryLuaSource(
+      "local function run(value)publish(value)end run(make())",
+      {
+        moduleLikeLua: false,
+        runtimeProfile: "stormworks",
+        mergeLocals: false,
+        collectOptimizationDiagnostics: true,
+      },
+    );
+    expect(result.minifier.optimizationDiagnostics).toContainEqual(
+      expect.objectContaining({
+        pass: "function-rewrite-final-cost",
+        decision: expect.stringMatching(/accepted|rejected/),
+      }),
+    );
+  });
 });

--- a/test/functionRewrites.integration.test.ts
+++ b/test/functionRewrites.integration.test.ts
@@ -203,11 +203,10 @@ return recursive(true),variadic(1)
         collectOptimizationDiagnostics: true,
       },
     );
-    expect(result.minifier.optimizationDiagnostics).toContainEqual(
-      expect.objectContaining({
-        pass: "function-rewrite-final-cost",
-        decision: expect.stringMatching(/accepted|rejected/),
-      }),
-    );
+    expect(
+      result.minifier.optimizationDiagnostics.some(
+        (diagnostic) => diagnostic.pass === "function-rewrite-final-cost",
+      ),
+    ).toBe(true);
   });
 });

--- a/test/functionRewrites.test.ts
+++ b/test/functionRewrites.test.ts
@@ -2,6 +2,7 @@ import Parser from "luaparse";
 import { describe, expect, test } from "vitest";
 import { analyzeCallGraph } from "../src/callGraph";
 import {
+  inlineBoundStatementFunctions,
   inlineClosedStatementFunctions,
   inlineClosedSingleUseFunctions,
   inlineLiteralArgumentFunctions,
@@ -181,5 +182,62 @@ describe("function rewrites", () => {
     collectStrings(finalReturn.arguments[0]);
     expect(strings[0].raw).toBe('"x"');
     expect(strings[0].loc).toEqual(firstActualLoc);
+  });
+
+  test("binds arbitrary actuals before splicing a statement body", () => {
+    const source =
+      "local function run(first,second) local sum=first+second publish(sum) end run(makeFirst(),makeSecond())";
+    const chunk = Parser.parse(source, {
+      luaVersion: "5.3",
+      comments: true,
+      locations: true,
+      ranges: true,
+    });
+    const resolved = resolveScopes(chunk);
+    const facts = analyzeOptimizerFacts(chunk, resolved);
+    const callGraph = analyzeCallGraph(chunk, resolved, facts);
+    const result = inlineBoundStatementFunctions(
+      chunk,
+      analyzeInterprocedural(chunk, resolved, callGraph),
+      resolved,
+      new SourceMetadata(chunk, source),
+      { maxIntroducedLocalsAt: () => 10 },
+    );
+
+    expect(result).toEqual({ changed: true, inlinedFunctions: 1 });
+    const replacement = chunk.body[1];
+    expect(replacement.type).toBe("DoStatement");
+    if (replacement.type !== "DoStatement") throw new Error("expected do");
+    expect(replacement.body[0]).toMatchObject({
+      type: "LocalStatement",
+      variables: [{ name: "first" }, { name: "second" }],
+      init: [
+        { type: "CallExpression", base: { name: "makeFirst" } },
+        { type: "CallExpression", base: { name: "makeSecond" } },
+      ],
+    });
+  });
+
+  test("rejects an upvalue whose spelling could be captured at the call site", () => {
+    const source =
+      "local captured=1 local function run(value) publish(captured,value) end do local captured=2 run(make()) end";
+    const chunk = Parser.parse(source, {
+      luaVersion: "5.3",
+      comments: true,
+      locations: true,
+      ranges: true,
+    });
+    const resolved = resolveScopes(chunk);
+    const facts = analyzeOptimizerFacts(chunk, resolved);
+    const callGraph = analyzeCallGraph(chunk, resolved, facts);
+    const result = inlineBoundStatementFunctions(
+      chunk,
+      analyzeInterprocedural(chunk, resolved, callGraph),
+      resolved,
+      new SourceMetadata(chunk, source),
+      { maxIntroducedLocalsAt: () => 10 },
+    );
+
+    expect(result).toEqual({ changed: false, inlinedFunctions: 0 });
   });
 });

--- a/test/functionRewrites.test.ts
+++ b/test/functionRewrites.test.ts
@@ -35,7 +35,7 @@ function rewrite(source: string) {
 
 function firstFunction(chunk: Parser.Chunk): Parser.FunctionDeclaration {
   const statement = chunk.body[0];
-  if (statement?.type !== "FunctionDeclaration")
+  if (statement.type !== "FunctionDeclaration")
     throw new Error("expected a function declaration");
   return statement;
 }

--- a/test/functionRewrites.test.ts
+++ b/test/functionRewrites.test.ts
@@ -1,7 +1,11 @@
 import Parser from "luaparse";
 import { describe, expect, test } from "vitest";
 import { analyzeCallGraph } from "../src/callGraph";
-import { pruneTrailingUnusedParameters } from "../src/functionRewrites";
+import {
+  inlineClosedSingleUseFunctions,
+  pruneTrailingUnusedParameters,
+} from "../src/functionRewrites";
+import { analyzeInterprocedural } from "../src/interproceduralAnalysis";
 import { analyzeOptimizerFacts } from "../src/optimizerFacts";
 import { resolveScopes } from "../src/resolver";
 import { SourceMetadata } from "../src/sourceMetadata";
@@ -61,5 +65,54 @@ describe("function rewrites", () => {
     );
     expect(result).toEqual({ changed: false, prunedParameters: 0 });
     expect(firstFunction(chunk).parameters).toHaveLength(1);
+  });
+
+  test("inlines a single-use closed return expression with body provenance", () => {
+    const source =
+      "local function value() return external()+1 end return value()";
+    const chunk = Parser.parse(source, {
+      luaVersion: "5.3",
+      comments: true,
+      locations: true,
+      ranges: true,
+    });
+    const resolved = resolveScopes(chunk);
+    const facts = analyzeOptimizerFacts(chunk, resolved);
+    const callGraph = analyzeCallGraph(chunk, resolved, facts);
+    const originalExpression = (
+      firstFunction(chunk).body[0] as Parser.ReturnStatement
+    ).arguments[0];
+    const result = inlineClosedSingleUseFunctions(
+      analyzeInterprocedural(chunk, resolved, callGraph),
+      resolved,
+      new SourceMetadata(chunk, source),
+    );
+    const finalReturn = chunk.body[1] as Parser.ReturnStatement;
+
+    expect(result).toEqual({ changed: true, inlinedFunctions: 1 });
+    expect(finalReturn.arguments[0].type).toBe("BinaryExpression");
+    expect(finalReturn.arguments[0]).not.toBe(originalExpression);
+    expect(finalReturn.arguments[0].loc).toEqual(originalExpression.loc);
+  });
+
+  test("rejects local/upvalue capture until alpha conversion is available", () => {
+    const source =
+      "local captured=1 local function value() return captured end do local captured=2 return value() end";
+    const chunk = Parser.parse(source, {
+      luaVersion: "5.3",
+      comments: true,
+      locations: true,
+      ranges: true,
+    });
+    const resolved = resolveScopes(chunk);
+    const facts = analyzeOptimizerFacts(chunk, resolved);
+    const callGraph = analyzeCallGraph(chunk, resolved, facts);
+    const result = inlineClosedSingleUseFunctions(
+      analyzeInterprocedural(chunk, resolved, callGraph),
+      resolved,
+      new SourceMetadata(chunk, source),
+    );
+
+    expect(result).toEqual({ changed: false, inlinedFunctions: 0 });
   });
 });

--- a/test/functionRewrites.test.ts
+++ b/test/functionRewrites.test.ts
@@ -2,6 +2,7 @@ import Parser from "luaparse";
 import { describe, expect, test } from "vitest";
 import { analyzeCallGraph } from "../src/callGraph";
 import {
+  inlineClosedStatementFunctions,
   inlineClosedSingleUseFunctions,
   pruneTrailingUnusedParameters,
 } from "../src/functionRewrites";
@@ -114,5 +115,32 @@ describe("function rewrites", () => {
     );
 
     expect(result).toEqual({ changed: false, inlinedFunctions: 0 });
+  });
+
+  test("splices a closed straight-line body at its only statement call", () => {
+    const source =
+      "local function run() first() globalValue=second() return end run()";
+    const chunk = Parser.parse(source, {
+      luaVersion: "5.3",
+      comments: true,
+      locations: true,
+      ranges: true,
+    });
+    const resolved = resolveScopes(chunk);
+    const facts = analyzeOptimizerFacts(chunk, resolved);
+    const callGraph = analyzeCallGraph(chunk, resolved, facts);
+    const result = inlineClosedStatementFunctions(
+      chunk,
+      analyzeInterprocedural(chunk, resolved, callGraph),
+      resolved,
+      new SourceMetadata(chunk, source),
+    );
+
+    expect(result).toEqual({ changed: true, inlinedFunctions: 1 });
+    expect(chunk.body.map((statement) => statement.type)).toEqual([
+      "FunctionDeclaration",
+      "CallStatement",
+      "AssignmentStatement",
+    ]);
   });
 });

--- a/test/functionRewrites.test.ts
+++ b/test/functionRewrites.test.ts
@@ -6,6 +6,7 @@ import {
   inlineClosedStatementFunctions,
   inlineClosedSingleUseFunctions,
   inlineLiteralArgumentFunctions,
+  inlineTailCallFunctions,
   pruneTrailingUnusedParameters,
 } from "../src/functionRewrites";
 import { analyzeInterprocedural } from "../src/interproceduralAnalysis";
@@ -239,5 +240,40 @@ describe("function rewrites", () => {
     );
 
     expect(result).toEqual({ changed: false, inlinedFunctions: 0 });
+  });
+
+  test("inlines multi-statement and tuple returns into a caller tail", () => {
+    const source =
+      "local function pair(value) local next=value+1 if flag then return value,next end return next,value end return pair(make())";
+    const chunk = Parser.parse(source, {
+      luaVersion: "5.3",
+      comments: true,
+      locations: true,
+      ranges: true,
+    });
+    const resolved = resolveScopes(chunk);
+    const facts = analyzeOptimizerFacts(chunk, resolved);
+    const callGraph = analyzeCallGraph(chunk, resolved, facts);
+    const result = inlineTailCallFunctions(
+      chunk,
+      analyzeInterprocedural(chunk, resolved, callGraph),
+      resolved,
+      new SourceMetadata(chunk, source),
+      { maxIntroducedLocalsAt: () => 10 },
+    );
+
+    expect(result).toEqual({ changed: true, inlinedFunctions: 1 });
+    const replacement = chunk.body[1];
+    expect(replacement.type).toBe("DoStatement");
+    if (replacement.type !== "DoStatement") throw new Error("expected do");
+    expect(replacement.body[0]).toMatchObject({
+      type: "LocalStatement",
+      init: [{ type: "CallExpression", base: { name: "make" } }],
+    });
+    expect(
+      replacement.body.filter(
+        (statement) => statement.type === "ReturnStatement",
+      ),
+    ).toHaveLength(1);
   });
 });

--- a/test/functionRewrites.test.ts
+++ b/test/functionRewrites.test.ts
@@ -211,12 +211,64 @@ describe("function rewrites", () => {
     if (replacement.type !== "DoStatement") throw new Error("expected do");
     expect(replacement.body[0]).toMatchObject({
       type: "LocalStatement",
-      variables: [{ name: "first" }, { name: "second" }],
+      variables: [{ name: "__stormInline0" }, { name: "__stormInline1" }],
       init: [
         { type: "CallExpression", base: { name: "makeFirst" } },
         { type: "CallExpression", base: { name: "makeSecond" } },
       ],
     });
+    expect(replacement.body[1]).toMatchObject({
+      type: "LocalStatement",
+      variables: [{ name: "__stormInline2" }],
+      init: [
+        {
+          type: "BinaryExpression",
+          left: { name: "__stormInline0" },
+          right: { name: "__stormInline1" },
+        },
+      ],
+    });
+  });
+
+  test("alpha-converts copied symbols away from call-site shadowing", () => {
+    const source =
+      "local function run(value) local result=value+1 publish(result) end do local result=99 run(make()) publish(result) end";
+    const chunk = Parser.parse(source, { luaVersion: "5.3" });
+    const resolved = resolveScopes(chunk);
+    const facts = analyzeOptimizerFacts(chunk, resolved);
+    const callGraph = analyzeCallGraph(chunk, resolved, facts);
+
+    inlineBoundStatementFunctions(
+      chunk,
+      analyzeInterprocedural(chunk, resolved, callGraph),
+      resolved,
+      new SourceMetadata(chunk, source),
+      { maxIntroducedLocalsAt: () => 10 },
+    );
+
+    const outer = chunk.body[1];
+    expect(outer.type).toBe("DoStatement");
+    if (outer.type !== "DoStatement") throw new Error("expected outer do");
+    const replacement = outer.body[1];
+    expect(replacement.type).toBe("DoStatement");
+    if (replacement.type !== "DoStatement")
+      throw new Error("expected inline do");
+    const binding = replacement.body[0] as Parser.LocalStatement;
+    const copiedLocal = replacement.body[1] as Parser.LocalStatement;
+    expect(binding.variables[0].name).toBe("__stormInline0");
+    expect(copiedLocal.variables[0].name).toBe("__stormInline1");
+
+    const after = resolveScopes(chunk);
+    const initializer = copiedLocal.init[0] as Parser.BinaryExpression;
+    expect(
+      after.symbolOf(initializer.left as Parser.Identifier)?.declaration,
+    ).toBe(binding.variables[0]);
+    const publish = replacement.body[2] as Parser.CallStatement;
+    const resultReference = (publish.expression as Parser.CallExpression)
+      .arguments[0] as Parser.Identifier;
+    expect(after.symbolOf(resultReference)?.declaration).toBe(
+      copiedLocal.variables[0],
+    );
   });
 
   test("rejects an upvalue whose spelling could be captured at the call site", () => {

--- a/test/functionRewrites.test.ts
+++ b/test/functionRewrites.test.ts
@@ -4,6 +4,7 @@ import { analyzeCallGraph } from "../src/callGraph";
 import {
   inlineClosedStatementFunctions,
   inlineClosedSingleUseFunctions,
+  inlineLiteralArgumentFunctions,
   pruneTrailingUnusedParameters,
 } from "../src/functionRewrites";
 import { analyzeInterprocedural } from "../src/interproceduralAnalysis";
@@ -142,5 +143,43 @@ describe("function rewrites", () => {
       "CallStatement",
       "AssignmentStatement",
     ]);
+  });
+
+  test("specializes primitive literal arguments with call-site provenance", () => {
+    const source =
+      'local function format(value,suffix)return prefix..value..suffix end return format("x","!")';
+    const chunk = Parser.parse(source, {
+      luaVersion: "5.3",
+      comments: true,
+      locations: true,
+      ranges: true,
+    });
+    const resolved = resolveScopes(chunk);
+    const facts = analyzeOptimizerFacts(chunk, resolved);
+    const callGraph = analyzeCallGraph(chunk, resolved, facts);
+    const call = callGraph.calls.at(-1)?.call;
+    if (call?.type !== "CallExpression") throw new Error("expected call");
+    const firstActualLoc = call.arguments[0].loc;
+    const result = inlineLiteralArgumentFunctions(
+      analyzeInterprocedural(chunk, resolved, callGraph),
+      resolved,
+      new SourceMetadata(chunk, source),
+    );
+    const finalReturn = chunk.body[1] as Parser.ReturnStatement;
+
+    expect(result).toEqual({ changed: true, inlinedFunctions: 1 });
+    expect(finalReturn.arguments[0].type).toBe("BinaryExpression");
+    const strings: Parser.StringLiteral[] = [];
+    const collectStrings = (value: unknown): void => {
+      if (!value || typeof value !== "object") return;
+      if ((value as Parser.Node).type === "StringLiteral") {
+        strings.push(value as Parser.StringLiteral);
+        return;
+      }
+      Object.values(value).forEach(collectStrings);
+    };
+    collectStrings(finalReturn.arguments[0]);
+    expect(strings[0].raw).toBe('"x"');
+    expect(strings[0].loc).toEqual(firstActualLoc);
   });
 });

--- a/test/functionRewrites.test.ts
+++ b/test/functionRewrites.test.ts
@@ -1,0 +1,65 @@
+import Parser from "luaparse";
+import { describe, expect, test } from "vitest";
+import { analyzeCallGraph } from "../src/callGraph";
+import { pruneTrailingUnusedParameters } from "../src/functionRewrites";
+import { analyzeOptimizerFacts } from "../src/optimizerFacts";
+import { resolveScopes } from "../src/resolver";
+import { SourceMetadata } from "../src/sourceMetadata";
+
+function rewrite(source: string) {
+  const chunk = Parser.parse(source, {
+    luaVersion: "5.3",
+    comments: true,
+    locations: true,
+    ranges: true,
+  });
+  const resolved = resolveScopes(chunk);
+  const facts = analyzeOptimizerFacts(chunk, resolved);
+  const callGraph = analyzeCallGraph(chunk, resolved, facts);
+  return {
+    chunk,
+    result: pruneTrailingUnusedParameters(
+      callGraph,
+      new SourceMetadata(chunk, source),
+    ),
+  };
+}
+
+function firstFunction(chunk: Parser.Chunk): Parser.FunctionDeclaration {
+  const statement = chunk.body[0];
+  if (statement?.type !== "FunctionDeclaration")
+    throw new Error("expected a function declaration");
+  return statement;
+}
+
+describe("function rewrites", () => {
+  test("prunes only the contiguous unused parameter tail", () => {
+    const { chunk, result } = rewrite(
+      "local function pick(first,unused,last) return last end return pick(1,side(),3)",
+    );
+    expect(result).toEqual({ changed: false, prunedParameters: 0 });
+    expect(firstFunction(chunk).parameters).toHaveLength(3);
+
+    const pruned = rewrite(
+      "local function pick(first,unused,last) return first end return pick(1,side(),3)",
+    );
+    expect(pruned.result).toEqual({ changed: true, prunedParameters: 2 });
+    expect(firstFunction(pruned.chunk).parameters).toHaveLength(1);
+  });
+
+  test("does not cross a vararg tail", () => {
+    const { chunk, result } = rewrite(
+      "local function collect(unused,...) return ... end return collect(side(),1)",
+    );
+    expect(result).toEqual({ changed: false, prunedParameters: 0 });
+    expect(firstFunction(chunk).parameters).toHaveLength(2);
+  });
+
+  test("honors keep annotations on the function declaration", () => {
+    const { chunk, result } = rewrite(
+      "--@storm keep\nlocal function kept(unused) return 1 end return kept(side())",
+    );
+    expect(result).toEqual({ changed: false, prunedParameters: 0 });
+    expect(firstFunction(chunk).parameters).toHaveLength(1);
+  });
+});

--- a/test/tableReadMerge.integration.test.ts
+++ b/test/tableReadMerge.integration.test.ts
@@ -59,6 +59,7 @@ use(first,second)
 
   test("projects a known helper write onto only the affected field", () => {
     const source = `
+--@storm keep
 local function writeY(value) value.y=2 end
 local tableValue={x=1}
 local first=tableValue.x


### PR DESCRIPTION
## 概要

- 共有call graph / function summaryを用いた末尾未使用parameter pruningを追加
- single-use local関数のexpression・statement・tail-call inlineを追加
- Resolveのsymbol単位のalpha conversion、実引数評価順・tuple規則・Source Map provenanceを保持
- unused local function DCE、post-inline最適化、resource gate、診断理由を追加
- 関数rewrite有無を最終Rename / Print後の厳密な短縮で独立比較
- recursion、escape、multi-use、vararg、未知target、未証明upvalue / closureは保守的に拒否

## 検証

- pnpm test: 43 files / 402 tests passed
- format check、lint、build passed
- Lua resource budget: 150 active locals、49/50 accepted、51 rejected
- Lua 5.3 differential semantics: 7 fixtures matched
- n-tracs fixed corpus: default 90,540 → 90,401 bytes、all opt-ins 90,147 → 90,021 bytes

Closes #76