### PR TITLE
whole-program object identityでmethod callを解決する

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "format:check": "prettier --check .",
     "verify:lua-budget": "node scripts/verify-lua-resource-budget.cjs",
     "report:optimizer": "pnpm run build && node scripts/report-optimizer-diagnostics.cjs",
+    "report:whole-program-objects": "pnpm run build && node scripts/report-whole-program-objects.cjs",
     "verify:effect-semantics": "pnpm run build && node scripts/verify-effect-semantics.cjs",
     "prepack": "pnpm run build"
   },

--- a/scripts/report-whole-program-objects.cjs
+++ b/scripts/report-whole-program-objects.cjs
@@ -1,0 +1,106 @@
+const { performance } = require("node:perf_hooks");
+const Parser = require("luaparse");
+const { Minifier } = require("../dist/minifier");
+
+const entry = process.argv.slice(2).find((argument) => argument !== "--");
+if (!entry) {
+  throw new Error("Usage: pnpm report:whole-program-objects -- <entry.lua>");
+}
+
+const parseSettings = {
+  comments: true,
+  locations: true,
+  luaVersion: "5.3",
+  ranges: true,
+};
+const mode = {
+  moduleLikeLua: true,
+  runtimeProfile: "stormworks",
+  collectOptimizationDiagnostics: true,
+};
+
+function run(variant) {
+  const started = performance.now();
+  const minifier = new Minifier(entry, parseSettings, mode, undefined, variant);
+  const code = minifier.parse().toString();
+  return { minifier, code, milliseconds: performance.now() - started };
+}
+
+run("trial");
+const baseline = run("baseline");
+const measured = [run("trial"), run("trial"), run("trial")];
+const trial = measured.at(-1);
+const analysis = trial.minifier.wholeProgramObjects;
+if (!analysis) throw new Error("Whole-program object analysis is missing");
+
+const colonCandidates = analysis.modules.reduce(
+  (count, module) =>
+    count +
+    module.analysis.callGraph.calls.filter(
+      (call) =>
+        call.call.type === "CallExpression" &&
+        call.call.base.type === "MemberExpression" &&
+        call.call.base.indexer === ":",
+    ).length,
+  0,
+);
+const refusalReasons = {};
+const refusalSamples = [];
+const refusalSampleCounts = {};
+analysis.diagnostics.forEach((diagnostic) => {
+  if (diagnostic.reason === "resolved-method-target") return;
+  refusalReasons[diagnostic.reason] =
+    (refusalReasons[diagnostic.reason] ?? 0) + 1;
+  const sampleCount = refusalSampleCounts[diagnostic.reason] ?? 0;
+  if (sampleCount < 3) {
+    const source = trial.minifier.moduleSourceText.get(diagnostic.moduleName);
+    refusalSamples.push({
+      reason: diagnostic.reason,
+      moduleName: diagnostic.moduleName,
+      sourceRange: diagnostic.sourceRange,
+      source:
+        source && diagnostic.sourceRange
+          ? source.slice(diagnostic.sourceRange[0], diagnostic.sourceRange[1])
+          : undefined,
+    });
+    refusalSampleCounts[diagnostic.reason] = sampleCount + 1;
+  }
+});
+const prunedMethodParameters = trial.minifier.optimizationDiagnostics
+  .filter(
+    (diagnostic) =>
+      diagnostic.pass === "whole-program-method-parameter-pruning" &&
+      diagnostic.decision === "accepted",
+  )
+  .reduce((total, diagnostic) => total + (diagnostic.candidateSize ?? 0), 0);
+const times = measured
+  .map((result) => result.milliseconds)
+  .sort((left, right) => left - right);
+const baselineBytes = Buffer.byteLength(baseline.code);
+const trialBytes = Buffer.byteLength(trial.code);
+
+console.log(
+  JSON.stringify(
+    {
+      entry,
+      moduleCount: analysis.modules.length,
+      objectIdentityCount: analysis.objects.length,
+      methodCandidates: colonCandidates,
+      resolvedMethods: analysis.resolvedMethods.length,
+      prunedMethodParameters,
+      refusalReasons,
+      refusalSamples,
+      baselineBytes,
+      trialBytes,
+      byteDifference: trialBytes - baselineBytes,
+      adoptedByStrictCostGate: trialBytes < baselineBytes,
+      measuredMilliseconds: times,
+      medianMilliseconds: times[1],
+      outputParsesAsLua53: Boolean(
+        Parser.parse(trial.code, { luaVersion: "5.3" }),
+      ),
+    },
+    null,
+    2,
+  ),
+);

--- a/scripts/verify-effect-semantics.cjs
+++ b/scripts/verify-effect-semantics.cjs
@@ -68,14 +68,66 @@ run((function() print("first") return 1 end)(),(function() print("second") retur
 const directory = fs.mkdtempSync(
   path.join(os.tmpdir(), "storm-effect-semantics-"),
 );
-function execute(file) {
-  const result = spawnSync(lua, [file], { encoding: "utf8" });
+function execute(file, cwd) {
+  const result = spawnSync(lua, [file], { encoding: "utf8", cwd });
   if (result.error) throw result.error;
   return {
     status: result.status,
     stdout: result.stdout,
     stderr: result.stderr,
   };
+}
+
+function verifyWholeProgramMethodFixture() {
+  const fixtureDirectory = path.join(directory, "whole-program-method");
+  fs.mkdirSync(fixtureDirectory);
+  const sources = {
+    "object.lua": `
+local Object={}
+function Object.create_instance(target,prototype)
+  for key,value in pairs(prototype) do
+    if key~="new" and type(value)=="function" then target[key]=value end
+  end
+  return target
+end
+return Object
+`,
+    "class.lua": `
+local Object=require("object")
+local Class={}
+function Class.new() return Object.create_instance({},Class) end
+function Class:method(value,unused) self.value=value return self.value end
+return Class
+`,
+    "main.lua": `
+local Class=require("class")
+local log={}
+local function mark(label,value) log[#log+1]=label return value end
+local function receiver() return mark("receiver",Class.new()) end
+local result=receiver():method(mark("value",7),mark("unused",9))
+print(result,table.concat(log,","))
+`,
+  };
+  Object.entries(sources).forEach(([name, source]) =>
+    fs.writeFileSync(path.join(fixtureDirectory, name), source),
+  );
+  const entry = path.join(fixtureDirectory, "main.lua");
+  const minifiedFile = path.join(fixtureDirectory, "main.min.lua");
+  const code = new Minifier(
+    entry,
+    { luaVersion: "5.3" },
+    { moduleLikeLua: true, runtimeProfile: "stormworks" },
+  )
+    .parse()
+    .toStringWithSourceMap({ file: path.basename(minifiedFile) }).code;
+  fs.writeFileSync(minifiedFile, code);
+  const original = execute(entry, fixtureDirectory);
+  const minified = execute(minifiedFile, fixtureDirectory);
+  if (JSON.stringify(original) !== JSON.stringify(minified)) {
+    throw new Error(
+      `semantic mismatch in whole-program method fixture\noriginal=${JSON.stringify(original)}\nminified=${JSON.stringify(minified)}\ncode=${code}`,
+    );
+  }
 }
 
 try {
@@ -99,8 +151,9 @@ try {
       );
     }
   });
+  verifyWholeProgramMethodFixture();
   process.stdout.write(
-    `${lua}: ${String(fixtures.length)} effect-aware fixtures matched exactly\n`,
+    `${lua}: ${String(fixtures.length + 1)} effect-aware fixtures matched exactly\n`,
   );
 } finally {
   fs.rmSync(directory, { recursive: true, force: true });

--- a/src/astWalk.ts
+++ b/src/astWalk.ts
@@ -7,6 +7,8 @@ import Parser from "luaparse";
  * nested blockまで集めるpassの両方が、同じAST分類を利用できる。
  */
 export interface AstWalkVisitor {
+  readonly onStatement?: (statement: Parser.Statement) => void;
+  readonly onExpression?: (expression: Parser.Expression) => void;
   readonly onIdentifierReference?: (id: Parser.Identifier) => void;
   readonly onBlock?: (body: Parser.Statement[]) => void;
   // Function bodyは遅延実行されるためwalker自身は入らない。必要な解析だけが
@@ -18,6 +20,7 @@ export function walkStatement(
   statement: Parser.Statement,
   visitor: AstWalkVisitor,
 ): void {
+  visitor.onStatement?.(statement);
   switch (statement.type) {
     case "LocalStatement":
       statement.init.forEach((expr) => {
@@ -105,6 +108,7 @@ export function walkExpression(
   expression: Parser.Expression,
   visitor: AstWalkVisitor,
 ): void {
+  visitor.onExpression?.(expression);
   switch (expression.type) {
     case "Identifier":
       visitor.onIdentifierReference?.(expression);
@@ -163,4 +167,21 @@ export function walkExpression(
       );
     }
   }
+}
+
+/** Walk a complete execution tree while preserving the shared node classification above. */
+export function walkBlockDeep(
+  body: readonly Parser.Statement[],
+  visitor: AstWalkVisitor,
+): void {
+  const deepVisitor: AstWalkVisitor = {
+    ...visitor,
+    onBlock: (nested) => {
+      visitor.onBlock?.(nested);
+      walkBlockDeep(nested, visitor);
+    },
+  };
+  body.forEach((statement) => {
+    walkStatement(statement, deepVisitor);
+  });
 }

--- a/src/callGraph.ts
+++ b/src/callGraph.ts
@@ -44,6 +44,64 @@ export interface CallGraphAnalysis {
   ): CallSite | undefined;
 }
 
+/** Combine generation-matched module graphs and replace proved method unknown edges. */
+export function combineCallGraphs(
+  graphs: readonly CallGraphAnalysis[],
+  resolvedTargets: ReadonlyMap<CallSite, Callable>,
+  generation: number,
+): CallGraphAnalysis {
+  if (graphs.some((graph) => graph.generation !== generation))
+    throw new Error(
+      "Cannot combine call graphs from different AST generations",
+    );
+  const functions = [...new Set(graphs.flatMap((graph) => graph.functions))];
+  const calls: CallSite[] = [];
+  const callSiteByExpression = new WeakMap<
+    | Parser.CallExpression
+    | Parser.TableCallExpression
+    | Parser.StringCallExpression,
+    CallSite
+  >();
+  graphs
+    .flatMap((graph) => graph.calls)
+    .forEach((original) => {
+      const resolved = resolvedTargets.get(original);
+      const targets = resolved
+        ? new Set<Callable>([...original.targets, resolved])
+        : original.targets;
+      const call: CallSite = {
+        ...original,
+        id: calls.length,
+        targets,
+        hasUnknownTarget: resolved ? false : original.hasUnknownTarget,
+      };
+      calls.push(call);
+      callSiteByExpression.set(call.call, call);
+    });
+  const sccs = stronglyConnectedComponents(functions, calls);
+  return {
+    generation,
+    functions,
+    calls,
+    sccs,
+    functionOf: (declaration) => {
+      for (const graph of graphs) {
+        const found = graph.functionOf(declaration);
+        if (found) return found;
+      }
+      return undefined;
+    },
+    functionOfSymbol: (symbol) => {
+      for (const graph of graphs) {
+        const found = graph.functionOfSymbol(symbol);
+        if (found) return found;
+      }
+      return undefined;
+    },
+    callSiteOf: (call) => callSiteByExpression.get(call),
+  };
+}
+
 /**
  * Resolve identityに基づくmodule-local call graphを構築する。
  *

--- a/src/functionRewrites.ts
+++ b/src/functionRewrites.ts
@@ -9,6 +9,7 @@ import { copyNodeOrigin } from "./generatedNode";
 export interface FunctionRewriteResult {
   readonly changed: boolean;
   readonly prunedParameters: number;
+  readonly prunedMethodParameters: number;
 }
 
 export interface InlineRewriteResult {
@@ -42,10 +43,15 @@ type PrimitiveLiteral =
 export function pruneTrailingUnusedParameters(
   callGraph: CallGraphAnalysis,
   metadata: SourceMetadata,
+  canRewrite: (
+    callable: CallGraphAnalysis["functions"][number],
+  ) => boolean = () => true,
 ): FunctionRewriteResult {
   let prunedParameters = 0;
+  let prunedMethodParameters = 0;
 
   callGraph.functions.forEach((callable) => {
+    if (!canRewrite(callable)) return;
     const declaration = callable.declaration;
     if (metadata.annotationsOf(declaration).keep) return;
 
@@ -61,13 +67,20 @@ export function pruneTrailingUnusedParameters(
     }
 
     if (retained === declaration.parameters.length) return;
-    prunedParameters += declaration.parameters.length - retained;
+    const removed = declaration.parameters.length - retained;
+    prunedParameters += removed;
+    if (
+      declaration.identifier?.type === "MemberExpression" &&
+      declaration.identifier.indexer === ":"
+    )
+      prunedMethodParameters += removed;
     declaration.parameters = declaration.parameters.slice(0, retained);
   });
 
   return {
     changed: prunedParameters > 0,
     prunedParameters,
+    prunedMethodParameters,
   };
 }
 

--- a/src/minifier.ts
+++ b/src/minifier.ts
@@ -45,6 +45,11 @@ import {
   inlineTailCallFunctions,
   pruneTrailingUnusedParameters,
 } from "./functionRewrites";
+import {
+  analyzeWholeProgramObjects,
+  WholeProgramObjectAnalysis,
+  WholeProgramModule,
+} from "./wholeProgramObjects";
 
 export type { RuntimeProfile } from "./runtimeEnvironment";
 
@@ -131,6 +136,8 @@ export class Minifier {
   private readonly diagnosticCollector?: OptimizationDiagnosticCollector;
   private readonly schedulerVariant?: "baseline" | "trial";
   private readonly functionRewriteVariant?: "baseline" | "trial";
+  private linkedAstGeneration = 0;
+  private wholeProgramObjectsValue?: WholeProgramObjectAnalysis;
 
   constructor(
     entryFilePath: string,
@@ -165,6 +172,10 @@ export class Minifier {
 
   get optimizationDiagnostics(): readonly OptimizationDiagnostic[] {
     return this.diagnosticCollector?.diagnostics ?? [];
+  }
+
+  get wholeProgramObjects(): WholeProgramObjectAnalysis | undefined {
+    return this.wholeProgramObjectsValue;
   }
 
   parse(): SourceNode {
@@ -278,6 +289,12 @@ export class Minifier {
     this.rebuildIdentifiersInUse();
     this.computeGlobalRenames();
     this.transformAll();
+    if (this.functionRewritesEnabled()) {
+      // fold/remove/schedule may have changed any module after method rewrites. Publish only a
+      // snapshot rebuilt from the complete linked AST generation consumed by final Rename/Print.
+      this.linkedAstGeneration++;
+      this.wholeProgramObjectsValue = this.analyzeWholeProgramObjects();
+    }
     this.renameAll();
 
     const result = this.mode.moduleLikeLua
@@ -301,6 +318,61 @@ export class Minifier {
       !this.functionRewritesEnabled()
     )
       return;
+
+    const initialWholeProgram = this.analyzeWholeProgramObjects();
+    const functionsByModule = new Map(
+      initialWholeProgram.modules.map((module) => [
+        module.name,
+        new Set(module.analysis.callGraph.functions),
+      ]),
+    );
+    const resolvedMethodTargets = new Set(
+      initialWholeProgram.resolvedMethods.map((method) => method.target),
+    );
+    const modulesWithPrunedParameters = new Set<string>();
+    this.linkOrder.forEach((moduleName) => {
+      const functions = functionsByModule.get(moduleName);
+      if (!functions) return;
+      const result = pruneTrailingUnusedParameters(
+        initialWholeProgram.callGraph,
+        this.getSourceMetadata(moduleName),
+        (callable) =>
+          functions.has(callable) &&
+          (callable.declaration.identifier?.type !== "MemberExpression" ||
+            callable.declaration.identifier.indexer !== ":" ||
+            resolvedMethodTargets.has(callable)),
+      );
+      if (!result.changed) return;
+      modulesWithPrunedParameters.add(moduleName);
+      this.diagnosticCollector?.record({
+        pass: "prune-trailing-unused-parameters",
+        moduleName,
+        runtimeProfile: this.mode.runtimeProfile ?? "lua53",
+        decision: "accepted",
+        reason: "function-rewrite-applied",
+        candidateSize: result.prunedParameters,
+        sourceRange: sourceRangeOf(this.moduleAST.get(moduleName) ?? {}),
+      });
+      if (result.prunedMethodParameters > 0)
+        this.diagnosticCollector?.record({
+          pass: "whole-program-method-parameter-pruning",
+          moduleName,
+          runtimeProfile: this.mode.runtimeProfile ?? "lua53",
+          decision: "accepted",
+          reason: "function-rewrite-applied",
+          candidateSize: result.prunedMethodParameters,
+          sourceRange: sourceRangeOf(this.moduleAST.get(moduleName) ?? {}),
+        });
+    });
+    if (modulesWithPrunedParameters.size > 0) {
+      modulesWithPrunedParameters.forEach((moduleName) => {
+        const ast = this.moduleAST.get(moduleName);
+        if (!ast) throw new Error(moduleName + " is not found");
+        this.moduleResolve.set(moduleName, resolveScopes(ast));
+      });
+      this.linkedAstGeneration++;
+      this.wholeProgramObjectsValue = undefined;
+    }
 
     this.linkOrder.forEach((moduleName) => {
       const ast = this.moduleAST.get(moduleName);
@@ -372,24 +444,6 @@ export class Minifier {
           candidateSize: 1,
           sourceRange: sourceRangeOf(callable.declaration),
         });
-      });
-      passes.run("prune-trailing-unused-parameters", () => {
-        const analysis = passes.analysis(
-          OPTIMIZER_ANALYSIS_CACHE_KEY,
-          analyzeOptimizerAtGeneration,
-        );
-        const result = pruneTrailingUnusedParameters(
-          analysis.interprocedural.callGraph,
-          this.getSourceMetadata(moduleName),
-        );
-        recordAccepted(
-          "prune-trailing-unused-parameters",
-          result.prunedParameters,
-        );
-        return {
-          changed: result.changed,
-          invalidatesResolve: result.changed,
-        };
       });
       passes.run("inline-closed-single-use-functions", (currentResolve) => {
         const analysis = passes.analysis(
@@ -520,7 +574,49 @@ export class Minifier {
         };
       });
       this.moduleResolve.set(moduleName, passes.resolved);
+      if (passes.astGeneration > 0) {
+        this.linkedAstGeneration += passes.astGeneration;
+        this.wholeProgramObjectsValue = undefined;
+      }
     });
+    this.wholeProgramObjectsValue = this.analyzeWholeProgramObjects();
+    this.recordWholeProgramObjectDiagnostics(this.wholeProgramObjectsValue);
+  }
+
+  private analyzeWholeProgramObjects(): WholeProgramObjectAnalysis {
+    const modules: WholeProgramModule[] = this.linkOrder.map((name) => {
+      const chunk = this.moduleAST.get(name);
+      const resolved = this.moduleResolve.get(name);
+      if (!chunk || !resolved) throw new Error(name + " is not found");
+      return {
+        name,
+        chunk,
+        resolved,
+        analysis: analyzeOptimizer(chunk, resolved, {
+          generation: this.linkedAstGeneration,
+        }),
+      };
+    });
+    return analyzeWholeProgramObjects(modules, this.linkedAstGeneration);
+  }
+
+  private recordWholeProgramObjectDiagnostics(
+    analysis: WholeProgramObjectAnalysis,
+  ): void {
+    analysis.diagnostics.forEach((diagnostic) =>
+      this.diagnosticCollector?.record({
+        pass: "whole-program-method-resolution",
+        moduleName: diagnostic.moduleName,
+        runtimeProfile: this.mode.runtimeProfile ?? "lua53",
+        decision:
+          diagnostic.reason === "resolved-method-target"
+            ? "accepted"
+            : "rejected",
+        reason: diagnostic.reason,
+        candidateSize: 1,
+        sourceRange: diagnostic.sourceRange,
+      }),
+    );
   }
 
   private requiresSchedulerSelection(): boolean {
@@ -565,6 +661,8 @@ export class Minifier {
     copyMap(minifier.renameCache, this.renameCache);
     this.globalRenames = new Map(minifier.globalRenames);
     copyMap(minifier.moduleMetadata, this.moduleMetadata);
+    this.linkedAstGeneration = minifier.linkedAstGeneration;
+    this.wholeProgramObjectsValue = minifier.wholeProgramObjectsValue;
     return output;
   }
 

--- a/src/optimizerDiagnostics.ts
+++ b/src/optimizerDiagnostics.ts
@@ -47,7 +47,15 @@ export type OptimizationDiagnosticReason =
   | "function-escape"
   | "recursive-function"
   | "vararg-function"
-  | "unused-function";
+  | "unused-function"
+  | "resolved-method-target"
+  | "instance-escape"
+  | "prototype-escape"
+  | "method-field-mutation"
+  | "metatable-mutation"
+  | "multiple-targets"
+  | "dynamic-module-boundary"
+  | "external-module-boundary";
 
 export interface OptimizationDiagnostic {
   readonly pass: string;

--- a/src/renamer.ts
+++ b/src/renamer.ts
@@ -77,9 +77,7 @@ export function assignRenames(
   keepNames.forEach((symbol) => unavailableNames.add(symbol.name));
   const variables = resolveResult.symbols.filter(
     (symbol) =>
-      symbol.kind !== "label" &&
-      symbol.name !== "self" &&
-      !keepNames.has(symbol),
+      symbol.kind !== "label" && !symbol.implicit && !keepNames.has(symbol),
   );
   const variableGraph = buildVariableInterference(
     chunk,
@@ -367,6 +365,16 @@ function validateBindings(
     },
   });
   original.symbols.forEach((symbol) => {
+    if (symbol.implicit) {
+      symbol.references.forEach((identifier) => {
+        const rebound = recolored.symbolOf(identifier);
+        if (!rebound?.implicit || rebound.name !== symbol.name)
+          throw new Error(
+            `Identifier coloring changed implicit binding for symbol ${String(symbol.id)}`,
+          );
+      });
+      return;
+    }
     [symbol.declaration, ...symbol.references].forEach((identifier) => {
       if (recolored.symbolOf(identifier)?.declaration !== symbol.declaration)
         throw new Error(

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -21,6 +21,8 @@ export interface Symbol {
   readonly declaration: Parser.Identifier;
   // このシンボルを指す参照（宣言箇所自体は含まない）
   readonly references: Parser.Identifier[];
+  /** Lua declares this binding without an identifier token (currently colon-method self). */
+  readonly implicit?: true;
 }
 
 export interface GlobalBinding {
@@ -96,6 +98,7 @@ export function resolveScopes(
     scope: MutableScope,
     node: Parser.Identifier,
     kind: SymbolKind,
+    implicit = false,
   ): Symbol {
     const name = identifierName(node);
     const symbol: Symbol = {
@@ -105,6 +108,7 @@ export function resolveScopes(
       scope,
       declaration: node,
       references: [],
+      ...(implicit ? { implicit: true as const } : {}),
     };
     // 同名の再宣言はスコープ内の以後の参照から見た束縛を上書きする（Luaの通常のシャドーイング）
     scope.symbols.push(symbol);
@@ -319,6 +323,15 @@ export function resolveScopes(
     }
     const inner = createScope("function", scope);
     functionScopes.set(fn, inner);
+    if (
+      fn.identifier?.type === "MemberExpression" &&
+      fn.identifier.indexer === ":"
+    ) {
+      // `function object:method(...)` declares an implicit first parameter. It has no
+      // declaration token in the AST, but it must still own every `self` reference so
+      // global analysis, aliases, summaries, and binding validation share Lua's binding.
+      declare(inner, { type: "Identifier", name: "self" }, "param", true);
+    }
     fn.parameters.forEach((parameter) => {
       if (parameter.type === "Identifier") {
         declare(inner, parameter, "param");

--- a/src/wholeProgramObjects.ts
+++ b/src/wholeProgramObjects.ts
@@ -1,0 +1,834 @@
+import Parser from "luaparse";
+import { walkBlockDeep } from "./astWalk";
+import {
+  CallGraphAnalysis,
+  CallSite,
+  Callable,
+  combineCallGraphs,
+} from "./callGraph";
+import { FunctionSummary } from "./interproceduralAnalysis";
+import { staticStringArgument } from "./linker";
+import { OptimizerAnalysis } from "./optimizerAnalysis";
+import { ResolveResult, Symbol } from "./resolver";
+
+export interface WholeProgramModule {
+  readonly name: string;
+  readonly chunk: Parser.Chunk;
+  readonly resolved: ResolveResult;
+  readonly analysis: OptimizerAnalysis;
+}
+
+export type ObjectRefusalReason =
+  | "allocation-unknown"
+  | "instance-escape"
+  | "prototype-escape"
+  | "method-field-mutation"
+  | "dynamic-key"
+  | "metatable-mutation"
+  | "multiple-targets"
+  | "dynamic-module-boundary"
+  | "external-module-boundary";
+
+export interface ProgramObjectIdentity {
+  readonly id: string;
+  readonly moduleName: string;
+  readonly kind: "module-return" | "prototype" | "allocation";
+  readonly methods: ReadonlyMap<string, Callable>;
+  readonly invalidationReasons: ReadonlySet<ObjectRefusalReason>;
+}
+
+export interface ResolvedMethodCall {
+  readonly call: CallSite;
+  readonly receiver: Parser.Expression;
+  readonly target: Callable;
+  readonly object: ProgramObjectIdentity;
+}
+
+export interface WholeProgramObjectDiagnostic {
+  readonly moduleName: string;
+  readonly reason: "resolved-method-target" | ObjectRefusalReason;
+  readonly sourceRange?: readonly [number, number];
+}
+
+export interface WholeProgramObjectAnalysis {
+  readonly generation: number;
+  readonly modules: readonly WholeProgramModule[];
+  readonly objects: readonly ProgramObjectIdentity[];
+  readonly callGraph: CallGraphAnalysis;
+  readonly resolvedMethods: readonly ResolvedMethodCall[];
+  readonly diagnostics: readonly WholeProgramObjectDiagnostic[];
+  objectOf(expression: Parser.Expression): ProgramObjectIdentity | undefined;
+  methodCallOf(call: CallSite): ResolvedMethodCall | undefined;
+  summaryOfMethodCall(call: CallSite): FunctionSummary | undefined;
+  effectsOfMethodCall(call: CallSite): FunctionSummary["effects"];
+}
+
+interface MutableObject {
+  readonly id: string;
+  readonly moduleName: string;
+  kind: ProgramObjectIdentity["kind"];
+  readonly methods: Map<string, Callable>;
+  readonly invalidationReasons: Set<ObjectRefusalReason>;
+}
+
+interface ConstructorTemplate {
+  readonly prototype: Parser.Expression;
+  readonly base: Parser.Expression;
+  readonly module: WholeProgramModule;
+}
+
+interface FactoryTemplate {
+  readonly targetParameter: Symbol;
+  readonly prototypeParameter: Symbol;
+  readonly copyAssignments: readonly Parser.AssignmentStatement[];
+}
+
+/**
+ * Build the object/module identity layer once for a linked AST generation.
+ *
+ * This analysis intentionally publishes resolved methods as ordinary CallSite -> Callable
+ * relations. Consumers do not need to know whether a callable came from a lexical alias or
+ * from a factory allocation. Unknown Lua table behaviour invalidates the affected identity;
+ * it never creates a guessed edge.
+ */
+export function analyzeWholeProgramObjects(
+  modules: readonly WholeProgramModule[],
+  generation: number,
+): WholeProgramObjectAnalysis {
+  const moduleByName = new Map(modules.map((module) => [module.name, module]));
+  const moduleOfNode = new WeakMap<object, WholeProgramModule>();
+  const callableModule = new Map<Callable, WholeProgramModule>();
+  const callableOfDeclaration = new WeakMap<
+    Parser.FunctionDeclaration,
+    Callable
+  >();
+  const callSiteOfExpression = new WeakMap<Parser.Expression, CallSite>();
+  modules.forEach((module) => {
+    walkStatements(module.chunk.body, (node) => moduleOfNode.set(node, module));
+    module.analysis.callGraph.functions.forEach((callable) => {
+      callableModule.set(callable, module);
+      callableOfDeclaration.set(callable.declaration, callable);
+    });
+    module.analysis.callGraph.calls.forEach((call) =>
+      callSiteOfExpression.set(call.call, call),
+    );
+  });
+
+  const mutableObjects: MutableObject[] = [];
+  const objectOfTable = new WeakMap<
+    Parser.TableConstructorExpression,
+    MutableObject
+  >();
+  const valuesOfSymbol = new Map<Symbol, Set<MutableObject>>();
+  const valuesOfExpression = new WeakMap<
+    Parser.Expression,
+    Set<MutableObject>
+  >();
+  const moduleReturns = new Map<string, Set<MutableObject>>();
+  const functionsOfSymbol = new Map<Symbol, Set<Callable>>();
+  const moduleFunctionReturns = new Map<string, Set<Callable>>();
+  const methodDefinitions = new WeakSet();
+  const factoryTemplates = new Map<Callable, FactoryTemplate>();
+  const factoryCopyAssignments = new WeakSet<Parser.AssignmentStatement>();
+  const constructorTemplates = new Map<Callable, ConstructorTemplate>();
+  const sourcesOfObject = new Map<MutableObject, Set<MutableObject>>();
+  let nextObject = 0;
+
+  const objectForTable = (
+    table: Parser.TableConstructorExpression,
+    module: WholeProgramModule,
+  ): MutableObject => {
+    const existing = objectOfTable.get(table);
+    if (existing) return existing;
+    const object: MutableObject = {
+      id: `${module.name}:table:${String(nextObject++)}`,
+      moduleName: module.name,
+      kind: "allocation",
+      methods: new Map(),
+      invalidationReasons: new Set(),
+    };
+    objectOfTable.set(table, object);
+    mutableObjects.push(object);
+    return object;
+  };
+
+  modules.forEach((module) => {
+    visitExpressions(module.chunk.body, (expression) => {
+      if (expression.type === "TableConstructorExpression")
+        objectForTable(expression, module);
+    });
+  });
+
+  modules.forEach((module) => {
+    const returned = topLevelReturn(module.chunk);
+    if (!returned) return;
+    let callable: Callable | undefined;
+    if (returned.type === "FunctionDeclaration")
+      callable = module.analysis.callGraph.functionOf(returned);
+    else if (returned.type === "Identifier") {
+      const symbol = module.resolved.symbolOf(returned);
+      if (symbol) callable = module.analysis.callGraph.functionOfSymbol(symbol);
+    }
+    if (callable) moduleFunctionReturns.set(module.name, new Set([callable]));
+  });
+
+  const directValues = (
+    expression: Parser.Expression,
+    module: WholeProgramModule,
+  ): Set<MutableObject> => {
+    const cached = valuesOfExpression.get(expression);
+    if (cached) return cached;
+    let result = new Set<MutableObject>();
+    if (expression.type === "TableConstructorExpression") {
+      result.add(objectForTable(expression, module));
+    } else if (expression.type === "Identifier") {
+      const symbol = module.resolved.symbolOf(expression);
+      if (symbol) result = new Set(valuesOfSymbol.get(symbol) ?? []);
+    } else if (expression.type === "CallExpression") {
+      const required = staticRequiredModule(expression);
+      if (required) result = new Set(moduleReturns.get(required) ?? []);
+    }
+    valuesOfExpression.set(expression, result);
+    return result;
+  };
+
+  // Stable table and require aliases form the seed identity relation.
+  let changed = true;
+  while (changed) {
+    changed = false;
+    modules.forEach((module) => {
+      visitBindings(module.chunk.body, (target, value) => {
+        const symbol = module.resolved.symbolOf(target);
+        if (!symbol || !stableSymbol(symbol, module.analysis)) return;
+        const incoming = directValues(value, module);
+        if (unionInto(valuesOfSymbol, symbol, incoming)) changed = true;
+        if (value.type === "CallExpression") {
+          const required = staticRequiredModule(value);
+          if (
+            required &&
+            unionCallableInto(
+              functionsOfSymbol,
+              symbol,
+              moduleFunctionReturns.get(required) ?? new Set(),
+            )
+          )
+            changed = true;
+        }
+      });
+      const returned = topLevelReturn(module.chunk);
+      if (returned) {
+        const incoming = directValues(returned, module);
+        const current = moduleReturns.get(module.name) ?? new Set();
+        const before = current.size;
+        incoming.forEach((object) => {
+          object.kind = "module-return";
+          current.add(object);
+        });
+        moduleReturns.set(module.name, current);
+        if (current.size !== before) changed = true;
+      }
+    });
+    valuesOfExpressionCleanup(valuesOfExpression, modules);
+  }
+
+  // Member function declarations establish prototype fields by object identity.
+  modules.forEach((module) => {
+    walkStatements(module.chunk.body, (node) => {
+      if (node.type !== "FunctionDeclaration") return;
+      const declaration = node;
+      if (declaration.identifier?.type !== "MemberExpression") return;
+      const callable = callableOfDeclaration.get(declaration);
+      if (!callable) return;
+      const key = declaration.identifier.identifier.name;
+      const bases = directValues(declaration.identifier.base, module);
+      bases.forEach((object) => {
+        object.kind =
+          object.kind === "module-return" ? object.kind : "prototype";
+        const prior = object.methods.get(key);
+        if (prior && prior !== callable)
+          object.invalidationReasons.add("method-field-mutation");
+        object.methods.set(key, callable);
+      });
+      if (declaration.identifier.indexer === ":") {
+        const self = callable.parameters[0];
+        if (self.name === "self")
+          bases.forEach((object) => {
+            unionInto(valuesOfSymbol, self, new Set([object]));
+          });
+      }
+      methodDefinitions.add(declaration.identifier);
+    });
+  });
+
+  modules.forEach((module) => {
+    module.analysis.callGraph.functions.forEach((callable) => {
+      const factory = recognizeMixinFactory(callable, module.resolved);
+      if (factory) {
+        factoryTemplates.set(callable, factory);
+        factory.copyAssignments.forEach((assignment) =>
+          factoryCopyAssignments.add(assignment),
+        );
+      }
+    });
+  });
+  const directCallTargets = (
+    call: CallSite,
+    module: WholeProgramModule,
+  ): Set<Callable> => {
+    const targets = new Set(call.targets);
+    const expression = call.call;
+    if (expression.type !== "CallExpression") return targets;
+    if (expression.base.type === "Identifier") {
+      const symbol = module.resolved.symbolOf(expression.base);
+      if (symbol)
+        functionsOfSymbol.get(symbol)?.forEach((target) => targets.add(target));
+    } else if (expression.base.type === "MemberExpression") {
+      const member = expression.base;
+      directValues(member.base, module).forEach((object) => {
+        const target = object.methods.get(member.identifier.name);
+        if (target) targets.add(target);
+      });
+    }
+    return targets;
+  };
+  modules.forEach((module) => {
+    module.analysis.callGraph.functions.forEach((callable) => {
+      const constructor = recognizeConstructor(
+        callable,
+        module,
+        factoryTemplates,
+        (call) => {
+          const site = callSiteOfExpression.get(call);
+          if (!site) return new Set();
+          const targets = directCallTargets(site, module);
+          const member =
+            call.base.type === "MemberExpression" ? call.base : undefined;
+          if (member)
+            directValues(member.base, module).forEach((object) => {
+              const target = object.methods.get(member.identifier.name);
+              if (target) targets.add(target);
+            });
+          return targets;
+        },
+      );
+      if (constructor) constructorTemplates.set(callable, constructor);
+    });
+  });
+
+  // Constructor calls allocate a distinct identity at each call site. The copied prototype
+  // and a factory-returned base contribute methods to that one identity.
+  const instanceOfCall = new WeakMap<Parser.Expression, MutableObject>();
+  changed = true;
+  while (changed) {
+    changed = false;
+    modules.forEach((module) => {
+      module.analysis.callGraph.calls.forEach((call) => {
+        if (call.call.type !== "CallExpression") return;
+        const targets = directCallTargets(call, module);
+        const member =
+          call.call.base.type === "MemberExpression"
+            ? call.call.base
+            : undefined;
+        if (member)
+          directValues(member.base, module).forEach((object) => {
+            const target = object.methods.get(member.identifier.name);
+            if (target) targets.add(target);
+          });
+        const constructor = [...targets]
+          .map((target) => constructorTemplates.get(target))
+          .filter((value): value is ConstructorTemplate => value !== undefined);
+        const mixin = [...targets]
+          .map((target) => factoryTemplates.get(target))
+          .filter((value): value is FactoryTemplate => value !== undefined);
+        if (constructor.length + mixin.length !== 1) return;
+        let instance = instanceOfCall.get(call.call);
+        if (!instance) {
+          instance = {
+            id: `${module.name}:call:${String(call.id)}`,
+            moduleName: module.name,
+            kind: "allocation",
+            methods: new Map(),
+            invalidationReasons: new Set(),
+          };
+          instanceOfCall.set(call.call, instance);
+          mutableObjects.push(instance);
+          changed = true;
+        }
+        const sources = new Set<MutableObject>();
+        if (constructor.length === 1) {
+          directValues(constructor[0].prototype, constructor[0].module).forEach(
+            (object) => sources.add(object),
+          );
+          directValues(constructor[0].base, constructor[0].module).forEach(
+            (object) => sources.add(object),
+          );
+        } else {
+          const args = call.call.arguments;
+          const base = args.at(0);
+          const prototype = args.at(1);
+          if (!base || !prototype) return;
+          directValues(base, module).forEach((object) => sources.add(object));
+          directValues(prototype, module).forEach((object) =>
+            sources.add(object),
+          );
+        }
+        sources.forEach((source) => {
+          const recordedSources = sourcesOfObject.get(instance) ?? new Set();
+          recordedSources.add(source);
+          sourcesOfObject.set(instance, recordedSources);
+          source.methods.forEach((target, key) =>
+            instance.methods.set(key, target),
+          );
+          source.invalidationReasons.forEach((reason) =>
+            instance.invalidationReasons.add(reason),
+          );
+        });
+        valuesOfExpression.set(call.call, new Set([instance]));
+      });
+      visitBindings(module.chunk.body, (target, value) => {
+        const symbol = module.resolved.symbolOf(target);
+        if (!symbol || !stableSymbol(symbol, module.analysis)) return;
+        if (unionInto(valuesOfSymbol, symbol, directValues(value, module)))
+          changed = true;
+      });
+      module.analysis.callGraph.calls.forEach((call) => {
+        const expression = call.call;
+        if (expression.type !== "CallExpression") return;
+        const targets = directCallTargets(call, module);
+        if (targets.size !== 1) return;
+        const target = [...targets][0];
+        target.parameters.forEach((parameter, index) => {
+          const actual = expression.arguments.at(index);
+          if (
+            actual &&
+            unionInto(valuesOfSymbol, parameter, directValues(actual, module))
+          )
+            changed = true;
+        });
+      });
+    });
+    valuesOfExpressionCleanup(valuesOfExpression, modules, true);
+  }
+
+  // Invalidate only identities that cross an unproved observation/mutation boundary.
+  modules.forEach((module) => {
+    walkStatements(module.chunk.body, (node) => {
+      if (node.type === "AssignmentStatement") {
+        const statement = node;
+        if (factoryCopyAssignments.has(statement)) return;
+        statement.variables.forEach((target) => {
+          if (target.type === "IndexExpression") {
+            directValues(target.base, module).forEach((object) =>
+              object.invalidationReasons.add("dynamic-key"),
+            );
+          } else if (target.type === "MemberExpression") {
+            if (methodDefinitions.has(target)) return;
+            directValues(target.base, module).forEach((object) => {
+              if (object.methods.has(target.identifier.name))
+                object.invalidationReasons.add("method-field-mutation");
+            });
+          }
+        });
+      }
+    });
+    module.analysis.callGraph.calls.forEach((call) => {
+      if (call.call.type !== "CallExpression") return;
+      if (
+        call.call.base.type === "Identifier" &&
+        call.call.base.name === "setmetatable"
+      ) {
+        directValues(call.call.arguments[0], module).forEach((object) =>
+          object.invalidationReasons.add("metatable-mutation"),
+        );
+        return;
+      }
+      if (
+        directCallTargets(call, module).size > 0 ||
+        staticRequiredModule(call.call)
+      )
+        return;
+      if (
+        call.caller &&
+        factoryTemplates.has(call.caller) &&
+        call.call.base.type === "Identifier" &&
+        (call.call.base.name === "pairs" || call.call.base.name === "type")
+      )
+        return;
+      if (call.call.base.type === "MemberExpression") {
+        const member = call.call.base;
+        const knownFactory = [
+          ...directValues(call.call.base.base, module),
+        ].some((object) => {
+          const target = object.methods.get(member.identifier.name);
+          return target ? factoryTemplates.has(target) : false;
+        });
+        if (knownFactory) return;
+      }
+      call.call.arguments.forEach((argument) => {
+        directValues(argument, module).forEach((object) =>
+          object.invalidationReasons.add(
+            object.kind === "prototype" || object.kind === "module-return"
+              ? "prototype-escape"
+              : "instance-escape",
+          ),
+        );
+      });
+    });
+  });
+
+  changed = true;
+  while (changed) {
+    changed = false;
+    sourcesOfObject.forEach((sources, object) => {
+      const before = object.invalidationReasons.size;
+      sources.forEach((source) => {
+        source.invalidationReasons.forEach((reason) =>
+          object.invalidationReasons.add(reason),
+        );
+      });
+      if (object.invalidationReasons.size !== before) changed = true;
+    });
+  }
+
+  const resolvedMethods: (Omit<ResolvedMethodCall, "object"> & {
+    readonly object: MutableObject;
+  })[] = [];
+  const diagnostics: WholeProgramObjectDiagnostic[] = [];
+  modules.forEach((module) => {
+    module.analysis.callGraph.calls.forEach((call) => {
+      if (
+        call.call.type === "CallExpression" &&
+        call.call.base.type === "Identifier" &&
+        call.call.base.name === "require"
+      ) {
+        const required = staticRequiredModule(call.call);
+        if (!required)
+          diagnostics.push({
+            moduleName: module.name,
+            reason: "dynamic-module-boundary",
+            ...sourceRangeOf(call.call),
+          });
+        else if (!moduleByName.has(required))
+          diagnostics.push({
+            moduleName: module.name,
+            reason: "external-module-boundary",
+            ...sourceRangeOf(call.call),
+          });
+      }
+      if (
+        call.call.type !== "CallExpression" ||
+        call.call.base.type !== "MemberExpression" ||
+        call.call.base.indexer !== ":"
+      )
+        return;
+      const receiver = call.call.base.base;
+      const candidates = [...directValues(receiver, module)];
+      const callerAllocations = candidates.filter(
+        (candidate) =>
+          candidate.kind === "allocation" &&
+          candidate.moduleName === module.name,
+      );
+      // A constructor template contains its own factory call, but each outer call owns the
+      // observable allocation identity. Keep the template allocation as provenance only.
+      const dispatchCandidates =
+        callerAllocations.length > 0 ? callerAllocations : candidates;
+      if (dispatchCandidates.length !== 1) {
+        diagnostics.push({
+          moduleName: module.name,
+          reason:
+            dispatchCandidates.length === 0
+              ? "allocation-unknown"
+              : "multiple-targets",
+          ...sourceRangeOf(call.call),
+        });
+        return;
+      }
+      const object = dispatchCandidates[0];
+      if (object.invalidationReasons.size > 0) {
+        object.invalidationReasons.forEach((reason) =>
+          diagnostics.push({
+            moduleName: module.name,
+            reason,
+            ...sourceRangeOf(call.call),
+          }),
+        );
+        return;
+      }
+      const target = object.methods.get(call.call.base.identifier.name);
+      if (!target) return;
+      const resolved = { call, receiver, target, object };
+      resolvedMethods.push(resolved);
+      diagnostics.push({
+        moduleName: module.name,
+        reason: "resolved-method-target",
+        ...sourceRangeOf(call.call),
+      });
+    });
+  });
+
+  const publicObjects: ProgramObjectIdentity[] = mutableObjects.map(
+    (object) => ({
+      id: object.id,
+      moduleName: object.moduleName,
+      kind: object.kind,
+      methods: object.methods,
+      invalidationReasons: object.invalidationReasons,
+    }),
+  );
+  const publicOfMutable = new Map(
+    mutableObjects.map((object, index) => [object, publicObjects[index]]),
+  );
+  const resolvedPublic = resolvedMethods.map((resolved) => ({
+    ...resolved,
+    object: publicOfMutable.get(resolved.object) as ProgramObjectIdentity,
+  }));
+  const methodByCall = new Map(
+    resolvedPublic.map((method) => [method.call, method]),
+  );
+  const methodByExpression = new WeakMap(
+    resolvedPublic.map((method) => [method.call.call, method] as const),
+  );
+  const resolvedTargetByCall = new Map(
+    resolvedPublic.map((method) => [method.call, method.target]),
+  );
+  modules.forEach((module) => {
+    module.analysis.callGraph.calls.forEach((call) => {
+      if (resolvedTargetByCall.has(call)) return;
+      const targets = directCallTargets(call, module);
+      if (targets.size === 1) resolvedTargetByCall.set(call, [...targets][0]);
+    });
+  });
+  const callGraph = combineCallGraphs(
+    modules.map((module) => module.analysis.callGraph),
+    resolvedTargetByCall,
+    generation,
+  );
+  const summaryOfTarget = (target: Callable): FunctionSummary | undefined => {
+    const module = callableModule.get(target);
+    return module?.analysis.interprocedural.summaryOf(target);
+  };
+  return {
+    generation,
+    modules,
+    objects: publicObjects,
+    callGraph,
+    resolvedMethods: resolvedPublic,
+    diagnostics,
+    objectOf: (expression) => {
+      const values = valuesOfExpression.get(expression);
+      if (values?.size !== 1) return undefined;
+      return publicOfMutable.get([...values][0]);
+    },
+    methodCallOf: (call) =>
+      methodByCall.get(call) ?? methodByExpression.get(call.call),
+    summaryOfMethodCall: (call) => {
+      const method =
+        methodByCall.get(call) ?? methodByExpression.get(call.call);
+      return method ? summaryOfTarget(method.target) : undefined;
+    },
+    effectsOfMethodCall: (call) => {
+      const method =
+        methodByCall.get(call) ?? methodByExpression.get(call.call);
+      if (!method) return [];
+      return summaryOfTarget(method.target)?.effects ?? [];
+    },
+  };
+}
+
+function stableSymbol(symbol: Symbol, analysis: OptimizerAnalysis): boolean {
+  return (
+    analysis.facts
+      .operationsOfSymbol(symbol)
+      .filter((operation) => operation.kind === "write").length === 0
+  );
+}
+
+function unionInto(
+  target: Map<Symbol, Set<MutableObject>>,
+  symbol: Symbol,
+  incoming: ReadonlySet<MutableObject>,
+): boolean {
+  const values = target.get(symbol) ?? new Set();
+  const before = values.size;
+  incoming.forEach((value) => values.add(value));
+  target.set(symbol, values);
+  return values.size !== before;
+}
+
+function unionCallableInto(
+  target: Map<Symbol, Set<Callable>>,
+  symbol: Symbol,
+  incoming: ReadonlySet<Callable>,
+): boolean {
+  const values = target.get(symbol) ?? new Set();
+  const before = values.size;
+  incoming.forEach((value) => values.add(value));
+  target.set(symbol, values);
+  return values.size !== before;
+}
+
+function staticRequiredModule(call: Parser.CallExpression): string | undefined {
+  return call.base.type === "Identifier" && call.base.name === "require"
+    ? staticStringArgument(call.arguments[0])
+    : undefined;
+}
+
+function topLevelReturn(chunk: Parser.Chunk): Parser.Expression | undefined {
+  const statement = chunk.body.at(-1);
+  return statement?.type === "ReturnStatement" &&
+    statement.arguments.length === 1
+    ? statement.arguments[0]
+    : undefined;
+}
+
+function recognizeMixinFactory(
+  callable: Callable,
+  resolved: ResolveResult,
+): FactoryTemplate | undefined {
+  if (callable.parameters.length < 2) return undefined;
+  const targetParameter = callable.parameters[0];
+  const prototypeParameter = callable.parameters[1];
+  const returned = callable.declaration.body.at(-1);
+  if (
+    returned?.type !== "ReturnStatement" ||
+    returned.arguments.length !== 1 ||
+    returned.arguments[0].type !== "Identifier" ||
+    resolved.symbolOf(returned.arguments[0]) !== targetParameter
+  )
+    return undefined;
+  const copyAssignments: Parser.AssignmentStatement[] = [];
+  callable.declaration.body.forEach((statement) => {
+    if (statement.type !== "ForGenericStatement") return;
+    const iterator = statement.iterators[0];
+    if (
+      iterator.type !== "CallExpression" ||
+      iterator.base.type !== "Identifier" ||
+      iterator.base.name !== "pairs" ||
+      iterator.arguments.length === 0 ||
+      iterator.arguments[0].type !== "Identifier" ||
+      resolved.symbolOf(iterator.arguments[0]) !== prototypeParameter
+    )
+      return;
+    const keyVariable = statement.variables.at(0);
+    const valueVariable = statement.variables.at(1);
+    if (!keyVariable || !valueVariable) return;
+    const keySymbol = resolved.symbolOf(keyVariable);
+    const valueSymbol = resolved.symbolOf(valueVariable);
+    if (!keySymbol || !valueSymbol) return;
+    walkStatements(statement.body, (node) => {
+      if (node.type !== "AssignmentStatement") return;
+      const assignment = node;
+      assignment.variables.forEach((target, index) => {
+        const value = assignment.init.at(index);
+        if (!value) return;
+        if (
+          target.type === "IndexExpression" &&
+          target.base.type === "Identifier" &&
+          resolved.symbolOf(target.base) === targetParameter &&
+          target.index.type === "Identifier" &&
+          resolved.symbolOf(target.index) === keySymbol &&
+          value.type === "Identifier" &&
+          resolved.symbolOf(value) === valueSymbol
+        )
+          copyAssignments.push(assignment);
+      });
+    });
+  });
+  return copyAssignments.length > 0
+    ? { targetParameter, prototypeParameter, copyAssignments }
+    : undefined;
+}
+
+function recognizeConstructor(
+  callable: Callable,
+  module: WholeProgramModule,
+  factories: ReadonlyMap<Callable, FactoryTemplate>,
+  targetsOf: (call: Parser.CallExpression) => ReadonlySet<Callable>,
+): ConstructorTemplate | undefined {
+  const returned = callable.declaration.body.at(-1);
+  if (
+    returned?.type !== "ReturnStatement" ||
+    returned.arguments.length !== 1 ||
+    returned.arguments[0].type !== "Identifier"
+  )
+    return undefined;
+  const returnedSymbol = module.resolved.symbolOf(returned.arguments[0]);
+  if (!returnedSymbol) return undefined;
+  let template: ConstructorTemplate | undefined;
+  callable.declaration.body.forEach((statement) => {
+    if (statement.type !== "LocalStatement") return;
+    statement.variables.forEach((variable, index) => {
+      if (module.resolved.symbolOf(variable) !== returnedSymbol) return;
+      const value = statement.init.at(index);
+      if (!value) return;
+      if (value.type !== "CallExpression") return;
+      if (![...targetsOf(value)].some((target) => factories.has(target)))
+        return;
+      if (value.arguments.length < 2) return;
+      template = {
+        base: value.arguments[0],
+        prototype: value.arguments[1],
+        module,
+      };
+    });
+  });
+  return template;
+}
+
+function sourceRangeOf(node: object): {
+  readonly sourceRange?: readonly [number, number];
+} {
+  const range = (node as { range?: [number, number] }).range;
+  return range ? { sourceRange: range } : {};
+}
+
+function valuesOfExpressionCleanup(
+  cache: WeakMap<Parser.Expression, Set<MutableObject>>,
+  modules: readonly WholeProgramModule[],
+  retainCalls = false,
+): void {
+  modules.forEach((module) => {
+    visitExpressions(module.chunk.body, (expression) => {
+      if (retainCalls && expression.type === "CallExpression") return;
+      if (expression.type !== "TableConstructorExpression")
+        cache.delete(expression);
+    });
+  });
+}
+
+function visitBindings(
+  body: readonly Parser.Statement[],
+  visit: (target: Parser.Identifier, value: Parser.Expression) => void,
+): void {
+  walkStatements(body, (node) => {
+    if (node.type === "LocalStatement") {
+      const statement = node;
+      statement.variables.forEach((target, index) => {
+        const value = statement.init.at(index);
+        if (!value) return;
+        visit(target, value);
+      });
+    } else if (node.type === "AssignmentStatement") {
+      const statement = node;
+      statement.variables.forEach((target, index) => {
+        const value = statement.init.at(index);
+        if (!value) return;
+        if (target.type === "Identifier") visit(target, value);
+      });
+    }
+  });
+}
+
+function walkStatements(
+  body: readonly Parser.Statement[],
+  visit: (node: Parser.Statement | Parser.Expression) => void,
+): void {
+  walkBlockDeep(body, { onStatement: visit, onExpression: visit });
+}
+
+function visitExpressions(
+  body: readonly Parser.Statement[],
+  visit: (expression: Parser.Expression) => void,
+): void {
+  walkBlockDeep(body, { onExpression: visit });
+}

--- a/test/functionRewrites.test.ts
+++ b/test/functionRewrites.test.ts
@@ -45,13 +45,21 @@ describe("function rewrites", () => {
     const { chunk, result } = rewrite(
       "local function pick(first,unused,last) return last end return pick(1,side(),3)",
     );
-    expect(result).toEqual({ changed: false, prunedParameters: 0 });
+    expect(result).toEqual({
+      changed: false,
+      prunedParameters: 0,
+      prunedMethodParameters: 0,
+    });
     expect(firstFunction(chunk).parameters).toHaveLength(3);
 
     const pruned = rewrite(
       "local function pick(first,unused,last) return first end return pick(1,side(),3)",
     );
-    expect(pruned.result).toEqual({ changed: true, prunedParameters: 2 });
+    expect(pruned.result).toEqual({
+      changed: true,
+      prunedParameters: 2,
+      prunedMethodParameters: 0,
+    });
     expect(firstFunction(pruned.chunk).parameters).toHaveLength(1);
   });
 
@@ -59,7 +67,11 @@ describe("function rewrites", () => {
     const { chunk, result } = rewrite(
       "local function collect(unused,...) return ... end return collect(side(),1)",
     );
-    expect(result).toEqual({ changed: false, prunedParameters: 0 });
+    expect(result).toEqual({
+      changed: false,
+      prunedParameters: 0,
+      prunedMethodParameters: 0,
+    });
     expect(firstFunction(chunk).parameters).toHaveLength(2);
   });
 
@@ -67,7 +79,11 @@ describe("function rewrites", () => {
     const { chunk, result } = rewrite(
       "--@storm keep\nlocal function kept(unused) return 1 end return kept(side())",
     );
-    expect(result).toEqual({ changed: false, prunedParameters: 0 });
+    expect(result).toEqual({
+      changed: false,
+      prunedParameters: 0,
+      prunedMethodParameters: 0,
+    });
     expect(firstFunction(chunk).parameters).toHaveLength(1);
   });
 

--- a/test/resolver.test.ts
+++ b/test/resolver.test.ts
@@ -10,6 +10,22 @@ function parse(code: string): Parser.Chunk {
   return Parser.parse(code, { luaVersion: "5.3" });
 }
 
+test("binds colon method self as an implicit first parameter", () => {
+  const chunk = parse(
+    "local Object={} function Object:method(value)return self.value,value end",
+  );
+  const result = resolveScopes(chunk);
+  const method = chunk.body[1] as Parser.FunctionDeclaration;
+  assert.equal(method.type, "FunctionDeclaration");
+  const self = result.scopeOfFunction(method)?.symbols[0];
+
+  assert.ok(self);
+  assert.equal(self.kind, "param");
+  assert.equal(self.name, "self");
+  assert.equal(self.references.length, 1);
+  assert.equal(result.globals.has("self"), false);
+});
+
 test("resolves references to their declaring local symbol", () => {
   const chunk = parse(`
     local x = 1

--- a/test/wholeProgramObjects.test.ts
+++ b/test/wholeProgramObjects.test.ts
@@ -1,0 +1,359 @@
+import Parser from "luaparse";
+import { SourceMapConsumer } from "source-map";
+import { describe, expect, test } from "vitest";
+import { analyzeOptimizer } from "../src/optimizerAnalysis";
+import { resolveScopes } from "../src/resolver";
+import { minifyTemporaryLuaProject } from "./lib/minifierHarness";
+import {
+  analyzeWholeProgramObjects,
+  WholeProgramModule,
+} from "../src/wholeProgramObjects";
+
+function programOf(sources: Readonly<Record<string, string>>) {
+  const modules: WholeProgramModule[] = Object.entries(sources).map(
+    ([name, source]) => {
+      const chunk = Parser.parse(source, {
+        luaVersion: "5.3",
+        ranges: true,
+        locations: true,
+      });
+      const resolved = resolveScopes(chunk);
+      return {
+        name,
+        chunk,
+        resolved,
+        analysis: analyzeOptimizer(chunk, resolved),
+      };
+    },
+  );
+  return analyzeWholeProgramObjects(modules, 0);
+}
+
+const objectModule = `
+local Object={}
+function Object.create_instance(target,prototype)
+  for key,value in pairs(prototype) do
+    if key~="new" and type(value)=="function" then target[key]=value end
+  end
+  return target
+end
+return Object
+`;
+
+describe("whole-program object identity", () => {
+  test("resolves a colon method through static require and a fresh factory allocation", () => {
+    const analysis = programOf({
+      object: objectModule,
+      class: `
+local Object=require("object")
+local Class={}
+function Class.new() local instance=Object.create_instance({},Class) return instance end
+function Class:method(value,unused) self.value=value return self.value end
+return Class
+`,
+      main: `local Class=require("class") local instance=Class.new() return instance:method(1,side())`,
+    });
+
+    expect(analysis.resolvedMethods).toHaveLength(1);
+    expect(
+      analysis.resolvedMethods[0].target.declaration.parameters,
+    ).toHaveLength(2);
+    expect(analysis.resolvedMethods[0].object.id).toContain("main:call:");
+    const edge = analysis.callGraph.calls.find(
+      (call) => analysis.methodCallOf(call) !== undefined,
+    );
+    expect(edge?.hasUnknownTarget).toBe(false);
+    expect(edge?.targets).toContain(analysis.resolvedMethods[0].target);
+    if (!edge) throw new Error("Resolved method edge is missing");
+    expect(analysis.summaryOfMethodCall(edge)).toBeDefined();
+    expect(analysis.effectsOfMethodCall(edge)).toEqual(
+      expect.arrayContaining([
+        { parameterIndex: 0, access: "write", staticKey: "76616c7565" },
+        { parameterIndex: 0, access: "read", staticKey: "76616c7565" },
+      ]),
+    );
+    expect(analysis.diagnostics).toContainEqual(
+      expect.objectContaining({ reason: "resolved-method-target" }),
+    );
+  });
+
+  test("combines methods from a returned base instance and a derived prototype", () => {
+    const analysis = programOf({
+      object: objectModule,
+      base: `
+local Object=require("object") local Base={}
+function Base.new() local instance=Object.create_instance({},Base) return instance end
+function Base:base_method() return 1 end
+return Base
+`,
+      derived: `
+local Object=require("object") local Base=require("base") local Derived={}
+function Derived.new() local instance=Object.create_instance(Base.new(),Derived) return instance end
+function Derived:derived_method() return 2 end
+return Derived
+`,
+      main: `local Derived=require("derived") local value=Derived.new() return value:base_method(),value:derived_method()`,
+    });
+
+    expect(
+      analysis.resolvedMethods.map(
+        (method) =>
+          method.call.call.type === "CallExpression" &&
+          method.call.call.base.type === "MemberExpression" &&
+          method.call.call.base.identifier.name,
+      ),
+    ).toEqual(["base_method", "derived_method"]);
+  });
+
+  test("publishes self as parameter zero while retaining existing effects, escapes, and returns", () => {
+    const analysis = programOf({
+      object: objectModule,
+      class: `
+local Object=require("object") local Class={}
+function Class.new() local instance=Object.create_instance({},Class) return instance end
+function Class:method(other) self.value=other.value consume(other) return self,other.value end
+return Class
+`,
+      main: `local Class=require("class") local value=Class.new() return value:method({value=1})`,
+    });
+    const edge = analysis.callGraph.calls.find(
+      (call) => analysis.methodCallOf(call) !== undefined,
+    );
+    if (!edge) throw new Error("Resolved method edge is missing");
+    const summary = analysis.summaryOfMethodCall(edge);
+
+    expect(summary?.effects).toEqual(
+      expect.arrayContaining([
+        { parameterIndex: 0, access: "write", staticKey: "76616c7565" },
+        { parameterIndex: 1, access: "read", staticKey: "76616c7565" },
+      ]),
+    );
+    expect(summary?.escapes).toEqual(
+      expect.arrayContaining([
+        { parameterIndex: 0, reason: "return" },
+        { parameterIndex: 1, reason: "unknown-call" },
+      ]),
+    );
+    expect(summary?.returns.prefix).toHaveLength(2);
+  });
+
+  test("propagates instance identity through a required module-return function", () => {
+    const analysis = programOf({
+      object: objectModule,
+      class: `
+local Object=require("object") local Class={}
+function Class.new() local instance=Object.create_instance({},Class) return instance end
+function Class:method() return 1 end
+return Class
+`,
+      apply: `return function(instance) return instance:method() end`,
+      main: `local Class=require("class") local apply=require("apply") local value=Class.new() return apply(value)`,
+    });
+
+    expect(analysis.resolvedMethods).toHaveLength(1);
+    const applyCall = analysis.callGraph.calls.find(
+      (call) =>
+        call.call.type === "CallExpression" &&
+        call.call.base.type === "Identifier" &&
+        call.call.base.name === "apply",
+    );
+    expect(applyCall?.hasUnknownTarget).toBe(false);
+  });
+
+  test("keeps the colon receiver as the single implicit parameter-zero evaluation", () => {
+    const analysis = programOf({
+      object: objectModule,
+      class: `
+local Object=require("object") local Class={}
+function Class.new() local instance=Object.create_instance({},Class) return instance end
+function Class:method(value) return value end
+return Class
+`,
+      main: `local Class=require("class") return Class.new():method(mark())`,
+    });
+    const method = analysis.resolvedMethods[0];
+
+    expect(method.receiver.type).toBe("CallExpression");
+    expect(method.call.call.type).toBe("CallExpression");
+    if (method.call.call.type !== "CallExpression") return;
+    expect(method.call.call.arguments).toHaveLength(1);
+    expect(
+      analysis.summaryOfMethodCall(method.call)?.callable.parameters[0].name,
+    ).toBe("self");
+  });
+
+  test("keeps a changed method field unknown and reports the invalidation", () => {
+    const analysis = programOf({
+      object: objectModule,
+      class: `
+local Object=require("object") local Class={}
+function Class.new() local instance=Object.create_instance({},Class) return instance end
+function Class:method() return 1 end
+Class.method=external
+return Class
+`,
+      main: `local Class=require("class") local value=Class.new() return value:method()`,
+    });
+
+    expect(analysis.resolvedMethods).toHaveLength(0);
+    expect(analysis.diagnostics).toContainEqual(
+      expect.objectContaining({ reason: "method-field-mutation" }),
+    );
+  });
+
+  test.each([
+    ["dynamic-key" as const, "value[key]=replacement"],
+    ["metatable-mutation" as const, "setmetatable(value,{})"],
+    ["instance-escape" as const, "external(value)"],
+  ])("keeps %s across an unknown object boundary", (reason, mutation) => {
+    const analysis = programOf({
+      object: objectModule,
+      class: `
+local Object=require("object") local Class={}
+function Class.new() local instance=Object.create_instance({},Class) return instance end
+function Class:method() return 1 end
+return Class
+`,
+      main: `local Class=require("class") local value=Class.new() ${mutation} return value:method()`,
+    });
+
+    expect(analysis.resolvedMethods).toHaveLength(0);
+    expect(analysis.diagnostics).toContainEqual(
+      expect.objectContaining({ reason }),
+    );
+  });
+
+  test("keeps a receiver with multiple allocation targets unknown", () => {
+    const analysis = programOf({
+      object: objectModule,
+      class: `
+local Object=require("object") local Class={}
+function Class.new() local instance=Object.create_instance({},Class) return instance end
+function Class:method() return 1 end
+return Class
+`,
+      main: `
+local Class=require("class")
+local function invoke(value) return value:method() end
+return invoke(Class.new()),invoke(Class.new())
+`,
+    });
+
+    expect(analysis.resolvedMethods).toHaveLength(0);
+    expect(analysis.diagnostics).toContainEqual(
+      expect.objectContaining({ reason: "multiple-targets" }),
+    );
+  });
+
+  test("reports dynamic and external module boundaries deterministically", () => {
+    const analysis = programOf({
+      main: `local dynamic=require(name) local external=require("outside") return dynamic,external`,
+    });
+    expect(analysis.diagnostics.map((diagnostic) => diagnostic.reason)).toEqual(
+      ["dynamic-module-boundary", "external-module-boundary"],
+    );
+  });
+
+  test("binds every snapshot to the supplied linked generation", () => {
+    expect(programOf({ main: "return {}" }).generation).toBe(0);
+  });
+
+  test("connects final linked edges to parameter pruning without removing actual evaluation", async () => {
+    const result = minifyTemporaryLuaProject(
+      {
+        "object.lua": objectModule,
+        "class.lua": `
+local Object=require("object") local Class={}
+function Class.new() local instance=Object.create_instance({},Class) return instance end
+function Class:method(value,unused) self.value=value return self.value end
+return Class
+`,
+        "main.lua": `local Class=require("class") local value=Class.new() return value:method(1,side())`,
+      },
+      {
+        moduleLikeLua: true,
+        runtimeProfile: "stormworks",
+        mergeLocals: false,
+        effectAwareLocalHoist: false,
+        effectAwareTableReads: false,
+        collectOptimizationDiagnostics: true,
+      },
+    );
+
+    expect(result.code).toContain("side()");
+    expect(result.minifier.wholeProgramObjects?.resolvedMethods).toHaveLength(
+      1,
+    );
+    expect(result.minifier.wholeProgramObjects?.generation).toBeGreaterThan(0);
+    expect(result.minifier.optimizationDiagnostics).toContainEqual(
+      expect.objectContaining({
+        pass: "whole-program-method-resolution",
+        decision: "accepted",
+        reason: "resolved-method-target",
+      }),
+    );
+    const method = result.minifier.moduleAST
+      .get("class")
+      ?.body.find(
+        (statement): statement is Parser.FunctionDeclaration =>
+          statement.type === "FunctionDeclaration" &&
+          statement.identifier?.type === "MemberExpression" &&
+          statement.identifier.identifier.name === "method",
+      );
+    const methodParameters = method?.parameters.length;
+    expect(methodParameters).toBe(1);
+
+    await SourceMapConsumer.with(result.map, null, (consumer) => {
+      expect(consumer.hasContentsOfAllSources()).toBe(true);
+      const sideMappings: {
+        source: string | null;
+        name: string | null;
+      }[] = [];
+      consumer.eachMapping((mapping) => {
+        if (mapping.name === "side")
+          sideMappings.push({ source: mapping.source, name: mapping.name });
+      });
+      expect(sideMappings).toContainEqual({
+        source: "main.lua",
+        name: "side",
+      });
+    });
+  });
+
+  test("does not rewrite an invalidated method target", () => {
+    const files = {
+      "object.lua": objectModule,
+      "class.lua": `
+local Object=require("object") local Class={}
+function Class.new() local instance=Object.create_instance({},Class) return instance end
+function Class:method(value,unused) return value end
+Class.method=external
+return Class
+`,
+      "main.lua": `local Class=require("class") local value=Class.new() return value:method(1,side())`,
+    };
+    const mode = {
+      moduleLikeLua: true,
+      runtimeProfile: "stormworks" as const,
+      mergeLocals: false,
+      effectAwareLocalHoist: false,
+      effectAwareTableReads: false,
+    };
+    const enabled = minifyTemporaryLuaProject(files, mode);
+    const disabled = minifyTemporaryLuaProject(files, {
+      ...mode,
+      effectAwareTransforms: false,
+    });
+
+    expect(enabled.code).toBe(disabled.code);
+    const method = enabled.minifier.moduleAST
+      .get("class")
+      ?.body.find(
+        (statement): statement is Parser.FunctionDeclaration =>
+          statement.type === "FunctionDeclaration" &&
+          statement.identifier?.type === "MemberExpression" &&
+          statement.identifier.identifier.name === "method",
+      );
+    expect(method?.parameters).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## 概要

static `require` でリンクされた全 module を同一 AST 世代で解析し、module return、prototype table、factory call ごとの allocation identity を接続します。証明できた colon method call は共有 call graph の解決済み edge として公開し、既存の function summary と末尾未使用 parameter pruning が同じ edge を利用します。

字句 binding は Resolver、object/module identity は optimizer 解析が所有する境界を維持しています。互換コードや method 専用 summary は追加していません。

Closes #83

## 変更内容

- module return、prototype、structurally proved factory、caller-sensitive allocation、module-return callable、parameter identity flow を扱う whole-program object 解析を追加
- 解決済み method target を generation 一致済みの module call graph へ統合
- colon 宣言の暗黙 `self` を Resolver の parameter 0 symbol として表現し、summary・rename・binding 検証で共有
- 解決済み method に限って既存の trailing unused parameter pruning を適用
- escape／mutation／dynamic boundary 等を unknown edge のまま保持し、決定的 diagnostics を公開
- 全 linked module の変換後に同じ世代の whole-program snapshot を再構築
- 代表 multi-module corpus 用の再現可能な report command を追加

## Issue #83 受け入れ条件の監査

全項目を達成しています。#83 から外した範囲はなく、Issue への除外コメントは不要でした。

- [x] **static require を越える一意 identity** — class/prototype/module return、factory call ごとの allocation、method declaration、colon call site を直接対応づける multi-module test を追加
- [x] **空 target と base instance target** — `create_instance({}, Prototype)` と、別 factory が返す base instance を target にする派生 fixture の双方を解決
- [x] **receiver の評価順・回数と暗黙 self** — colon receiver は AST 上の単一 receiver のまま parameter 0 に接続し、Lua 差分 fixture で receiver・各実引数の順序と一回評価を確認
- [x] **既存 summary の effect／escape／return tuple** — 解決 method から parameter field read/write、escape、複数 return の既存 interprocedural summary を取得する test を追加
- [x] **末尾未使用 method parameter pruning** — 既存 pruning を解決済み method edge に接続し、parameter を除去しても surplus actual の `side()` が残ることを確認
- [x] **unknown edge と主要 diagnostics** — instance/prototype escape、method field mutation、dynamic key、metatable mutation、multiple targets、dynamic/external module boundary を拒否理由付きで直接検証
- [x] **AST 世代の更新と全 consumer の一致** — mixed-generation call graph を拒否し、変換後に whole-program analysis を再構築して最終 edge／allocation／summary を同じ generation で公開
- [x] **runtime と binding identity** — 解決 fixture は Lua 5.3 の変換前後を完全一致で比較。Resolver の implicit self test と Renamer の全 symbol 再解決検証を通過。unknown fixture は method rewrite on/off の生成結果一致を確認
- [x] **Lua／binding／Source Map／resource／strict cost gate** — resolved fixture の Source Map 出自を直接検証。既存 resource budget と最終 Rename/Print の function-rewrite baseline/trial strict-shorter gateを通過
- [x] **再現可能な代表 benchmark** — `pnpm report:whole-program-objects -- <entry>` で module、identity、candidate、resolved、pruned、refusal、byte 差、処理時間、Lua parse を報告

method body の複製と call-site specialization は、Issue 本文で明示された後続 #85 の境界です。#84 が消費する返却 field identity と併せ、今回の解析結果を共有 facts として公開しています。

## 検証

- `pnpm run format:check`
- `pnpm run lint`
- `pnpm run build`
- 全 test suite: 44 files / 416 tests passed（監査前の production code 最終状態）
- 監査補強後の対象 test: 3 files / 35 tests passed
- Lua 5.3 differential: 8 fixtures matched exactly
- Lua resource budget: 150 active locals、49/50 accepted、51 rejected
- optimizer report: 15 accepted / 28 rejected / 43 estimated bytes saved

監査補強は test／verifier のみで production code と `origin/develop` に変更がなかったため、明示合意に基づき全 suite と固定 corpus の重複再実行は省略しました。

## 固定 multi-module benchmark

N-TRACS commit `0b0d3c0`、32 modules:

- object identities: 1,831
- colon candidates: 373
- resolved: 21
- method parameters pruned: 0（専用 fixture では pruning を確認）
- refusals: allocation-unknown 306 / instance-escape 44 / prototype-escape 44
- function-rewrite baseline: 91,362 bytes
- trial: 91,247 bytes（-115 bytes、strict gate accepted）
- Windows measured runs: 4,991.937 / 5,018.635 / 5,047.202 ms
- median: 5,018.635 ms
- Lua 5.3 parse: passed
